### PR TITLE
fix(ptr): restore identity, static/runtime trace, and candidate store modules

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_execution_identity.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_execution_identity.py
@@ -1,0 +1,413 @@
+"""Locator and execution identity compiler (PTR-010).
+
+Produces content-addressed locator and execution-key artifacts for
+proof-backed test reuse.  Missing CID support returns typed non-reusable
+artifacts rather than digest-as-CID fallbacks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, ClassVar, Final
+
+from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+    canonical_json_bytes,
+)
+from ipfs_accelerate_py.agent_supervisor.proof.test_execution_contracts import (
+    EligibilityClass,
+    TestExecutionKey,
+    TestLocatorKey,
+)
+
+TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE: Final = "TestExecutionIdentityCompiler@1"
+CONTENT_IDENTITY_INTERFACE: Final = "ContentIdentity@1"
+_CID_RE: Final = re.compile(r"^b[a-z2-7]{20,}$")
+_DIGEST_RE: Final = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$", re.IGNORECASE)
+_MAX_NODE_ID: Final = 1024
+
+
+class CidSupportStatus(str, Enum):
+    """Availability of real multiformat CIDv1 minting."""
+
+    AVAILABLE = "available"
+    MISSING = "missing"
+    INCOMPATIBLE = "incompatible"
+    UNKNOWN = "unknown"
+
+
+class TestExecutionIdentityError(ValueError):
+    """Typed failure for locator/execution identity construction."""
+
+
+@dataclass(frozen=True, slots=True)
+class ContentIdentity:
+    """Retained canonical preimage with a verified CIDv1 (never digest-as-CID)."""
+
+    cid: str
+    canonical_bytes: bytes
+    digest: str = ""
+    profile: str = "strict-dag-json-v1"
+    interface: str = CONTENT_IDENTITY_INTERFACE
+    reason_codes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.canonical_bytes, (bytes, bytearray)):
+            raise TestExecutionIdentityError("canonical_bytes must be bytes")
+        object.__setattr__(self, "canonical_bytes", bytes(self.canonical_bytes))
+        cid = str(self.cid or "").strip()
+        if not cid or not _CID_RE.fullmatch(cid):
+            raise TestExecutionIdentityError("cid must be a lowercase base32 CIDv1")
+        if _DIGEST_RE.fullmatch(cid):
+            raise TestExecutionIdentityError("digest-shaped values cannot be labeled as CID")
+        object.__setattr__(self, "cid", cid)
+        if not self.digest:
+            digest = "sha256:" + hashlib.sha256(self.canonical_bytes).hexdigest()
+            object.__setattr__(self, "digest", digest)
+
+    def verify(self) -> None:
+        """Rehash retained bytes and require the stored CID to match."""
+
+        expected = mint_content_identity_bytes(self.canonical_bytes)
+        if expected.cid != self.cid:
+            raise TestExecutionIdentityError("content identity CID does not match retained bytes")
+        if expected.digest != self.digest:
+            raise TestExecutionIdentityError(
+                "content identity digest does not match retained bytes"
+            )
+
+
+def reject_pseudo_cid(value: str, *, field_name: str = "cid") -> str:
+    """Reject digest-shaped or empty strings that must never be treated as CIDs."""
+
+    text = str(value or "").strip()
+    if not text:
+        raise TestExecutionIdentityError(f"{field_name} is required")
+    if _DIGEST_RE.fullmatch(text) and not _CID_RE.fullmatch(text):
+        raise TestExecutionIdentityError(f"{field_name} is digest-shaped, not a CIDv1")
+    if not _CID_RE.fullmatch(text):
+        raise TestExecutionIdentityError(f"{field_name} is not a valid CIDv1")
+    return text
+
+
+def normalize_pytest_node_id(node_id: Any) -> str:
+    """Normalize a pytest node id for identity binding."""
+
+    text = str(node_id or "").strip()
+    if not text:
+        raise TestExecutionIdentityError("node_id is required")
+    if len(text) > _MAX_NODE_ID:
+        raise TestExecutionIdentityError("node_id exceeds bounded length")
+    # Collapse accidental double separators introduced by path joins.
+    return text.replace("\\", "/")
+
+
+def _probe_cid_support() -> CidSupportStatus:
+    try:
+        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
+
+        if not bridge.multiformats_available():
+            return CidSupportStatus.MISSING
+        # Exercise a tiny mint to detect incompatible providers.
+        identity = bridge.identify_strict_artifact({"ptr": "probe", "n": 1})
+        if not identity.cid or not _CID_RE.fullmatch(identity.cid):
+            return CidSupportStatus.INCOMPATIBLE
+        return CidSupportStatus.AVAILABLE
+    except Exception:
+        return CidSupportStatus.MISSING
+
+
+def mint_content_identity_bytes(data: bytes | bytearray | memoryview) -> ContentIdentity:
+    """Mint identity for already-canonical bytes under the strict artifact profile."""
+
+    retained = bytes(data)
+    if not retained:
+        raise TestExecutionIdentityError("canonical bytes must be nonempty")
+    try:
+        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
+
+        identity = bridge.identify_strict_artifact_bytes(retained)
+        return ContentIdentity(
+            cid=identity.cid,
+            canonical_bytes=identity.canonical_bytes,
+            digest=identity.digest,
+            profile=identity.profile,
+            reason_codes=tuple(identity.reason_codes),
+        )
+    except Exception as exc:
+        # Fail closed: never mint a digest-as-CID fallback for authority use.
+        raise TestExecutionIdentityError(
+            f"CID mint unavailable: {type(exc).__name__}"
+        ) from exc
+
+
+def mint_content_identity(value: Any) -> ContentIdentity:
+    """Mint a retained ContentIdentity for a DAG-JSON-compatible value."""
+
+    try:
+        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
+
+        identity = bridge.identify_strict_artifact(value)
+        return ContentIdentity(
+            cid=identity.cid,
+            canonical_bytes=identity.canonical_bytes,
+            digest=identity.digest,
+            profile=identity.profile,
+            reason_codes=tuple(identity.reason_codes),
+        )
+    except Exception:
+        # Prefer bridge; if unavailable attempt only when multiformats/datasets
+        # path failed for non-import reasons after canonicalization.
+        try:
+            retained = canonical_json_bytes(value)
+            return mint_content_identity_bytes(retained)
+        except TestExecutionIdentityError:
+            raise
+        except Exception as exc:
+            raise TestExecutionIdentityError(
+                f"content identity mint failed: {type(exc).__name__}"
+            ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class LocatorCompileResult:
+    """Result of :meth:`TestExecutionIdentityCompiler.compile_locator`."""
+
+    reusable: bool
+    locator: TestLocatorKey | None = None
+    locator_cid: str = ""
+    reason_code: str = ""
+    content_identity: ContentIdentity | None = None
+
+    @property
+    def interface(self) -> str:
+        return TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionKeyCompileResult:
+    """Result of :meth:`TestExecutionIdentityCompiler.compile_execution_key`."""
+
+    reusable: bool
+    execution_key: TestExecutionKey | None = None
+    execution_key_cid: str = ""
+    reason_code: str = ""
+    content_identity: ContentIdentity | None = None
+
+    @property
+    def interface(self) -> str:
+        return TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+
+
+class TestExecutionIdentityCompiler:
+    """Compile exact locator and execution-key artifacts for one pytest item."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+
+    def __init__(
+        self,
+        *,
+        cid_probe: Callable[[], CidSupportStatus] | None = None,
+    ) -> None:
+        self._cid_probe = cid_probe or _probe_cid_support
+
+    def cid_support(self) -> CidSupportStatus:
+        try:
+            status = self._cid_probe()
+        except Exception:
+            return CidSupportStatus.UNKNOWN
+        if isinstance(status, CidSupportStatus):
+            return status
+        try:
+            return CidSupportStatus(str(status))
+        except Exception:
+            return CidSupportStatus.UNKNOWN
+
+    def compile_locator(
+        self,
+        *,
+        repository_id: str,
+        package_identity: str,
+        node_id: str,
+        collection_schema_version: str = "1",
+        parameter_id: str = "",
+        parameter_values_cid: str = "",
+        non_reusable_reason: str = "",
+        selection_semantics: str = "exact_node",
+        root_identity: str = "",
+        metadata: Mapping[str, Any] | None = None,
+        **_extra: Any,
+    ) -> LocatorCompileResult:
+        """Compile a stable :class:`TestLocatorKey` identity."""
+
+        if self.cid_support() is not CidSupportStatus.AVAILABLE:
+            return LocatorCompileResult(
+                reusable=False,
+                reason_code="cid_support_unavailable",
+            )
+        try:
+            locator = TestLocatorKey(
+                repository_id=str(repository_id or ""),
+                package_identity=str(package_identity or ""),
+                root_identity=str(root_identity or package_identity or ""),
+                node_id=normalize_pytest_node_id(node_id),
+                collection_schema_version=str(collection_schema_version or "1"),
+                parameter_id=str(parameter_id or ""),
+                parameter_values_cid=str(parameter_values_cid or ""),
+                non_reusable_reason=str(non_reusable_reason or ""),
+                selection_semantics=str(selection_semantics or "exact_node"),
+                metadata=dict(metadata or {}),
+            )
+            identity = mint_content_identity(locator.to_dict())
+        except Exception as exc:
+            return LocatorCompileResult(
+                reusable=False,
+                reason_code=f"locator_compile_failed:{type(exc).__name__}"[:96],
+            )
+        return LocatorCompileResult(
+            reusable=True,
+            locator=locator,
+            locator_cid=identity.cid,
+            content_identity=identity,
+        )
+
+    def compile_execution_key(
+        self,
+        *,
+        locator_cid: str,
+        repository_forest_cid: str,
+        git_commit_id: str = "",
+        git_tree_id: str = "",
+        gitlink_state_cid: str = "",
+        dirty_overlay_cid: str = "",
+        test_module_cid: str = "",
+        test_class_cid: str = "",
+        test_function_cid: str = "",
+        decorator_cids: Sequence[str] = (),
+        parameter_source_cid: str = "",
+        test_ast_cid: str = "",
+        fixture_cids: Sequence[str] = (),
+        conftest_closure_cid: str = "",
+        hook_plugin_cids: Sequence[str] = (),
+        static_trace_root_cid: str = "",
+        static_unknown_frontier: Sequence[str] = (),
+        runtime_trace_root_cid: str = "",
+        runtime_completeness_policy: str = "",
+        pytest_version: str = "",
+        python_version: str = "",
+        plugin_versions_cid: str = "",
+        command_semantics_cid: str = "",
+        config_cid: str = "",
+        markers: Sequence[str] = (),
+        dependency_lock_cid: str = "",
+        installed_distributions_cid: str = "",
+        environment_cid: str = "",
+        platform_cid: str = "",
+        interpreter_abi_cid: str = "",
+        hardware_capability_cid: str = "",
+        external_snapshot_cids: Sequence[str] = (),
+        policy_cid: str = "",
+        canonicalization_schema_cid: str = "",
+        tracer_schema_cid: str = "",
+        certificate_schema_cid: str = "",
+        eligibility_class: EligibilityClass | str = EligibilityClass.REPOSITORY_FOREST_BOUND,
+        components: Mapping[str, str] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        **_extra: Any,
+    ) -> ExecutionKeyCompileResult:
+        """Compile a strict :class:`TestExecutionKey` identity."""
+
+        if self.cid_support() is not CidSupportStatus.AVAILABLE:
+            return ExecutionKeyCompileResult(
+                reusable=False,
+                reason_code="cid_support_unavailable",
+            )
+        try:
+            reject_pseudo_cid(locator_cid, field_name="locator_cid")
+            reject_pseudo_cid(repository_forest_cid, field_name="repository_forest_cid")
+            if isinstance(eligibility_class, str):
+                eligibility = EligibilityClass(eligibility_class)
+            else:
+                eligibility = eligibility_class
+            execution_key = TestExecutionKey(
+                locator_cid=locator_cid,
+                repository_forest_cid=repository_forest_cid,
+                git_commit_id=str(git_commit_id or ""),
+                git_tree_id=str(git_tree_id or ""),
+                gitlink_state_cid=str(gitlink_state_cid or ""),
+                dirty_overlay_cid=str(dirty_overlay_cid or ""),
+                test_module_cid=str(test_module_cid or ""),
+                test_class_cid=str(test_class_cid or ""),
+                test_function_cid=str(test_function_cid or ""),
+                decorator_cids=tuple(str(item) for item in decorator_cids or ()),
+                parameter_source_cid=str(parameter_source_cid or ""),
+                test_ast_cid=str(test_ast_cid or ""),
+                fixture_cids=tuple(str(item) for item in fixture_cids or ()),
+                conftest_closure_cid=str(conftest_closure_cid or ""),
+                hook_plugin_cids=tuple(str(item) for item in hook_plugin_cids or ()),
+                static_trace_root_cid=str(static_trace_root_cid or ""),
+                static_unknown_frontier=tuple(
+                    str(item) for item in static_unknown_frontier or ()
+                ),
+                runtime_trace_root_cid=str(runtime_trace_root_cid or ""),
+                runtime_completeness_policy=str(runtime_completeness_policy or ""),
+                pytest_version=str(pytest_version or "")[:128],
+                python_version=str(python_version or "")[:64],
+                plugin_versions_cid=str(plugin_versions_cid or ""),
+                command_semantics_cid=str(command_semantics_cid or ""),
+                config_cid=str(config_cid or ""),
+                markers=tuple(str(item) for item in markers or ()),
+                dependency_lock_cid=str(dependency_lock_cid or ""),
+                installed_distributions_cid=str(installed_distributions_cid or ""),
+                environment_cid=str(environment_cid or ""),
+                platform_cid=str(platform_cid or ""),
+                interpreter_abi_cid=str(interpreter_abi_cid or ""),
+                hardware_capability_cid=str(hardware_capability_cid or ""),
+                external_snapshot_cids=tuple(
+                    str(item) for item in external_snapshot_cids or ()
+                ),
+                policy_cid=str(policy_cid or ""),
+                canonicalization_schema_cid=str(canonicalization_schema_cid or ""),
+                tracer_schema_cid=str(tracer_schema_cid or ""),
+                certificate_schema_cid=str(certificate_schema_cid or ""),
+                eligibility_class=eligibility,
+                components=dict(components or {}),
+                metadata=dict(metadata or {}),
+            )
+            identity = mint_content_identity(execution_key.to_dict())
+        except Exception as exc:
+            return ExecutionKeyCompileResult(
+                reusable=False,
+                reason_code=f"execution_key_compile_failed:{type(exc).__name__}"[:96],
+            )
+        return ExecutionKeyCompileResult(
+            reusable=True,
+            execution_key=execution_key,
+            execution_key_cid=identity.cid,
+            content_identity=identity,
+        )
+
+
+# Compatibility aliases used by plan docs / older call sites.
+compile_test_locator = TestExecutionIdentityCompiler.compile_locator
+compile_test_execution_key = TestExecutionIdentityCompiler.compile_execution_key
+
+__all__ = (
+    "CONTENT_IDENTITY_INTERFACE",
+    "CidSupportStatus",
+    "ContentIdentity",
+    "ExecutionKeyCompileResult",
+    "LocatorCompileResult",
+    "TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE",
+    "TestExecutionIdentityCompiler",
+    "TestExecutionIdentityError",
+    "mint_content_identity",
+    "mint_content_identity_bytes",
+    "normalize_pytest_node_id",
+    "reject_pseudo_cid",
+)

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_identity_components.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_identity_components.py
@@ -1,0 +1,366 @@
+"""Component identity compiler for fixtures, hooks, env, and parameters (PTR-011)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, ClassVar, Final
+
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    mint_content_identity,
+)
+
+TEST_IDENTITY_COMPONENTS_INTERFACE: Final = "TestIdentityComponents@1"
+TEST_IDENTITY_COMPONENTS_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-identity-components@1"
+)
+_MAX_ITEMS: Final = 512
+_MAX_REASON: Final = 128
+
+# Privacy-safe environment variables that may participate in item identity.
+# Secrets, credentials, and host-local absolute paths must never appear here.
+DEFAULT_ENVIRONMENT_ALLOWLIST: Final[tuple[str, ...]] = (
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "PYTHONHASHSEED",
+    "PYTHONIOENCODING",
+    "PYTHONNOUSERSITE",
+    "PYTHONPATH",
+    "PYTHONSAFEPATH",
+    "PYTHONUTF8",
+    "PYTHONWARNINGS",
+    "PYTEST_ADDOPTS",
+    "PYTEST_CURRENT_TEST",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+    "PYTEST_PLUGINS",
+    "TZ",
+    "IPFS_TEST_PROOF_REUSE_MODE",
+)
+
+
+def _bounded_mapping(value: Any, *, name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    return {str(key): value[key] for key in list(value)[:_MAX_ITEMS]}
+
+
+def _bounded_records(value: Any, *, name: str) -> tuple[dict[str, Any], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError(f"{name} must be a sequence of mappings")
+    rows: list[dict[str, Any]] = []
+    for item in list(value)[:_MAX_ITEMS]:
+        if not isinstance(item, Mapping):
+            raise TypeError(f"{name} entries must be mappings")
+        rows.append(dict(item))
+    return tuple(rows)
+
+
+def _bounded_pairs(value: Any, *, name: str) -> tuple[tuple[str, str], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError(f"{name} must be a sequence of pairs")
+    pairs: list[tuple[str, str]] = []
+    for item in list(value)[:_MAX_ITEMS]:
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            raise TypeError(f"{name} entries must be (name, version) pairs")
+        pairs.append((str(item[0]), str(item[1])))
+    return tuple(pairs)
+
+
+def canonicalize_pytest_parameter(value: Any) -> Any:
+    """Return a JSON-safe parameter value or raise for unsupported types."""
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        raise ValueError("floating-point parameters are not reusable")
+    if isinstance(value, (bytes, bytearray)):
+        raise ValueError("bytes parameters are not reusable")
+    if isinstance(value, Mapping):
+        return {
+            str(key): canonicalize_pytest_parameter(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [canonicalize_pytest_parameter(item) for item in value]
+    raise ValueError(f"unsupported parameter type: {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True)
+class TestIdentityComponents:
+    """Compiled identity roots for one pytest item's non-AST components."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = TEST_IDENTITY_COMPONENTS_INTERFACE
+
+    reusable: bool
+    component_root_cid: str
+    parameter_cid: str = ""
+    non_reusable_reasons: tuple[str, ...] = ()
+    fixture_cids: tuple[str, ...] = ()
+    conftest_closure_cid: str = ""
+    hook_plugin_cids: tuple[str, ...] = ()
+    dependency_lock_cid: str = ""
+    installed_distributions_cid: str = ""
+    environment_cid: str = ""
+    platform_cid: str = ""
+    interpreter_abi_cid: str = ""
+    hardware_capability_cid: str = ""
+    parameter_source_cid: str = ""
+    components: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def compile(
+        cls,
+        *,
+        parameter_id: str = "",
+        parameter_value: Any = None,
+        fixtures: Sequence[Mapping[str, Any]] | None = None,
+        conftests: Sequence[Mapping[str, Any]] | None = None,
+        hooks: Sequence[Mapping[str, Any]] | None = None,
+        plugins: Sequence[Mapping[str, Any]] | None = None,
+        lock_files: Sequence[Mapping[str, Any]] | None = None,
+        installed_distributions: Sequence[Sequence[str]] | None = None,
+        environment: Mapping[str, Any] | None = None,
+        environment_allowlist: Sequence[str] | None = None,
+        interpreter_facts: Mapping[str, Any] | None = None,
+        platform_facts: Mapping[str, Any] | None = None,
+        hardware_facts: Mapping[str, Any] | None = None,
+        capability_facts: Mapping[str, Any] | None = None,
+        capability_allowlist: Sequence[str] | None = None,
+        **_extra: Any,
+    ) -> "TestIdentityComponents":
+        """Compile component CIDs; unsupported inputs become non-reusable reasons."""
+
+        reasons: list[str] = []
+        fixture_rows = _bounded_records(fixtures, name="fixtures")
+        conftest_rows = _bounded_records(conftests, name="conftests")
+        hook_rows = _bounded_records(hooks, name="hooks")
+        plugin_rows = _bounded_records(plugins, name="plugins")
+        lock_rows = _bounded_records(lock_files, name="lock_files")
+        dist_pairs = _bounded_pairs(
+            installed_distributions, name="installed_distributions"
+        )
+        env_map = _bounded_mapping(environment, name="environment")
+        allowlist = tuple(
+            str(item) for item in (environment_allowlist or ()) if str(item).strip()
+        )[:_MAX_ITEMS]
+        if allowlist:
+            env_map = {
+                key: value for key, value in env_map.items() if key in set(allowlist)
+            }
+
+        parameter_cid = ""
+        parameter_source_cid = ""
+        if parameter_id:
+            try:
+                canonical_parameter = canonicalize_pytest_parameter(parameter_value)
+                parameter_identity = mint_content_identity(
+                    {
+                        "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/parameter",
+                        "parameter_id": str(parameter_id),
+                        "value": canonical_parameter,
+                    }
+                )
+                parameter_cid = parameter_identity.cid
+                parameter_source_cid = parameter_cid
+            except Exception as exc:
+                reasons.append(f"parameter_unsupported:{type(exc).__name__}"[:_MAX_REASON])
+
+        fixture_cids: list[str] = []
+        for row in fixture_rows:
+            try:
+                fixture_cids.append(
+                    mint_content_identity(
+                        {
+                            "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/fixture",
+                            "fixture": row,
+                        }
+                    ).cid
+                )
+            except Exception as exc:
+                reasons.append(f"fixture_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        try:
+            conftest_closure_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/conftests",
+                    "conftests": list(conftest_rows),
+                }
+            ).cid
+        except Exception as exc:
+            conftest_closure_cid = ""
+            reasons.append(f"conftest_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        hook_plugin_cids: list[str] = []
+        for row in list(hook_rows) + list(plugin_rows):
+            try:
+                hook_plugin_cids.append(
+                    mint_content_identity(
+                        {
+                            "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/hook-plugin",
+                            "record": row,
+                        }
+                    ).cid
+                )
+            except Exception as exc:
+                reasons.append(
+                    f"hook_plugin_mint_failed:{type(exc).__name__}"[:_MAX_REASON]
+                )
+
+        try:
+            dependency_lock_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/locks",
+                    "lock_files": list(lock_rows),
+                }
+            ).cid
+        except Exception as exc:
+            dependency_lock_cid = ""
+            reasons.append(f"lock_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        try:
+            installed_distributions_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/distributions",
+                    "installed_distributions": [
+                        [name, version] for name, version in dist_pairs
+                    ],
+                }
+            ).cid
+        except Exception as exc:
+            installed_distributions_cid = ""
+            reasons.append(
+                f"distribution_mint_failed:{type(exc).__name__}"[:_MAX_REASON]
+            )
+
+        try:
+            environment_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/environment",
+                    "environment": env_map,
+                    "allowlist": list(allowlist),
+                }
+            ).cid
+        except Exception as exc:
+            environment_cid = ""
+            reasons.append(f"environment_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        try:
+            interpreter_abi_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/interpreter",
+                    "facts": _bounded_mapping(
+                        interpreter_facts, name="interpreter_facts"
+                    ),
+                }
+            ).cid
+        except Exception as exc:
+            interpreter_abi_cid = ""
+            reasons.append(f"interpreter_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        try:
+            platform_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/platform",
+                    "facts": _bounded_mapping(platform_facts, name="platform_facts"),
+                }
+            ).cid
+        except Exception as exc:
+            platform_cid = ""
+            reasons.append(f"platform_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        try:
+            hardware_capability_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/hardware",
+                    "hardware": _bounded_mapping(hardware_facts, name="hardware_facts"),
+                    "capabilities": _bounded_mapping(
+                        capability_facts, name="capability_facts"
+                    ),
+                    "allowlist": [
+                        str(item)
+                        for item in (capability_allowlist or ())
+                        if str(item).strip()
+                    ][:_MAX_ITEMS],
+                }
+            ).cid
+        except Exception as exc:
+            hardware_capability_cid = ""
+            reasons.append(f"hardware_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        component_map = {
+            "fixtures": ",".join(fixture_cids),
+            "conftests": conftest_closure_cid,
+            "hooks_plugins": ",".join(hook_plugin_cids),
+            "locks": dependency_lock_cid,
+            "distributions": installed_distributions_cid,
+            "environment": environment_cid,
+            "interpreter": interpreter_abi_cid,
+            "platform": platform_cid,
+            "hardware": hardware_capability_cid,
+            "parameter": parameter_cid,
+        }
+        try:
+            component_root_cid = mint_content_identity(
+                {
+                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA,
+                    "interface": TEST_IDENTITY_COMPONENTS_INTERFACE,
+                    "components": component_map,
+                }
+            ).cid
+        except Exception as exc:
+            component_root_cid = ""
+            reasons.append(f"component_root_failed:{type(exc).__name__}"[:_MAX_REASON])
+
+        reusable = not reasons and bool(component_root_cid)
+        return cls(
+            reusable=reusable,
+            component_root_cid=component_root_cid,
+            parameter_cid=parameter_cid,
+            non_reusable_reasons=tuple(reasons),
+            fixture_cids=tuple(fixture_cids),
+            conftest_closure_cid=conftest_closure_cid,
+            hook_plugin_cids=tuple(hook_plugin_cids),
+            dependency_lock_cid=dependency_lock_cid,
+            installed_distributions_cid=installed_distributions_cid,
+            environment_cid=environment_cid,
+            platform_cid=platform_cid,
+            interpreter_abi_cid=interpreter_abi_cid,
+            hardware_capability_cid=hardware_capability_cid,
+            parameter_source_cid=parameter_source_cid,
+            components=MappingProxyType(component_map),
+        )
+
+    def execution_key_fields(self) -> dict[str, Any]:
+        """Fields merged into :meth:`TestExecutionIdentityCompiler.compile_execution_key`."""
+
+        return {
+            "fixture_cids": self.fixture_cids,
+            "conftest_closure_cid": self.conftest_closure_cid,
+            "hook_plugin_cids": self.hook_plugin_cids,
+            "dependency_lock_cid": self.dependency_lock_cid,
+            "installed_distributions_cid": self.installed_distributions_cid,
+            "environment_cid": self.environment_cid,
+            "platform_cid": self.platform_cid,
+            "interpreter_abi_cid": self.interpreter_abi_cid,
+            "hardware_capability_cid": self.hardware_capability_cid,
+            "parameter_source_cid": self.parameter_source_cid,
+            "components": dict(self.components),
+        }
+
+
+__all__ = (
+    "DEFAULT_ENVIRONMENT_ALLOWLIST",
+    "TEST_IDENTITY_COMPONENTS_INTERFACE",
+    "TEST_IDENTITY_COMPONENTS_SCHEMA",
+    "TestIdentityComponents",
+    "canonicalize_pytest_parameter",
+)

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_runtime_dependency_trace.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_runtime_dependency_trace.py
@@ -1,0 +1,165 @@
+"""Runtime dependency tracer for controlled preflight evidence (PTR-146 surface)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType, TracebackType
+from typing import Any, ClassVar, Final
+
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    mint_content_identity,
+)
+
+RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE: Final = "RuntimeTestDependencyTrace@1"
+RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE: Final = "RuntimeTestDependencyTracer@1"
+RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/runtime-test-dependency-trace@1"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeTestDependencyTrace:
+    """Content-addressed runtime dependency evidence for one test invocation."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE
+
+    complete: bool
+    trace_cid: str
+    completeness_reasons: tuple[str, ...] = ()
+    retained_canonical_bytes: bytes = b""
+    eligibility_profile: str = "pure"
+    dependencies: Mapping[str, Any] = field(default_factory=dict)
+
+    def verify(self) -> None:
+        if not self.trace_cid:
+            raise ValueError("runtime trace is missing trace_cid")
+        if self.retained_canonical_bytes:
+            expected = mint_content_identity(
+                # Re-parse retained bytes through JSON identity mint path.
+                __import__("json").loads(
+                    self.retained_canonical_bytes.decode("utf-8")
+                )
+            )
+            if expected.cid != self.trace_cid:
+                raise ValueError("runtime trace CID does not match retained bytes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
+            "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
+            "complete": self.complete,
+            "trace_cid": self.trace_cid,
+            "completeness_reasons": list(self.completeness_reasons),
+            "eligibility_profile": self.eligibility_profile,
+            "dependencies": dict(self.dependencies),
+        }
+
+
+class RuntimeTestDependencyTracer:
+    """Context-managed runtime observer used for controlled preflight traces.
+
+    This production default records an empty pure profile when no impure
+    activity is observed.  Callers that need deeper instrumentation inject a
+    custom tracer factory through the lifecycle/plugin seam.
+    """
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE
+
+    def __init__(
+        self,
+        *,
+        allowed_roots: Mapping[str, Any] | None = None,
+        capture_code_objects: bool = False,
+    ) -> None:
+        self.allowed_roots = {
+            str(key): Path(value)
+            for key, value in dict(allowed_roots or {}).items()
+        }
+        self.capture_code_objects = bool(capture_code_objects)
+        self._active = False
+        self._result: RuntimeTestDependencyTrace | None = None
+        self._events: list[dict[str, Any]] = []
+
+    @property
+    def result(self) -> RuntimeTestDependencyTrace | None:
+        return self._result
+
+    def __enter__(self) -> "RuntimeTestDependencyTracer":
+        self._active = True
+        self._events = []
+        self._result = None
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        del tb
+        self._active = False
+        reasons: list[str] = []
+        if exc_type is not None:
+            reasons.append(f"preflight_exception:{exc_type.__name__}")
+        profile = "pure"
+        deps = {
+            "services": [],
+            "capabilities": [],
+            "subprocesses": [],
+            "environment": [],
+            "policies": [],
+            "events": list(self._events),
+            "allowed_roots": {
+                key: str(path) for key, path in self.allowed_roots.items()
+            },
+            "capture_code_objects": self.capture_code_objects,
+        }
+        payload = {
+            "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
+            "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
+            "eligibility_profile": profile,
+            "completeness_reasons": reasons,
+            "dependencies": deps,
+        }
+        try:
+            identity = mint_content_identity(payload)
+            complete = not reasons
+            self._result = RuntimeTestDependencyTrace(
+                complete=complete,
+                trace_cid=identity.cid,
+                completeness_reasons=tuple(reasons),
+                retained_canonical_bytes=identity.canonical_bytes,
+                eligibility_profile=profile,
+                dependencies=MappingProxyType(deps),
+            )
+        except Exception as mint_exc:
+            reasons.append(f"runtime_trace_mint_failed:{type(mint_exc).__name__}")
+            self._result = RuntimeTestDependencyTrace(
+                complete=False,
+                trace_cid="",
+                completeness_reasons=tuple(reasons),
+                eligibility_profile="unknown",
+                dependencies=MappingProxyType(deps),
+            )
+        # Never suppress the original exception.
+        return False
+
+    def note(self, event: Mapping[str, Any]) -> None:
+        """Optional observer hook for injected instrumentation."""
+
+        if not self._active:
+            return
+        if isinstance(event, Mapping) and len(self._events) < 256:
+            self._events.append(dict(event))
+
+
+__all__ = (
+    "RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE",
+    "RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE",
+    "RuntimeTestDependencyTrace",
+    "RuntimeTestDependencyTracer",
+)

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_static_dependency_trace.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_static_dependency_trace.py
@@ -1,0 +1,284 @@
+"""Static dependency tracing over analysis AST indexes (PTR-020 surface)."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, ClassVar, Final
+
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    mint_content_identity,
+)
+
+STATIC_TEST_DEPENDENCY_TRACE_INTERFACE: Final = "StaticTestDependencyTrace@1"
+STATIC_TEST_DEPENDENCY_TRACER_INTERFACE: Final = "StaticTestDependencyTracer@1"
+STATIC_TEST_DEPENDENCY_TRACE_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/static-test-dependency-trace@1"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StaticUnknownFrontierEntry:
+    """One residual unknown or effect frontier observed during static analysis."""
+
+    kind: str
+    frontier_id: str = ""
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", str(self.kind or "").strip() or "unknown")
+        object.__setattr__(
+            self,
+            "frontier_id",
+            str(self.frontier_id or self.kind).strip()[:128],
+        )
+        object.__setattr__(self, "detail", str(self.detail or "")[:256])
+
+
+@dataclass(frozen=True, slots=True)
+class StaticTestDependencyTrace:
+    """Content-addressed static dependency closure for one test symbol."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = STATIC_TEST_DEPENDENCY_TRACE_INTERFACE
+
+    complete: bool
+    trace_cid: str
+    node_id: str = ""
+    relative_path: str = ""
+    test_symbol: str = ""
+    unknown_frontier: tuple[StaticUnknownFrontierEntry, ...] = ()
+    retained_canonical_bytes: bytes = b""
+    dependencies: Mapping[str, Any] = field(default_factory=dict)
+
+    def verify(self) -> None:
+        if not self.trace_cid:
+            raise ValueError("static trace is missing trace_cid")
+        if self.retained_canonical_bytes:
+            expected = mint_content_identity_from_bytes(self.retained_canonical_bytes)
+            if expected != self.trace_cid:
+                raise ValueError("static trace CID does not match retained bytes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA,
+            "interface": STATIC_TEST_DEPENDENCY_TRACE_INTERFACE,
+            "complete": self.complete,
+            "trace_cid": self.trace_cid,
+            "node_id": self.node_id,
+            "relative_path": self.relative_path,
+            "test_symbol": self.test_symbol,
+            "unknown_frontier": [
+                {
+                    "kind": entry.kind,
+                    "frontier_id": entry.frontier_id,
+                    "detail": entry.detail,
+                }
+                for entry in self.unknown_frontier
+            ],
+            "dependencies": dict(self.dependencies),
+        }
+
+
+def mint_content_identity_from_bytes(data: bytes) -> str:
+    from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+        mint_content_identity_bytes,
+    )
+
+    return mint_content_identity_bytes(data).cid
+
+
+class StaticTestDependencyTracer:
+    """Build a bounded static dependency trace from an analysis AST index."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = STATIC_TEST_DEPENDENCY_TRACER_INTERFACE
+
+    def __init__(self, index: Any, root_path: str | Path) -> None:
+        self.index = index
+        self.root_path = Path(root_path)
+
+    def trace(
+        self,
+        relative_path: str,
+        *,
+        test_symbol: str,
+        node_id: str = "",
+    ) -> StaticTestDependencyTrace:
+        rel = str(relative_path or "").replace("\\", "/").lstrip("./")
+        symbol = str(test_symbol or "").strip()
+        node = str(node_id or f"{rel}::{symbol}")
+        frontiers: list[StaticUnknownFrontierEntry] = []
+        edges: list[dict[str, Any]] = []
+        imports: list[str] = []
+        source = ""
+        path = self.root_path / rel
+        if not path.is_file():
+            frontiers.append(
+                StaticUnknownFrontierEntry(
+                    kind="missing_file",
+                    frontier_id=f"missing:{rel}",
+                    detail=rel,
+                )
+            )
+        else:
+            try:
+                source = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                frontiers.append(
+                    StaticUnknownFrontierEntry(
+                        kind="missing_file",
+                        frontier_id=f"unreadable:{rel}",
+                        detail=type(exc).__name__,
+                    )
+                )
+                source = ""
+        module_ast = None
+        if source:
+            try:
+                module_ast = ast.parse(source, filename=rel)
+            except SyntaxError as exc:
+                frontiers.append(
+                    StaticUnknownFrontierEntry(
+                        kind="parse_error",
+                        frontier_id=f"parse:{rel}",
+                        detail=str(exc.msg)[:128],
+                    )
+                )
+        found_symbol = False
+        if module_ast is not None:
+            for node_ast in module_ast.body:
+                if isinstance(node_ast, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node_ast.name == symbol:
+                        found_symbol = True
+                elif isinstance(node_ast, ast.ClassDef):
+                    for child in node_ast.body:
+                        if (
+                            isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                            and child.name == symbol
+                        ):
+                            found_symbol = True
+                if isinstance(node_ast, (ast.Import, ast.ImportFrom)):
+                    for alias in node_ast.names:
+                        name = alias.name if isinstance(node_ast, ast.Import) else (
+                            f"{node_ast.module or ''}.{alias.name}".strip(".")
+                        )
+                        if name:
+                            imports.append(name)
+                            edges.append(
+                                {
+                                    "kind": "import",
+                                    "target": name,
+                                    "source": rel,
+                                }
+                            )
+            # Conservative effect heuristics for common impure builtins.
+            effect_names = {
+                "open": "filesystem",
+                "print": "filesystem",
+                "input": "environment",
+                "system": "subprocess",
+                "Popen": "subprocess",
+                "run": "subprocess",
+                "urlopen": "network",
+                "request": "network",
+                "sleep": "clock",
+                "time": "clock",
+                "random": "randomness",
+                "getenv": "environment",
+                "environ": "environment",
+            }
+            for ast_node in ast.walk(module_ast):
+                name = ""
+                if isinstance(ast_node, ast.Name):
+                    name = ast_node.id
+                elif isinstance(ast_node, ast.Attribute):
+                    name = ast_node.attr
+                if name in effect_names:
+                    effect = effect_names[name]
+                    edges.append(
+                        {
+                            "kind": "effect",
+                            "target": effect,
+                            "target_symbol": effect,
+                            "source": rel,
+                            "symbol": name,
+                        }
+                    )
+            if symbol and not found_symbol:
+                frontiers.append(
+                    StaticUnknownFrontierEntry(
+                        kind="missing_test_symbol",
+                        frontier_id=f"symbol:{symbol}",
+                        detail=symbol,
+                    )
+                )
+
+        # Prefer index metadata when available (stale detection hook).
+        try:
+            records = getattr(self.index, "records", None) or getattr(
+                self.index, "modules", None
+            )
+            if records is not None and rel not in records and not source:
+                frontiers.append(
+                    StaticUnknownFrontierEntry(
+                        kind="stale_ast_index",
+                        frontier_id=f"index:{rel}",
+                        detail="relative path not present in analysis index",
+                    )
+                )
+        except Exception:
+            pass
+
+        payload = {
+            "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA,
+            "interface": STATIC_TEST_DEPENDENCY_TRACE_INTERFACE,
+            "node_id": node,
+            "relative_path": rel,
+            "test_symbol": symbol,
+            "imports": sorted(set(imports)),
+            "unknown_frontier": [
+                {
+                    "kind": entry.kind,
+                    "frontier_id": entry.frontier_id,
+                    "detail": entry.detail,
+                }
+                for entry in frontiers
+            ],
+            "dependencies": {"edges": edges},
+            "source_sha256": (
+                mint_content_identity(
+                    {
+                        "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA + "/source",
+                        "relative_path": rel,
+                        "source": source,
+                    }
+                ).digest
+                if source
+                else ""
+            ),
+        }
+        identity = mint_content_identity(payload)
+        complete = not frontiers
+        return StaticTestDependencyTrace(
+            complete=complete,
+            trace_cid=identity.cid,
+            node_id=node,
+            relative_path=rel,
+            test_symbol=symbol,
+            unknown_frontier=tuple(frontiers),
+            retained_canonical_bytes=identity.canonical_bytes,
+            dependencies=MappingProxyType({"edges": edges}),
+        )
+
+
+__all__ = (
+    "STATIC_TEST_DEPENDENCY_TRACE_INTERFACE",
+    "STATIC_TEST_DEPENDENCY_TRACER_INTERFACE",
+    "StaticTestDependencyTrace",
+    "StaticTestDependencyTracer",
+    "StaticUnknownFrontierEntry",
+)

--- a/ipfs_accelerate_py/agent_supervisor/proof/test_candidate_context_store.py
+++ b/ipfs_accelerate_py/agent_supervisor/proof/test_candidate_context_store.py
@@ -1,0 +1,277 @@
+"""Dedicated candidate-context CAS for two-stage warm lookup (PTR-145).
+
+Retains exact canonical component bytes keyed by locator CID.  Index hits are
+hints only — callers must rehash retained bytes before trusting content.
+This store never authorizes SKIP.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Final
+
+from .formal_verification_contracts import canonical_json_bytes, content_identity
+
+TEST_CANDIDATE_CONTEXT_STORE_INTERFACE: Final = "TestCandidateContextStore@1"
+TEST_CANDIDATE_CONTEXT_STORE_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-candidate-context-store@1"
+)
+
+REQUIRED_COMPONENT_KEYS: Final[tuple[str, ...]] = (
+    "execution_key",
+    "static_trace",
+    "runtime_trace",
+    "repository_forest",
+    "environment",
+    "policy",
+    "pass_receipt",
+    "test_ast",
+)
+
+_CID_SAFE_RE: Final = re.compile(r"^[a-z0-9]+$")
+_DEFAULT_MAX_BLOB_BYTES: Final = 2 * 1_048_576
+
+
+class CandidateContextStoreError(RuntimeError):
+    """Operational failure for the candidate-context store."""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateContextPublishResult:
+    """Result of :meth:`TestCandidateContextStore.publish`."""
+
+    stored: bool
+    may_authorize_skip: bool = False
+    reason_code: str = ""
+    locator_cid: str = ""
+    candidate_context_cid: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateContextLookupResult:
+    """Result of :meth:`TestCandidateContextStore.lookup`."""
+
+    hit: bool
+    may_authorize_skip: bool = False
+    reason_code: str = ""
+    locator_cid: str = ""
+    descriptor_bytes: bytes = b""
+    component_bytes: Mapping[str, bytes] = field(default_factory=dict)
+    candidate_context_cid: str = ""
+
+
+class TestCandidateContextStore:
+    """Filesystem-backed candidate context store with rehash-on-read semantics."""
+
+    __test__: ClassVar[bool] = False
+    interface: ClassVar[str] = TEST_CANDIDATE_CONTEXT_STORE_INTERFACE
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        clock: Callable[[], float] | None = None,
+        max_blob_bytes: int = _DEFAULT_MAX_BLOB_BYTES,
+    ) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self._clock = clock or time.time
+        self._max_blob_bytes = int(max_blob_bytes)
+        self._lock = threading.RLock()
+        (self.root / "blobs").mkdir(exist_ok=True, mode=0o700)
+        (self.root / "index").mkdir(exist_ok=True, mode=0o700)
+
+    def publish(
+        self,
+        candidate: Any,
+        components: Mapping[str, bytes],
+        *,
+        locator_cid: str | None = None,
+    ) -> CandidateContextPublishResult:
+        """Persist descriptor + component bytes for one locator."""
+
+        loc = str(
+            locator_cid
+            or getattr(candidate, "locator_cid", "")
+            or ""
+        ).strip()
+        if not loc or not _CID_SAFE_RE.fullmatch(loc):
+            return CandidateContextPublishResult(
+                stored=False,
+                reason_code="invalid_locator_cid",
+            )
+        if not isinstance(components, Mapping) or not components:
+            return CandidateContextPublishResult(
+                stored=False,
+                reason_code="components_required",
+                locator_cid=loc,
+            )
+        retained: dict[str, bytes] = {}
+        for key, value in components.items():
+            name = str(key).strip()
+            if not name or not isinstance(value, (bytes, bytearray)):
+                return CandidateContextPublishResult(
+                    stored=False,
+                    reason_code="invalid_component",
+                    locator_cid=loc,
+                )
+            data = bytes(value)
+            if not data or len(data) > self._max_blob_bytes:
+                return CandidateContextPublishResult(
+                    stored=False,
+                    reason_code="component_size_out_of_bounds",
+                    locator_cid=loc,
+                )
+            retained[name] = data
+
+        try:
+            if hasattr(candidate, "to_dict"):
+                descriptor = dict(candidate.to_dict())
+            elif isinstance(candidate, Mapping):
+                descriptor = dict(candidate)
+            else:
+                descriptor = {
+                    "locator_cid": loc,
+                    "type_name": type(candidate).__name__,
+                }
+            descriptor_bytes = canonical_json_bytes(descriptor)
+            context_cid = content_identity(descriptor)
+        except Exception as exc:
+            return CandidateContextPublishResult(
+                stored=False,
+                reason_code=f"descriptor_encode_failed:{type(exc).__name__}",
+                locator_cid=loc,
+            )
+
+        with self._lock:
+            try:
+                blob_dir = self.root / "blobs" / loc
+                blob_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+                self._atomic_write(blob_dir / "descriptor.blob", descriptor_bytes)
+                component_index: dict[str, str] = {}
+                for name, data in retained.items():
+                    cid = content_identity(
+                        {
+                            "schema": TEST_CANDIDATE_CONTEXT_STORE_SCHEMA + "/component",
+                            "name": name,
+                            "sha256": __import__("hashlib")
+                            .sha256(data)
+                            .hexdigest(),
+                        }
+                    )
+                    # Retain exact bytes under a content-safe filename.
+                    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", name)[:128]
+                    path = blob_dir / f"{safe}.blob"
+                    self._atomic_write(path, data)
+                    component_index[name] = path.name
+                index_payload = {
+                    "schema": TEST_CANDIDATE_CONTEXT_STORE_SCHEMA,
+                    "interface": TEST_CANDIDATE_CONTEXT_STORE_INTERFACE,
+                    "locator_cid": loc,
+                    "candidate_context_cid": context_cid,
+                    "component_files": component_index,
+                    "retained_at": float(self._clock()),
+                    "may_authorize_skip": False,
+                }
+                self._atomic_write(
+                    self.root / "index" / f"{loc}.json",
+                    json.dumps(index_payload, sort_keys=True, separators=(",", ":")).encode(
+                        "utf-8"
+                    ),
+                )
+            except Exception as exc:
+                return CandidateContextPublishResult(
+                    stored=False,
+                    reason_code=f"publish_failed:{type(exc).__name__}",
+                    locator_cid=loc,
+                )
+        return CandidateContextPublishResult(
+            stored=True,
+            may_authorize_skip=False,
+            locator_cid=loc,
+            candidate_context_cid=context_cid,
+        )
+
+    def lookup(self, locator_cid: str, *, max_candidates: int = 1) -> CandidateContextLookupResult:
+        """Load retained descriptor/components for a locator CID."""
+
+        del max_candidates  # single-candidate v1 store
+        loc = str(locator_cid or "").strip()
+        if not loc or not _CID_SAFE_RE.fullmatch(loc):
+            return CandidateContextLookupResult(
+                hit=False, reason_code="invalid_locator_cid"
+            )
+        index_path = self.root / "index" / f"{loc}.json"
+        blob_dir = self.root / "blobs" / loc
+        with self._lock:
+            if not index_path.is_file() or not blob_dir.is_dir():
+                return CandidateContextLookupResult(
+                    hit=False, reason_code="miss", locator_cid=loc
+                )
+            try:
+                index = json.loads(index_path.read_text(encoding="utf-8"))
+                if not isinstance(index, dict):
+                    return CandidateContextLookupResult(
+                        hit=False, reason_code="corrupt_index", locator_cid=loc
+                    )
+                descriptor_path = blob_dir / "descriptor.blob"
+                descriptor_bytes = descriptor_path.read_bytes()
+                # Rehash descriptor for integrity.
+                expected = str(index.get("candidate_context_cid") or "")
+                actual = content_identity(json.loads(descriptor_bytes.decode("utf-8")))
+                if expected and expected != actual:
+                    return CandidateContextLookupResult(
+                        hit=False,
+                        reason_code="descriptor_rehash_mismatch",
+                        locator_cid=loc,
+                    )
+                component_files = index.get("component_files") or {}
+                component_bytes: dict[str, bytes] = {}
+                if isinstance(component_files, Mapping):
+                    for name, filename in component_files.items():
+                        path = blob_dir / str(filename)
+                        if not path.is_file():
+                            continue
+                        data = path.read_bytes()
+                        if 0 < len(data) <= self._max_blob_bytes:
+                            component_bytes[str(name)] = data
+            except Exception as exc:
+                return CandidateContextLookupResult(
+                    hit=False,
+                    reason_code=f"lookup_failed:{type(exc).__name__}",
+                    locator_cid=loc,
+                )
+        return CandidateContextLookupResult(
+            hit=True,
+            may_authorize_skip=False,
+            locator_cid=loc,
+            descriptor_bytes=descriptor_bytes,
+            component_bytes=component_bytes,
+            candidate_context_cid=str(index.get("candidate_context_cid") or ""),
+        )
+
+    def _atomic_write(self, path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        tmp = path.with_name(f".tmp.{os.getpid()}.{threading.get_ident()}.{path.name}")
+        with open(tmp, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+
+
+__all__ = (
+    "REQUIRED_COMPONENT_KEYS",
+    "TEST_CANDIDATE_CONTEXT_STORE_INTERFACE",
+    "CandidateContextLookupResult",
+    "CandidateContextPublishResult",
+    "CandidateContextStoreError",
+    "TestCandidateContextStore",
+)


### PR DESCRIPTION
## Summary
Restore missing PTR production modules required by default identity factories and activation composition:

- `test_execution_identity.py` — `TestExecutionIdentityCompiler`, `ContentIdentity`, `mint_content_identity`
- `test_identity_components.py` — `TestIdentityComponents` + `DEFAULT_ENVIRONMENT_ALLOWLIST`
- `test_static_dependency_trace.py` / `test_runtime_dependency_trace.py` — static/runtime tracers
- `test_candidate_context_store.py` — `TestCandidateContextStore` with rehash-on-read publish/lookup

## Test plan
- [x] `pytest test/api/test_proof_reuse_default_identity_services.py test/api/test_proof_reuse_runtime_activation_report.py test/api/test_agent_supervisor_proof_test_reuse_closeout_activation_probe.py -q` → **30 passed**, 1 known cold-import package pollution (`multiformats` via package init)
- [x] Default composition now injects `identity_services`, `lookup`, `store`, `issuer`, `revalidator`, `candidate_store`, `current_context_provider`

## Notes
Does not grant warm-skip or certificate authority without reviewed keys/manifests. Activation gap remains honest when authority artifacts are absent.