### PR TITLE
feat(fvt): rebind live cohort authority after main merge

### DIFF
--- a/docs/architecture/formal_verification_authoritative_vendor_release.json
+++ b/docs/architecture/formal_verification_authoritative_vendor_release.json
@@ -4,7 +4,7 @@
     "clean_wheel_evidence_bound": false,
     "complete_specialized_semantic_cases_bound": false,
     "current_task_future_merge_not_claimed": true,
-    "dependencies_content_identity_bound": false,
+    "dependencies_content_identity_bound": true,
     "dependencies_fresh": true,
     "dependencies_reachable": true,
     "disagreement_quarantines_bound": true,
@@ -22,7 +22,7 @@
     "secpal_authoritative_live_receipt_bound": true,
     "secpal_production_use_permitted": true,
     "source_and_merged_trees_bound": false,
-    "tactician_completion_bound_and_clear": false
+    "tactician_completion_bound_and_clear": true
   },
   "assessment_complete": true,
   "blocker_details": [
@@ -97,7 +97,6 @@
   "blockers": [
     "clean_wheel_evidence_bound",
     "complete_specialized_semantic_cases_bound",
-    "dependencies_content_identity_bound",
     "durable_supervisor_completion_bound",
     "every_readiness_axis_jointly_ready",
     "exact_dependency_and_platform_identities_bound",
@@ -105,8 +104,7 @@
     "origin_publication_bound",
     "post_merge_attestation_bound_and_ready",
     "recursive_gitlinks_bound",
-    "source_and_merged_trees_bound",
-    "tactician_completion_bound_and_clear"
+    "source_and_merged_trees_bound"
   ],
   "claims": {
     "all_lock_rows_jointly_ready_including_external_secpal": false,
@@ -136,15 +134,15 @@
       "file_sha256": "sha256:eeaf6f6a9a1b03a29b8a02fea3be41f4429686ad622f5ad0849e478fd9a62e7e",
       "fresh": true,
       "freshness": {
-        "age_seconds": 16138.0,
+        "age_seconds": 16633.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
+        "release_wall_clock_age_seconds": 0.215886,
         "timestamp": "2026-08-04T18:17:30Z",
         "valid": true,
-        "wall_clock_age_seconds": 16138.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 16633.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": "FVT-G220",
       "identity_valid": true,
@@ -182,15 +180,15 @@
       "file_sha256": "sha256:6517d6f52e7aa1305d6688372128dcd451302ed65b540d4355a0cd225d03a634",
       "fresh": true,
       "freshness": {
-        "age_seconds": 12391.0,
+        "age_seconds": 12886.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
+        "release_wall_clock_age_seconds": 0.215886,
         "timestamp": "2026-08-04T19:19:57Z",
         "valid": true,
-        "wall_clock_age_seconds": 12391.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 12886.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": "FVT-G218",
       "identity_valid": true,
@@ -228,15 +226,15 @@
       "file_sha256": "sha256:d9c22f220d324c7b06be6062d742f14e4882c948960c21d66f020a76903ab5e1",
       "fresh": true,
       "freshness": {
-        "age_seconds": 3421.0,
+        "age_seconds": 3916.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
+        "release_wall_clock_age_seconds": 0.215886,
         "timestamp": "2026-08-04T21:49:27Z",
         "valid": true,
-        "wall_clock_age_seconds": 3421.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 3916.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": "FVT-G214",
       "identity_valid": true,
@@ -274,15 +272,15 @@
       "file_sha256": "sha256:21a174efba2db036d923067227e60ea38aa84f73eee3e3b122b66e8d1a71a9da",
       "fresh": true,
       "freshness": {
-        "age_seconds": 5168.0,
+        "age_seconds": 5663.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
+        "release_wall_clock_age_seconds": 0.215886,
         "timestamp": "2026-08-04T21:20:20Z",
         "valid": true,
-        "wall_clock_age_seconds": 5168.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 5663.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": "FVT-G213",
       "identity_valid": true,
@@ -320,15 +318,15 @@
       "file_sha256": "sha256:6ce269f01904084ce10378a7e00f073e8b0916a5636302309ab7d8e17af939c7",
       "fresh": true,
       "freshness": {
-        "age_seconds": 20592.0,
+        "age_seconds": 21087.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
+        "release_wall_clock_age_seconds": 0.215886,
         "timestamp": "2026-08-04T17:03:16Z",
         "valid": true,
-        "wall_clock_age_seconds": 20592.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 21087.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": "FVT-G219",
       "identity_valid": true,
@@ -357,26 +355,24 @@
       "task_id": "FVT-086"
     },
     "tactician_completion": {
-      "binding_failures": [
-        "selected_repository_file_not_committed_at_head"
-      ],
-      "binding_valid": false,
-      "declared_identity": "sha256:c632891a8590e11ea04073438b57621032ffc690dffee1936105e158dd33b3ba",
+      "binding_failures": [],
+      "binding_valid": true,
+      "declared_identity": "sha256:ee1487751125758ab679aad38e9d11ae800fb9188873afb36d9835cbb6a7134f",
       "declared_identity_field": "receipt_identity",
       "fallback_used": false,
       "file_present": true,
-      "file_sha256": "sha256:4653e196682162c023f1f85619514e16555f4f07f044e09780edf75bd8d66efa",
+      "file_sha256": "sha256:86560311c7e9655ee51c028399316f92b6903556fa139af1d8d7f7da0f4afadf",
       "fresh": true,
       "freshness": {
-        "age_seconds": 1.0,
+        "age_seconds": 14.0,
         "clock_skew_seconds": 300,
         "failures": [],
         "max_age_seconds": 86400,
-        "release_wall_clock_age_seconds": 0.059864,
-        "timestamp": "2026-08-04T22:46:27Z",
+        "release_wall_clock_age_seconds": 0.215886,
+        "timestamp": "2026-08-04T22:54:29Z",
         "valid": true,
-        "wall_clock_age_seconds": 1.059864,
-        "wall_clock_observed_at": "2026-08-04T22:46:28.059864Z"
+        "wall_clock_age_seconds": 14.215886,
+        "wall_clock_observed_at": "2026-08-04T22:54:43.215886Z"
       },
       "goal_id": null,
       "identity_valid": true,
@@ -385,7 +381,7 @@
       "interface_contract_valid": true,
       "interface_valid": true,
       "path": "docs/architecture/formal_verification_tactician_readiness_completion_receipt.json",
-      "payload_content_identity": "sha256:efc5b817f96ee1ef8a2e0c29bbd6416ee555a1ebf597859a49a9280046384136",
+      "payload_content_identity": "sha256:813cb0418ef79c184589224ec5743486c126e7f42c94c0cceced1cb6863a7e38",
       "present": true,
       "public_evidence_audit": {
         "failure_count": 0,
@@ -395,10 +391,10 @@
       "public_safe": true,
       "reachable": true,
       "repository_body_matches": true,
-      "repository_content_bound": false,
-      "repository_file_committed_at_head": false,
-      "repository_head_blob": "23f39ff42ac4696d279710695e9e0684977ade97",
-      "repository_working_blob": "561529890e32b9f0f888fff385c689c016efe116",
+      "repository_content_bound": true,
+      "repository_file_committed_at_head": true,
+      "repository_head_blob": "e7e2719d542c7afcc78c4c612671dee6a69992d4",
+      "repository_working_blob": "e7e2719d542c7afcc78c4c612671dee6a69992d4",
       "schema_version": "formal-verification-tactician-completion-receipt/v1",
       "source_kind": "checked_file",
       "status": null,
@@ -1438,7 +1434,7 @@
     "This receipt never attests FVT-089's own future merge or publication.",
     "assessment_complete records a finished fail-closed fan-in; it does not imply deployment_ready when blockers remain disclosed."
   ],
-  "observed_at": "2026-08-04T22:46:28Z",
+  "observed_at": "2026-08-04T22:54:43Z",
   "policy": {
     "advisor_proposal_only_does_not_block_replacement_fanin": true,
     "advisory_ergoai_never_grants_proof_authority": true,
@@ -1754,14 +1750,14 @@
   },
   "release_chain": {
     "candidate_ready": true,
-    "completion_ready": false,
+    "completion_ready": true,
     "durable_supervisor_completion_bound": false,
     "origin_publication_bound": false,
     "post_merge_acceptance_count": 28,
     "post_merge_ready": false,
     "source_and_merged_trees_bound": false
   },
-  "release_identity": "sha256:c5e7a5572df0a19e2af9b40553506df4a9c4eef24912090fbe0562a85ab52605",
+  "release_identity": "sha256:7cc7bfeca54d22a48dfbbdb2996bcf6c61d0be272956aa38de05734e51e5f643",
   "schema_version": "formal-verification-authoritative-vendor-release/v1",
   "status": "authoritative_vendor_release_blocked",
   "task_id": "FVT-089",
@@ -1827,7 +1823,7 @@
       "raw_checks_digest_bound": true,
       "rederived_interface": "ErgoAILiveToolchainContract@1",
       "rederived_raw_checks_digest_sha256": "6b92793bf2f20581322a5ba11db246a0a2e39c9689f627cffb2aa34048ba509c",
-      "rederived_receipt_digest_sha256": "3bc52a0edcd3384e638a0663caa0194f0e500d35f03898a0019657a9aa29ea2d",
+      "rederived_receipt_digest_sha256": "4a4fdc561f0e29cb9ac39f740b51b359b1eee5570b239ccc98795bd3e2d4ed55",
       "release_artifact_identity_bound": true,
       "repository_receipt_bound": true,
       "semantic_cases": {

--- a/docs/architecture/formal_verification_authorization_replacement_project_owner_disposition.json
+++ b/docs/architecture/formal_verification_authorization_replacement_project_owner_disposition.json
@@ -1,8 +1,8 @@
 {
   "binding": {
     "external_provider_id_not_used": "secpal",
-    "implementation_commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
-    "implementation_tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
+    "implementation_commit": "64d194809bd450e1c2dba9b1a6e7e5c058e395e7",
+    "implementation_tree": "582f5a7c42f61eeccd32a0f50205f42215b6c676",
     "provider_id": "production-authorization-replacement",
     "reference_provider_id": "secpal-authorization"
   },
@@ -28,7 +28,7 @@
   "disposition_complete": true,
   "goal_id": "FVT-G232",
   "interface": "AuthorizationReplacementProjectOwnerDisposition@1",
-  "observed_at": "2026-08-04T22:46:26Z",
+  "observed_at": "2026-08-04T22:54:29Z",
   "policy": {
     "agent_may_not_forge_external_counsel_signatures": true,
     "agent_may_record_owner_directed_disposition": true,
@@ -44,7 +44,7 @@
     "Public authorization-research concepts associated with SecPAL-era papers are decades old; they are not treated as a live patent blocker for shipping own clean-room software that does not use Microsoft artifacts.",
     "FVT-G219 Microsoft SecPAL live authority remains blocked and is not completed by this disposition."
   ],
-  "receipt_digest_sha256": "ed42832d2f106ebc6087f499b3371948e2bbad44872657b043c9d8bf249059ed",
+  "receipt_digest_sha256": "8a528500a9c8ccbde33c324ff096f03d9e693540e231fd4d279886a8ff0061ec",
   "satisfies_fvt_g232_deployment_disposition": true,
   "schema_version": "authorization-replacement-project-owner-disposition/v1",
   "status": "project_owner_disposition_complete",

--- a/docs/architecture/formal_verification_post_remediation_delta.json
+++ b/docs/architecture/formal_verification_post_remediation_delta.json
@@ -52,7 +52,7 @@
     "certificate_lock_digest_matches": true,
     "matrix_audit_complete": true,
     "matrix_deployment_ready": false,
-    "matrix_digest_sha256": "81b8b2490f8f0268fd659762daa2d2ed2d27b8d8059256671ded524d9e3d8e40",
+    "matrix_digest_sha256": "08ff6efb5cbc0bd02a68a90fb7a86678fcc27ab0fdfe4186b3f699a29e441534",
     "ready_count": 27,
     "ready_provider_ids": [
       "apalache",
@@ -85,7 +85,7 @@
     ],
     "total_count": 28
   },
-  "delta_digest_sha256": "019b5cc7082896855c94bcf0ffd31c7013022a8ce82e603c898d8d30bdef0391",
+  "delta_digest_sha256": "1fbfe881a2a3eafc0aca29fa560b285bdc2e9af7afa264ad1a218ec3677da16b",
   "deployment_readiness_inputs": {
     "audit_complete": true,
     "certificate_lock_fresh": true,
@@ -118,7 +118,7 @@
       "kind": "repository_file",
       "path": "docs/architecture/formal_verification_authoritative_vendor_release.json",
       "present": true,
-      "sha256": "sha256:eb96c72aa8248263bbe45e7a3aede26e7ded64a77b5b2e1f101cb103eedd528a"
+      "sha256": "sha256:01f2cfb8864c5378349b1249a3ee35af3db8d2976974387e1a888d39e86ce304"
     },
     "end_to_end_assurance_matrix": {
       "evidence_id": "end_to_end_assurance_matrix",
@@ -181,7 +181,7 @@
     }
   },
   "interface": "FormalVerificationPostRemediationAssurance@1",
-  "observed_at": "2026-08-04T22:46:27+00:00",
+  "observed_at": "2026-08-04T22:54:30+00:00",
   "production_authorization_replacement_row": {
     "axes": {
       "authority": {
@@ -322,7 +322,7 @@
             "kind": "repository_file",
             "path": "requirements.txt",
             "present": true,
-            "sha256": "sha256:c83ea33a892c2ef6b1a912714fcce32e890e6eaa3268170a169f31abefd61a94"
+            "sha256": "sha256:e5e14f47580a20fb04e7db1ba6b06f5d43a10e64b97cf79a71da5bd18bcf2cfe"
           },
           {
             "evidence_id": "packaging:ipfs_datasets_py/setup.py",

--- a/docs/architecture/formal_verification_readiness_baseline.json
+++ b/docs/architecture/formal_verification_readiness_baseline.json
@@ -924,6 +924,10 @@
         "implementation_commits": [
           {
             "repository": "root",
+            "commit": "9895859501076c2e4a3f9212599dc5e27b8e285a"
+          },
+          {
+            "repository": "root",
             "commit": "a98029cfd178f814ce23c2a0027ba425ee8b0719"
           }
         ],
@@ -931,8 +935,8 @@
           {
             "repository": "root",
             "path": "ipfs_accelerate_py/agent_supervisor/planning/formal_replanner.py",
-            "commit": "a98029cfd178f814ce23c2a0027ba425ee8b0719",
-            "content_identity": "sha256:e2dc95be602210b2afd6f2c80a45f42f097342d5222b613f4afb61cf3a16ba89"
+            "commit": "9895859501076c2e4a3f9212599dc5e27b8e285a",
+            "content_identity": "sha256:809146ebba134157fd5d9d96e07071e2377797a9cd08f8906501c7caf7d653cf"
           }
         ],
         "validation_tests": [

--- a/docs/architecture/formal_verification_tactician_benchmark.json
+++ b/docs/architecture/formal_verification_tactician_benchmark.json
@@ -250,8 +250,8 @@
     },
     "repository_binding": {
       "trusted_ref": "refs/remotes/origin/main",
-      "commit_sha": "2c6964f8874c56dd8b33a453cf25795be16b3c9a",
-      "tree_sha": "cd36d3370adf4ddbb8f5f9635ac04354dbea9154",
+      "commit_sha": "4f82a1b2f1ad8f7a4c7b9e3fea65dca7a16d0bf3",
+      "tree_sha": "8bebcebd7fce836e71020debdde9be3d206e86ca",
       "receipt_blob_sha": "69ea27bcc220d937ca109b3489654195f2976c0a",
       "verifier_blob_sha": "9fca8fe9aa73fdfc5dffb2e883d54ff9e011e86e"
     },
@@ -260,6 +260,6 @@
       "function": "verify_authoritative_benchmark_evidence",
       "sha256": "sha256:097608f90002bae389517aa64ca2dd9bb50f62edbeb588f14bf0232c6a7822a7"
     },
-    "content_id": "sha256:2961f32361b16fe9744ebd5455cb89b997a6323da48e85ef8a5b5d55d44cdfc0"
+    "content_id": "sha256:3f9c4269ee718b98453f621c9ff7614616ea0cd99d48baaab3060b9a98a998f0"
   }
 }

--- a/docs/architecture/formal_verification_tactician_readiness_completion_receipt.json
+++ b/docs/architecture/formal_verification_tactician_readiness_completion_receipt.json
@@ -6,15 +6,15 @@
   "completion_goal_id": "FVT-G090",
   "task_id": "FVT-036",
   "program": "formal-verification-tactician/readiness",
-  "observed_at": "2026-08-04T22:46:27Z",
+  "observed_at": "2026-08-04T22:54:29Z",
   "binding_mode": "current_tree_content_identity",
   "source": {
-    "parent_commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
-    "parent_tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
+    "parent_commit": "64d194809bd450e1c2dba9b1a6e7e5c058e395e7",
+    "parent_tree": "582f5a7c42f61eeccd32a0f50205f42215b6c676",
     "datasets_gitlink": "6fecc4b4bb58e41170518cc0624c69e5629d6577",
     "datasets_embedded_head": "6fecc4b4bb58e41170518cc0624c69e5629d6577",
     "datasets_origin_main": "354631938920f89b9af62f02c904f41e70832ed0",
-    "parent_origin_main": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
+    "parent_origin_main": "64d194809bd450e1c2dba9b1a6e7e5c058e395e7",
     "binding_mode": "current_tree_content_identity"
   },
   "acceptance": {
@@ -49,12 +49,10 @@
       "missing_measurements": [],
       "certificate_identity_valid": true,
       "benchmark_evidence": {
-        "authoritative": false,
+        "authoritative": true,
         "hard_zero_clearable": true,
-        "branch_live_cohort_pending_main_merge": true,
-        "failures": [
-          "benchmark_authority_verifier_rejected"
-        ],
+        "branch_live_cohort_pending_main_merge": false,
+        "failures": [],
         "hard_gates": {
           "authority": {
             "actual_bps": 10000,
@@ -79,11 +77,11 @@
         "report_id_valid": true,
         "authority_anchor": {
           "present": true,
-          "bound": false,
+          "bound": true,
           "schema": "ipfs_accelerate_py.agent_supervisor.goal_tactician_authoritative_benchmark_evidence@1",
           "interface": "GoalTacticianAuthoritativeBenchmarkEvidence@1",
           "goal_id": "FVT-G063",
-          "content_id": "sha256:2961f32361b16fe9744ebd5455cb89b997a6323da48e85ef8a5b5d55d44cdfc0",
+          "content_id": "sha256:3f9c4269ee718b98453f621c9ff7614616ea0cd99d48baaab3060b9a98a998f0",
           "report_id": "goal-tactician-bench-b9506430763dc4be6319e83a28e56a4ad4fd10e7b6a83ab14d86c5aa33c0fd4a",
           "verifier": {
             "path": "ipfs_accelerate_py/agent_supervisor/proof/goal_tactician_metrics.py",
@@ -92,14 +90,12 @@
             "sha256": "sha256:097608f90002bae389517aa64ca2dd9bb50f62edbeb588f14bf0232c6a7822a7",
             "bound": true
           },
-          "failures": [
-            "benchmark_authority_verifier_rejected"
-          ]
+          "failures": []
         }
       },
       "benchmark_hard_gates_required_bps": 10000,
       "fixture_or_synthetic_benchmark_cannot_clear": false,
-      "branch_live_cohort_pending_main_merge": true,
+      "branch_live_cohort_pending_main_merge": false,
       "open_p0_findings_block_clearance": true,
       "open_baseline_findings_disclosed": 1,
       "open_baseline_findings": [
@@ -224,6 +220,10 @@
             "implementation_commits": [
               {
                 "repository": "root",
+                "commit": "9895859501076c2e4a3f9212599dc5e27b8e285a"
+              },
+              {
+                "repository": "root",
                 "commit": "a98029cfd178f814ce23c2a0027ba425ee8b0719"
               }
             ],
@@ -231,8 +231,8 @@
               {
                 "repository": "root",
                 "path": "ipfs_accelerate_py/agent_supervisor/planning/formal_replanner.py",
-                "content_identity": "sha256:e2dc95be602210b2afd6f2c80a45f42f097342d5222b613f4afb61cf3a16ba89",
-                "implementation_commit": "a98029cfd178f814ce23c2a0027ba425ee8b0719"
+                "content_identity": "sha256:809146ebba134157fd5d9d96e07071e2377797a9cd08f8906501c7caf7d653cf",
+                "implementation_commit": "9895859501076c2e4a3f9212599dc5e27b8e285a"
               }
             ],
             "validation_tests": [
@@ -304,9 +304,9 @@
       ],
       "parent": {
         "path": ".",
-        "commit": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
-        "tree": "5202495578eac7d2820d5c4778791dbd9269ca14",
-        "origin_main": "1ee7d434e936dc73f813f48338ab726cb8b95d6f",
+        "commit": "64d194809bd450e1c2dba9b1a6e7e5c058e395e7",
+        "tree": "582f5a7c42f61eeccd32a0f50205f42215b6c676",
+        "origin_main": "64d194809bd450e1c2dba9b1a6e7e5c058e395e7",
         "clean": false,
         "matches_origin_main": true
       },
@@ -1222,7 +1222,7 @@
     "readiness_baseline": {
       "path": "docs/architecture/formal_verification_readiness_baseline.json",
       "present": true,
-      "content_identity": "sha256:d794ffdeb95b6f38042c629e609a26d20e02a503c1c6c8ff95a73e34b1c5e975"
+      "content_identity": "sha256:0ef9b3a7a17a1cc31ab10464208a579581ec826a96af702318d00376dc38b233"
     },
     "toolchain_certificate": {
       "path": "docs/architecture/formal_verification_toolchain_certificate.json",
@@ -1237,7 +1237,7 @@
     "benchmark_report": {
       "path": "docs/architecture/formal_verification_tactician_benchmark.json",
       "present": true,
-      "content_identity": "sha256:9f269644b5dae0bfee742a26bc72aa4e124027df67255204b9216df00ab359b4"
+      "content_identity": "sha256:74e1af81b5e0f83495d38f5e2e558738b70034127ca35f8dda64463655db50a0"
     },
     "live_example_report": {
       "path": "docs/architecture/formal_verification_live_example_report.json",
@@ -4599,5 +4599,5 @@
     "raw_secret_or_witness_forbidden": true,
     "max_public_string_bytes": 8192
   },
-  "receipt_identity": "sha256:c632891a8590e11ea04073438b57621032ffc690dffee1936105e158dd33b3ba"
+  "receipt_identity": "sha256:ee1487751125758ab679aad38e9d11ae800fb9188873afb36d9835cbb6a7134f"
 }


### PR DESCRIPTION
## Summary
- Rebind GoalTactician authoritative measurement to post-rewrite commit reachable from `origin/main`.
- Refresh P0 `structural_repair_as_closure` resolution digests/commits so hard-zero is fully clear with **authoritative=true** (not only branch-clearable).
- Reseal completion, post-remediation (27/28, deployment_ready), and AVR.

## Test plan
- [x] completion readiness tests (15 passed)