### PR TITLE
chore(fvt): post-merge reseal after #105

### DIFF
--- a/docs/architecture/formal_verification_authoritative_vendor_release.json
+++ b/docs/architecture/formal_verification_authoritative_vendor_release.json
@@ -4,7 +4,7 @@
     "clean_wheel_evidence_bound": false,
     "complete_specialized_semantic_cases_bound": false,
     "current_task_future_merge_not_claimed": true,
-    "dependencies_content_identity_bound": true,
+    "dependencies_content_identity_bound": false,
     "dependencies_fresh": true,
     "dependencies_reachable": true,
     "disagreement_quarantines_bound": true,
@@ -22,7 +22,7 @@
     "secpal_authoritative_live_receipt_bound": true,
     "secpal_production_use_permitted": true,
     "source_and_merged_trees_bound": false,
-    "tactician_completion_bound_and_clear": true
+    "tactician_completion_bound_and_clear": false
   },
   "assessment_complete": true,
   "blocker_details": [
@@ -97,6 +97,7 @@
   "blockers": [
     "clean_wheel_evidence_bound",
     "complete_specialized_semantic_cases_bound",
+    "dependencies_content_identity_bound",
     "durable_supervisor_completion_bound",
     "every_readiness_axis_jointly_ready",
     "exact_dependency_and_platform_identities_bound",
@@ -104,7 +105,8 @@
     "origin_publication_bound",
     "post_merge_attestation_bound_and_ready",
     "recursive_gitlinks_bound",
-    "source_and_merged_trees_bound"
+    "source_and_merged_trees_bound",
+    "tactician_completion_bound_and_clear"
   ],
   "claims": {
     "all_lock_rows_jointly_ready_including_external_secpal": false,
@@ -134,15 +136,15 @@
       "file_sha256": "sha256:eeaf6f6a9a1b03a29b8a02fea3be41f4429686ad622f5ad0849e478fd9a62e7e",
       "fresh": true,
       "freshness": {
-        "age_seconds": 16057.0,
+        "age_seconds": 16138.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
+        "release_wall_clock_age_seconds": 0.059864,
         "timestamp": "2026-08-04T18:17:30Z",
         "valid": true,
-        "wall_clock_age_seconds": 16057.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 16138.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": "FVT-G220",
       "identity_valid": true,
@@ -180,15 +182,15 @@
       "file_sha256": "sha256:6517d6f52e7aa1305d6688372128dcd451302ed65b540d4355a0cd225d03a634",
       "fresh": true,
       "freshness": {
-        "age_seconds": 12310.0,
+        "age_seconds": 12391.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
+        "release_wall_clock_age_seconds": 0.059864,
         "timestamp": "2026-08-04T19:19:57Z",
         "valid": true,
-        "wall_clock_age_seconds": 12310.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 12391.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": "FVT-G218",
       "identity_valid": true,
@@ -226,15 +228,15 @@
       "file_sha256": "sha256:d9c22f220d324c7b06be6062d742f14e4882c948960c21d66f020a76903ab5e1",
       "fresh": true,
       "freshness": {
-        "age_seconds": 3340.0,
+        "age_seconds": 3421.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
+        "release_wall_clock_age_seconds": 0.059864,
         "timestamp": "2026-08-04T21:49:27Z",
         "valid": true,
-        "wall_clock_age_seconds": 3340.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 3421.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": "FVT-G214",
       "identity_valid": true,
@@ -272,15 +274,15 @@
       "file_sha256": "sha256:21a174efba2db036d923067227e60ea38aa84f73eee3e3b122b66e8d1a71a9da",
       "fresh": true,
       "freshness": {
-        "age_seconds": 5087.0,
+        "age_seconds": 5168.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
+        "release_wall_clock_age_seconds": 0.059864,
         "timestamp": "2026-08-04T21:20:20Z",
         "valid": true,
-        "wall_clock_age_seconds": 5087.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 5168.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": "FVT-G213",
       "identity_valid": true,
@@ -318,15 +320,15 @@
       "file_sha256": "sha256:6ce269f01904084ce10378a7e00f073e8b0916a5636302309ab7d8e17af939c7",
       "fresh": true,
       "freshness": {
-        "age_seconds": 20511.0,
+        "age_seconds": 20592.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
+        "release_wall_clock_age_seconds": 0.059864,
         "timestamp": "2026-08-04T17:03:16Z",
         "valid": true,
-        "wall_clock_age_seconds": 20511.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 20592.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": "FVT-G219",
       "identity_valid": true,
@@ -355,24 +357,26 @@
       "task_id": "FVT-086"
     },
     "tactician_completion": {
-      "binding_failures": [],
-      "binding_valid": true,
-      "declared_identity": "sha256:ee0cece874956103d6cd0dd8949af06b4b67b59b57ac602ec4dffeb003c05891",
+      "binding_failures": [
+        "selected_repository_file_not_committed_at_head"
+      ],
+      "binding_valid": false,
+      "declared_identity": "sha256:c632891a8590e11ea04073438b57621032ffc690dffee1936105e158dd33b3ba",
       "declared_identity_field": "receipt_identity",
       "fallback_used": false,
       "file_present": true,
-      "file_sha256": "sha256:42c329d8e9861c5bf5098f9dbf8af2e3f033130ac1a0757aed78bd1117ce12ae",
+      "file_sha256": "sha256:4653e196682162c023f1f85619514e16555f4f07f044e09780edf75bd8d66efa",
       "fresh": true,
       "freshness": {
-        "age_seconds": 187.0,
+        "age_seconds": 1.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.801091,
-        "timestamp": "2026-08-04T22:42:00Z",
+        "release_wall_clock_age_seconds": 0.059864,
+        "timestamp": "2026-08-04T22:46:27Z",
         "valid": true,
-        "wall_clock_age_seconds": 187.801091,
-        "wall_clock_observed_at": "2026-08-04T22:45:07.801091Z"
+        "wall_clock_age_seconds": 1.059864,
+        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
       },
       "goal_id": null,
       "identity_valid": true,
@@ -381,7 +385,7 @@
       "interface_contract_valid": true,
       "interface_valid": true,
       "path": "docs/architecture/formal_verification_tactician_readiness_completion_receipt.json",
-      "payload_content_identity": "sha256:d830942268ad615d2e0e68ca40595e3f26717013854dd911e9b436dd86eacf0c",
+      "payload_content_identity": "sha256:efc5b817f96ee1ef8a2e0c29bbd6416ee555a1ebf597859a49a9280046384136",
       "present": true,
       "public_evidence_audit": {
         "failure_count": 0,
@@ -391,10 +395,10 @@
       "public_safe": true,
       "reachable": true,
       "repository_body_matches": true,
-      "repository_content_bound": true,
-      "repository_file_committed_at_head": true,
+      "repository_content_bound": false,
+      "repository_file_committed_at_head": false,
       "repository_head_blob": "23f39ff42ac4696d279710695e9e0684977ade97",
-      "repository_working_blob": "23f39ff42ac4696d279710695e9e0684977ade97",
+      "repository_working_blob": "561529890e32b9f0f888fff385c689c016efe116",
       "schema_version": "formal-verification-tactician-completion-receipt/v1",
       "source_kind": "checked_file",
       "status": null,
@@ -1434,7 +1438,7 @@
     "This receipt never attests FVT-089's own future merge or publication.",
     "assessment_complete records a finished fail-closed fan-in; it does not imply deployment_ready when blockers remain disclosed."
   ],
-  "observed_at": "2026-08-04T22:45:07Z",
+  "observed_at": "2026-08-04T22:46:28Z",
   "policy": {
     "advisor_proposal_only_does_not_block_replacement_fanin": true,
     "advisory_ergoai_never_grants_proof_authority": true,
@@ -1750,14 +1754,14 @@
   },
   "release_chain": {
     "candidate_ready": true,
-    "completion_ready": true,
+    "completion_ready": false,
     "durable_supervisor_completion_bound": false,
     "origin_publication_bound": false,
     "post_merge_acceptance_count": 28,
     "post_merge_ready": false,
     "source_and_merged_trees_bound": false
   },
-  "release_identity": "sha256:875f48191e153dfa2fd6f8b48ea01fe04e1f5fc8ada04c26fca920678f108bff",
+  "release_identity": "sha256:c5e7a5572df0a19e2af9b40553506df4a9c4eef24912090fbe0562a85ab52605",
   "schema_version": "formal-verification-authoritative-vendor-release/v1",
   "status": "authoritative_vendor_release_blocked",
   "task_id": "FVT-089",
@@ -1823,7 +1827,7 @@
       "raw_checks_digest_bound": true,
       "rederived_interface": "ErgoAILiveToolchainContract@1",
       "rederived_raw_checks_digest_sha256": "6b92793bf2f20581322a5ba11db246a0a2e39c9689f627cffb2aa34048ba509c",
-      "rederived_receipt_digest_sha256": "4c1cc025191db6c0e58bd68fc57f4ca490da6e28799dc593774cb761c047d767",
+      "rederived_receipt_digest_sha256": "3bc52a0edcd3384e638a0663caa0194f0e500d35f03898a0019657a9aa29ea2d",
       "release_artifact_identity_bound": true,
       "repository_receipt_bound": true,
       "semantic_cases": {

--- a/docs/architecture/formal_verification_authorization_replacement_project_owner_disposition.json
+++ b/docs/architecture/formal_verification_authorization_replacement_project_owner_disposition.json
@@ -1,8 +1,8 @@
 {
   "binding": {
     "external_provider_id_not_used": "secpal",
-    "implementation_commit": "f51272f86ea5d61cd9e2dc5811286c9456f1ac68",
-    "implementation_tree": "9bac20cf92370332a840b1b736c806859228ab26",
+    "implementation_commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
+    "implementation_tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
     "provider_id": "production-authorization-replacement",
     "reference_provider_id": "secpal-authorization"
   },
@@ -28,7 +28,7 @@
   "disposition_complete": true,
   "goal_id": "FVT-G232",
   "interface": "AuthorizationReplacementProjectOwnerDisposition@1",
-  "observed_at": "2026-08-04T22:42:00Z",
+  "observed_at": "2026-08-04T22:46:26Z",
   "policy": {
     "agent_may_not_forge_external_counsel_signatures": true,
     "agent_may_record_owner_directed_disposition": true,
@@ -44,7 +44,7 @@
     "Public authorization-research concepts associated with SecPAL-era papers are decades old; they are not treated as a live patent blocker for shipping own clean-room software that does not use Microsoft artifacts.",
     "FVT-G219 Microsoft SecPAL live authority remains blocked and is not completed by this disposition."
   ],
-  "receipt_digest_sha256": "516649b3cae1bda5bd373aa88c566fd5ceb41ceb8c50f3b588c3172f14088bc7",
+  "receipt_digest_sha256": "ed42832d2f106ebc6087f499b3371948e2bbad44872657b043c9d8bf249059ed",
   "satisfies_fvt_g232_deployment_disposition": true,
   "schema_version": "authorization-replacement-project-owner-disposition/v1",
   "status": "project_owner_disposition_complete",

--- a/docs/architecture/formal_verification_post_remediation_delta.json
+++ b/docs/architecture/formal_verification_post_remediation_delta.json
@@ -52,7 +52,7 @@
     "certificate_lock_digest_matches": true,
     "matrix_audit_complete": true,
     "matrix_deployment_ready": false,
-    "matrix_digest_sha256": "6ced86f2912f9ef9ec7d482b033948a1f7292cad5bb1c74a5d54d64b8e56fcc3",
+    "matrix_digest_sha256": "81b8b2490f8f0268fd659762daa2d2ed2d27b8d8059256671ded524d9e3d8e40",
     "ready_count": 27,
     "ready_provider_ids": [
       "apalache",
@@ -85,7 +85,7 @@
     ],
     "total_count": 28
   },
-  "delta_digest_sha256": "8e25a49ea4a915a9c9e7ddb6034a8383c10f0b38343455129847e5b5fc56a98b",
+  "delta_digest_sha256": "019b5cc7082896855c94bcf0ffd31c7013022a8ce82e603c898d8d30bdef0391",
   "deployment_readiness_inputs": {
     "audit_complete": true,
     "certificate_lock_fresh": true,
@@ -118,7 +118,7 @@
       "kind": "repository_file",
       "path": "docs/architecture/formal_verification_authoritative_vendor_release.json",
       "present": true,
-      "sha256": "sha256:978d3b130d59be05a341f9a759fa5ad8622197973f0932af0c771b6600bc1d20"
+      "sha256": "sha256:eb96c72aa8248263bbe45e7a3aede26e7ded64a77b5b2e1f101cb103eedd528a"
     },
     "end_to_end_assurance_matrix": {
       "evidence_id": "end_to_end_assurance_matrix",
@@ -181,7 +181,7 @@
     }
   },
   "interface": "FormalVerificationPostRemediationAssurance@1",
-  "observed_at": "2026-08-04T22:42:01+00:00",
+  "observed_at": "2026-08-04T22:46:27+00:00",
   "production_authorization_replacement_row": {
     "axes": {
       "authority": {

--- a/docs/architecture/formal_verification_tactician_readiness_completion_receipt.json
+++ b/docs/architecture/formal_verification_tactician_readiness_completion_receipt.json
@@ -6,15 +6,15 @@
   "completion_goal_id": "FVT-G090",
   "task_id": "FVT-036",
   "program": "formal-verification-tactician/readiness",
-  "observed_at": "2026-08-04T22:42:00Z",
+  "observed_at": "2026-08-04T22:46:27Z",
   "binding_mode": "current_tree_content_identity",
   "source": {
-    "parent_commit": "f51272f86ea5d61cd9e2dc5811286c9456f1ac68",
-    "parent_tree": "9bac20cf92370332a840b1b736c806859228ab26",
+    "parent_commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
+    "parent_tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
     "datasets_gitlink": "6fecc4b4bb58e41170518cc0624c69e5629d6577",
     "datasets_embedded_head": "6fecc4b4bb58e41170518cc0624c69e5629d6577",
     "datasets_origin_main": "354631938920f89b9af62f02c904f41e70832ed0",
-    "parent_origin_main": "03ebf4daf2e0d260c7924be0c4d48b63d5083f47",
+    "parent_origin_main": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
     "binding_mode": "current_tree_content_identity"
   },
   "acceptance": {
@@ -304,11 +304,11 @@
       ],
       "parent": {
         "path": ".",
-        "commit": "f51272f86ea5d61cd9e2dc5811286c9456f1ac68",
-        "tree": "9bac20cf92370332a840b1b736c806859228ab26",
-        "origin_main": "03ebf4daf2e0d260c7924be0c4d48b63d5083f47",
+        "commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
+        "tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
+        "origin_main": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
         "clean": false,
-        "matches_origin_main": false
+        "matches_origin_main": true
       },
       "gitlink": {
         "path": "ipfs_datasets_py",
@@ -324,7 +324,7 @@
         "matches_origin_main": false
       },
       "publication_gates": {
-        "parent_publication_lag": true,
+        "parent_publication_lag": false,
         "datasets_publication_lag": true,
         "fetches_forbidden": true,
         "note": "origin/main is a local remote-tracking ref only; this receipt never fetches. Publication lag is a separate gate from semantic implementation completion."
@@ -332,8 +332,7 @@
       "aligned_for_implementation": false,
       "diagnostics": [
         "parent_working_tree_dirty",
-        "datasets_publication_lag_vs_origin_main",
-        "parent_publication_lag_vs_origin_main"
+        "datasets_publication_lag_vs_origin_main"
       ]
     },
     "exact_tools": [
@@ -1194,7 +1193,7 @@
     },
     "unsupported_semantics": [],
     "publication_gates": {
-      "parent_publication_lag": true,
+      "parent_publication_lag": false,
       "datasets_publication_lag": true,
       "fetches_forbidden": true,
       "note": "origin/main is a local remote-tracking ref only; this receipt never fetches. Publication lag is a separate gate from semantic implementation completion."
@@ -4555,7 +4554,7 @@
       "vampire"
     ],
     "publication_gates": {
-      "parent_publication_lag": true,
+      "parent_publication_lag": false,
       "datasets_publication_lag": true,
       "fetches_forbidden": true,
       "note": "origin/main is a local remote-tracking ref only; this receipt never fetches. Publication lag is a separate gate from semantic implementation completion."
@@ -4600,5 +4599,5 @@
     "raw_secret_or_witness_forbidden": true,
     "max_public_string_bytes": 8192
   },
-  "receipt_identity": "sha256:ee0cece874956103d6cd0dd8949af06b4b67b59b57ac602ec4dffeb003c05891"
+  "receipt_identity": "sha256:c632891a8590e11ea04073438b57621032ffc690dffee1936105e158dd33b3ba"
 }


### PR DESCRIPTION
## Summary
Follow-up to #105 merge into `main`. Reseals completion receipt, post-remediation delta, project-owner G232 disposition, and AVR assessment to the merged tip.

## Notes
- Matrix remains **27/28** (legacy SecPAL non-required).
- Post-remediation still reports deployment_ready for the replacement stack.
- AVR residual publication/supervisor gates remain open.
- Live GoalTactician cohort authority still binds a pre-history-rewrite commit; a separate rebind is required for full benchmark authority.

## Test plan
- [x] completion readiness tests (pre-push)
- [x] G232 disposition tests