### PR TITLE
fix(agent-supervisor): worktree links, merge abandon, refill mapping

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/objectives/scan_receipts.py
+++ b/ipfs_accelerate_py/agent_supervisor/objectives/scan_receipts.py
@@ -1300,8 +1300,31 @@ class RefillScanResult(Generic[T]):
     def __getitem__(self, index: slice) -> tuple[T, ...]:
         ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[T, tuple[T, ...]]:
+    @overload
+    def __getitem__(self, index: str) -> Any:
+        ...
+
+    def __getitem__(self, index: Union[int, slice, str]) -> Any:
+        # Legacy supervisor callers treat refill results as mapping-like
+        # envelopes (payload["objective_heap_schedule_count"]).  Prefer
+        # metadata, then the JSON contract envelope.
+        if isinstance(index, str):
+            metadata = dict(self.metadata or {})
+            if index in metadata:
+                return metadata[index]
+            envelope = self.to_dict()
+            if index in envelope:
+                return envelope[index]
+            raise KeyError(index)
         return self.items[index]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Mapping-style access for metadata / envelope fields."""
+
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable contract envelope."""

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -26560,10 +26560,30 @@ class PortalImplementationDaemon:
             for protected in self.implementation_protected_paths
         )
 
-    def _link_shared_worktree_paths(self, worktree_path: Path) -> None:
+    def _is_allowed_shared_link_worktree(self, worktree_path: Path) -> bool:
+        """Return whether shared dependency links may target ``worktree_path``.
+
+        Managed worktrees under ``worktree_root`` are always allowed.  Sibling
+        worktrees next to ``repo_root`` (common pytest and ephemeral layouts
+        with ``tmp/repo`` + ``tmp/worktree``) are also allowed so validation
+        workspaces can reuse shared ``node_modules`` without disabling the
+        safety rail that blocks arbitrary system paths.
+        """
+
         try:
-            worktree_path.resolve().relative_to(self.worktree_root.resolve())
-        except (OSError, RuntimeError, ValueError):
+            worktree = worktree_path.resolve()
+            managed = self.worktree_root.resolve()
+            if worktree == managed or self._path_is_under(worktree, managed):
+                return True
+            repo = self.repo_root.resolve()
+            if worktree != repo and worktree.parent == repo.parent:
+                return True
+        except (OSError, RuntimeError, ValueError, AttributeError):
+            return False
+        return False
+
+    def _link_shared_worktree_paths(self, worktree_path: Path) -> None:
+        if not self._is_allowed_shared_link_worktree(worktree_path):
             logger.warning(
                 "Refusing to link shared dependencies outside managed worktree root: %s",
                 worktree_path,
@@ -41705,6 +41725,21 @@ class PortalImplementationDaemon:
                     and reconcile_reason
                     == "stale_failed_merge_candidate"
                 ):
+                    abandoned_candidates.add(candidate_key)
+                elif (
+                    implementation_commit
+                    and candidate_key
+                    not in persistence_recovery_candidate_keys
+                    and merge_reason
+                    in {
+                        "main_checkout_dirty_conflict",
+                        "main_checkout_dirty",
+                        "dirty_worktree",
+                    }
+                ):
+                    # An attempted merge that failed because the main checkout
+                    # was dirty is not a useful reconciliation candidate; the
+                    # operator must clean the target before retrying.
                     abandoned_candidates.add(candidate_key)
                 continue
             if str(event.get("type") or "") != "implementation_finished":


### PR DESCRIPTION
## Summary
- Allow shared dependency linking for sibling worktrees next to `repo_root` (pytest / ephemeral layouts).
- Abandon failed-merge candidates after `main_checkout_dirty_conflict` (and related dirty checkout reasons).
- `RefillScanResult` supports mapping-style access for legacy metadata keys (`payload[\"objective_heap_schedule_count\"]`).

Unblocks monorepo tests: worktree dependencies, merge lock retry, objective task janitor.