### PR TITLE
Increase agent task scope for larger, more complete implementations

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/objective_graph.py
+++ b/ipfs_accelerate_py/agent_supervisor/objective_graph.py
@@ -1527,8 +1527,8 @@ def render_task_block(
     parents = ", ".join(finding.parent_goal_ids) or "none"
     packet_goals = ", ".join(finding.goal_packet_goal_ids)
     packet_acceptance = (
-        f"This task is part of {finding.goal_packet_key}; when practical, make one cohesive change that advances "
-        f"the packet goals ({packet_goals}) and covers the shared packet evidence without expanding the prompt."
+        f"This task is part of {finding.goal_packet_key}; implement a complete, cohesive change that fully advances "
+        f"the packet goals ({packet_goals}) and covers all the shared packet evidence in one comprehensive pass."
         if finding.goal_packet_key and packet_goals
         else ""
     )

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/context.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/context.py
@@ -87,7 +87,7 @@ def select_relevant_context_paths(
     *,
     allowed_prefixes: Sequence[str] = (),
     suffixes: Sequence[str] = DEFAULT_CONTEXT_SUFFIXES,
-    max_files: int = 6,
+    max_files: int = 16,
     preferred_path_fragments: Sequence[str] = (),
 ) -> list[str]:
     """Select tracked files most relevant to a task token set."""
@@ -131,8 +131,8 @@ def render_relevant_file_context(
     task_or_title: Any,
     allowed_prefixes: Sequence[str] = (),
     suffixes: Sequence[str] = DEFAULT_CONTEXT_SUFFIXES,
-    max_files: int = 6,
-    max_file_chars: int = 12000,
+    max_files: int = 16,
+    max_file_chars: int = 24000,
     preferred_path_fragments: Sequence[str] = (),
     no_tokens_message: str = "[No selected task tokens available.]",
     no_files_message: str = "[No relevant current file contents selected.]",

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -89,7 +89,7 @@ SHARED_WORKTREE_PATHS = (
     "hallucinate_app/swissknife/node_modules",
 )
 DEFAULT_TODO_VECTOR_CONTEXT_TOKEN_BUDGET = int(
-    os.environ.get("IPFS_ACCELERATE_AGENT_TODO_VECTOR_CONTEXT_TOKEN_BUDGET", "260")
+    os.environ.get("IPFS_ACCELERATE_AGENT_TODO_VECTOR_CONTEXT_TOKEN_BUDGET", "600")
 )
 
 
@@ -6263,7 +6263,9 @@ Compact todo vector context:
         )
         return f"""You are an autonomous implementation agent working in this repository.
 
-Implement exactly this backlog task and keep changes scoped.
+Implement this backlog task completely and thoroughly. Produce a full, production-ready implementation
+that covers all expected outputs. Do not artificially limit scope or break the work into smaller pieces —
+deliver the entire task in one pass, touching as many files as needed.
 
 Task:
 - ID: {task.task_id}
@@ -6286,9 +6288,10 @@ Primary plan document:
 Rules:
 - Read the relevant plan and nearby code before editing.
 - Do not revert unrelated local changes.
-- Prefer existing repo patterns and small, reviewable changes.
-- Implement the expected outputs for this task.
-- If a compact execution packet or goal packet is shown, prefer one cohesive implementation that advances the shared packet evidence without making unrelated edits.
+- Prefer existing repo patterns. Implement comprehensively — create all necessary files, classes, functions, tests, and integrations that the task requires.
+- Implement ALL expected outputs for this task in full. Do not leave stubs, placeholders, or TODOs.
+- If a compact execution packet or goal packet is shown, implement a single cohesive change that advances all the shared packet evidence together without making unrelated edits.
+- You may create new files and modify multiple existing files. Larger, complete implementations are preferred over minimal patches.
 - Run the listed validation commands when practical.
 - The daemon will run the listed validation commands and will only commit and merge the worktree if they pass.
 - Leave generated artifacts and shared dependency paths alone; the daemon restores dist, screenshot artifacts, and linked node_modules before commit.


### PR DESCRIPTION
## Motivation

The multi-agent supervisor's implementation daemon consistently produces commits in the 200-300 line range rather than the 1000+ line implementations it should be capable of. After auditing the full invocation chain, the root cause is a combination of prompt-level instructions that explicitly tell the agent to self-limit ("keep changes scoped", "small, reviewable changes") and context starvation that prevents the agent from seeing enough of the codebase to make broad changes.

## Approach

Three targeted changes that compound to unlock larger output:

- **Prompt rewrite** (`implementation_daemon.py`): Replaced conservative "keep changes scoped" / "small, reviewable changes" language with instructions to "implement completely and thoroughly", "do not artificially limit scope", and "larger, complete implementations are preferred over minimal patches". The agent now receives explicit permission to touch as many files as needed.

- **Context window expansion** (`context.py`): Increased the number of relevant files from 6 to 16, and per-file char budget from 12KB to 24KB. This gives the agent visibility into ~2.5x more of the codebase so it can confidently modify files it can actually read.

- **Supporting adjustments**: Bumped the todo vector context token budget from 260 to 600 tokens for richer task context, and updated the objective graph's goal-packet acceptance text to encourage "one comprehensive pass" rather than "without expanding the prompt".

## What's NOT changing

The Codex/Copilot CLI invocations themselves have no explicit token caps -- they're bounded only by the tool's internal limits and the existing 30-minute timeout. The `max_new_tokens: 2048` limit only applies to the LLM router (task proposals/refinement), not to the actual implementation CLI calls. So the CLI tools were never the bottleneck -- the prompt was.