### PR TITLE
fix(ptr): restore full identity module implementations and unit suites

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_execution_identity.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_execution_identity.py
@@ -1,38 +1,82 @@
-"""Locator and execution identity compiler (PTR-010).
+"""Core locator and execution identity compiler (PTR-010 / PTR-G020).
 
-Produces content-addressed locator and execution-key artifacts for
-proof-backed test reuse.  Missing CID support returns typed non-reusable
-artifacts rather than digest-as-CID fallbacks.
+Interfaces:
+
+* ``ContentIdentity@1`` — retained canonical DAG-JSON bytes plus a verified
+  CIDv1 / lowercase base32 / ``dag-json`` / ``sha2-256`` address.
+* ``TestExecutionIdentityCompiler@1`` — compile ``TestLocatorKey@1`` and
+  ``TestExecutionKey@1`` into content-addressed artifacts.
+
+Authority doctrine (fail-closed):
+
+* A CID only identifies bytes; it never authorizes reuse by itself.
+* Locator identities narrow candidate retrieval; execution identities bind the
+  exact reusable context (forest, source/AST roots, fixtures, policy, …).
+* Missing multiformats / CID support returns an explicit **non-reusable**
+  artifact and never labels a fallback digest or kit pseudo-hash as a CID.
+* Retained canonical bytes must decode and rehash to the stored CID.
 """
 
 from __future__ import annotations
 
 import hashlib
-import re
-from collections.abc import Callable, Mapping, Sequence
+import json
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from types import MappingProxyType
-from typing import Any, ClassVar, Final
+from typing import Any, ClassVar, Dict, Final, Optional
 
-from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
-    canonical_json_bytes,
-)
 from ipfs_accelerate_py.agent_supervisor.proof.test_execution_contracts import (
     EligibilityClass,
+    ReuseReasonCode,
+    TEST_EXECUTION_CONTRACT_VERSION,
+    TEST_EXECUTION_KEY_INTERFACE,
+    TEST_LOCATOR_KEY_INTERFACE,
+    TestExecutionContractError,
     TestExecutionKey,
     TestLocatorKey,
 )
 
-TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE: Final = "TestExecutionIdentityCompiler@1"
-CONTENT_IDENTITY_INTERFACE: Final = "ContentIdentity@1"
-_CID_RE: Final = re.compile(r"^b[a-z2-7]{20,}$")
-_DIGEST_RE: Final = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$", re.IGNORECASE)
-_MAX_NODE_ID: Final = 1024
 
+# ---------------------------------------------------------------------------
+# Schema / interface constants
+# ---------------------------------------------------------------------------
+
+CONTENT_IDENTITY_INTERFACE: Final = "ContentIdentity@1"
+TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE: Final = (
+    "TestExecutionIdentityCompiler@1"
+)
+
+CONTENT_IDENTITY_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/content-identity@1"
+)
+TEST_EXECUTION_IDENTITY_COMPILER_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-execution-identity-compiler@1"
+)
+COMPILED_LOCATOR_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/compiled-test-locator@1"
+)
+COMPILED_EXECUTION_KEY_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/compiled-test-execution-key@1"
+)
+
+# Frozen CID profile (matches multiformats_identity / plan §6.1).
+CID_VERSION: Final = 1
+CID_BASE: Final = "base32"
+CID_CODEC: Final = "dag-json"
+MH_TYPE: Final = "sha2-256"
+DIGEST_SIZE: Final = 32
+
+# Explicit non-reusable reason codes retained on artifacts (string form of enum).
+REASON_CID_PROVIDER_UNAVAILABLE: Final = (
+    ReuseReasonCode.CID_PROVIDER_UNAVAILABLE.value
+)
+REASON_NON_REUSABLE: Final = ReuseReasonCode.NON_REUSABLE.value
+REASON_MALFORMED_ARTIFACT: Final = ReuseReasonCode.MALFORMED_ARTIFACT.value
+REASON_UNSUPPORTED: Final = ReuseReasonCode.UNSUPPORTED.value
 
 class CidSupportStatus(str, Enum):
-    """Availability of real multiformat CIDv1 minting."""
+    """Cold probe result for the multiformats content-identity bridge."""
 
     AVAILABLE = "available"
     MISSING = "missing"
@@ -41,373 +85,1323 @@ class CidSupportStatus(str, Enum):
 
 
 class TestExecutionIdentityError(ValueError):
-    """Typed failure for locator/execution identity construction."""
+    """Raised when identity compilation fails hard (not a non-reusable soft path)."""
+
+    # Not a pytest test class.
+    __test__ = False
 
 
-@dataclass(frozen=True, slots=True)
-class ContentIdentity:
-    """Retained canonical preimage with a verified CIDv1 (never digest-as-CID)."""
+# ---------------------------------------------------------------------------
+# Lazy multiformats bridge access (never invent pseudo-CIDs)
+# ---------------------------------------------------------------------------
 
-    cid: str
-    canonical_bytes: bytes
-    digest: str = ""
-    profile: str = "strict-dag-json-v1"
-    interface: str = CONTENT_IDENTITY_INTERFACE
-    reason_codes: tuple[str, ...] = ()
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.canonical_bytes, (bytes, bytearray)):
-            raise TestExecutionIdentityError("canonical_bytes must be bytes")
-        object.__setattr__(self, "canonical_bytes", bytes(self.canonical_bytes))
-        cid = str(self.cid or "").strip()
-        if not cid or not _CID_RE.fullmatch(cid):
-            raise TestExecutionIdentityError("cid must be a lowercase base32 CIDv1")
-        if _DIGEST_RE.fullmatch(cid):
-            raise TestExecutionIdentityError("digest-shaped values cannot be labeled as CID")
-        object.__setattr__(self, "cid", cid)
-        if not self.digest:
-            digest = "sha256:" + hashlib.sha256(self.canonical_bytes).hexdigest()
-            object.__setattr__(self, "digest", digest)
+class _LocalContentIdentityBridge:
+    """Hermetic CIDv1/base32/dag-json/sha2-256 bridge.
 
-    def verify(self) -> None:
-        """Rehash retained bytes and require the stored CID to match."""
+    Prefer the shared formal contract encoder (same bytes as
+    ``TestLocatorKey.content_id`` / ``TestExecutionKey.content_id``).  When the
+    ``multiformats`` package is installed, CIDs are cross-checked against an
+    independent construction.  When the supervisor ``multiformats_identity``
+    module (and its ``ipfs_datasets_py.utils.cid_utils`` dependency) is
+    unavailable, this bridge still provides a full reusable profile so identity
+    compilation does not soft-fail solely because of that optional import path.
+    """
 
-        expected = mint_content_identity_bytes(self.canonical_bytes)
-        if expected.cid != self.cid:
-            raise TestExecutionIdentityError("content identity CID does not match retained bytes")
-        if expected.digest != self.digest:
+    def canonical_dag_json_bytes(
+        self, obj: Any, *, for_identity: bool = False
+    ) -> bytes:
+        del for_identity
+        return _formal_canonical_json_bytes(obj)
+
+    def require_canonical_dag_json_bytes(self, data: bytes) -> bytes:
+        if type(data) is not bytes:
             raise TestExecutionIdentityError(
-                "content identity digest does not match retained bytes"
+                "DAG-JSON identity input must be exact bytes"
             )
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise TestExecutionIdentityError("DAG-JSON bytes must be UTF-8") from exc
+        try:
+            parsed = json.loads(text, parse_constant=_reject_json_constant)
+        except json.JSONDecodeError as exc:
+            raise TestExecutionIdentityError(
+                "DAG-JSON bytes are not valid JSON"
+            ) from exc
+        expected = _formal_canonical_json_bytes(parsed)
+        if data != expected:
+            raise TestExecutionIdentityError(
+                "DAG-JSON bytes are not canonical (unsorted keys, non-compact "
+                "separators, or non-normalized form)"
+            )
+        return data
 
+    def cid_for_bytes(
+        self,
+        data: bytes,
+        *,
+        base: str = CID_BASE,
+        codec: str = "raw",
+        mh_type: str = MH_TYPE,
+        version: int = CID_VERSION,
+    ) -> str:
+        if type(data) is not bytes:
+            raise TestExecutionIdentityError("cid_for_bytes requires exact bytes")
+        if base != CID_BASE or mh_type != MH_TYPE or version != CID_VERSION:
+            raise TestExecutionIdentityError(
+                "only CIDv1/base32/sha2-256 is admitted for ContentIdentity@1"
+            )
+        if codec not in (CID_CODEC, "raw"):
+            raise TestExecutionIdentityError(
+                "only dag-json or raw codec is admitted for ContentIdentity@1"
+            )
+        return _cidv1_for_payload(data, codec=codec)
 
-def reject_pseudo_cid(value: str, *, field_name: str = "cid") -> str:
-    """Reject digest-shaped or empty strings that must never be treated as CIDs."""
-
-    text = str(value or "").strip()
-    if not text:
-        raise TestExecutionIdentityError(f"{field_name} is required")
-    if _DIGEST_RE.fullmatch(text) and not _CID_RE.fullmatch(text):
-        raise TestExecutionIdentityError(f"{field_name} is digest-shaped, not a CIDv1")
-    if not _CID_RE.fullmatch(text):
-        raise TestExecutionIdentityError(f"{field_name} is not a valid CIDv1")
-    return text
-
-
-def normalize_pytest_node_id(node_id: Any) -> str:
-    """Normalize a pytest node id for identity binding."""
-
-    text = str(node_id or "").strip()
-    if not text:
-        raise TestExecutionIdentityError("node_id is required")
-    if len(text) > _MAX_NODE_ID:
-        raise TestExecutionIdentityError("node_id exceeds bounded length")
-    # Collapse accidental double separators introduced by path joins.
-    return text.replace("\\", "/")
-
-
-def _probe_cid_support() -> CidSupportStatus:
-    try:
-        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
-
-        if not bridge.multiformats_available():
-            return CidSupportStatus.MISSING
-        # Exercise a tiny mint to detect incompatible providers.
-        identity = bridge.identify_strict_artifact({"ptr": "probe", "n": 1})
-        if not identity.cid or not _CID_RE.fullmatch(identity.cid):
-            return CidSupportStatus.INCOMPATIBLE
-        return CidSupportStatus.AVAILABLE
-    except Exception:
-        return CidSupportStatus.MISSING
-
-
-def mint_content_identity_bytes(data: bytes | bytearray | memoryview) -> ContentIdentity:
-    """Mint identity for already-canonical bytes under the strict artifact profile."""
-
-    retained = bytes(data)
-    if not retained:
-        raise TestExecutionIdentityError("canonical bytes must be nonempty")
-    try:
-        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
-
-        identity = bridge.identify_strict_artifact_bytes(retained)
-        return ContentIdentity(
-            cid=identity.cid,
-            canonical_bytes=identity.canonical_bytes,
-            digest=identity.digest,
-            profile=identity.profile,
-            reason_codes=tuple(identity.reason_codes),
+    def cid_for_dag_json(
+        self,
+        obj: Any,
+        *,
+        base: str = CID_BASE,
+        mh_type: str = MH_TYPE,
+        version: int = CID_VERSION,
+        for_identity: bool = False,
+    ) -> str:
+        del for_identity
+        if base != CID_BASE or mh_type != MH_TYPE or version != CID_VERSION:
+            raise TestExecutionIdentityError(
+                "only CIDv1/base32/sha2-256 is admitted for ContentIdentity@1"
+            )
+        encoded = self.canonical_dag_json_bytes(obj, for_identity=True)
+        return self.cid_for_bytes(
+            encoded,
+            base=base,
+            codec=CID_CODEC,
+            mh_type=mh_type,
+            version=version,
         )
-    except Exception as exc:
-        # Fail closed: never mint a digest-as-CID fallback for authority use.
+
+    def validate_cid(
+        self,
+        value: Any,
+        *,
+        codecs: Any = ("raw", "dag-json"),
+    ) -> str:
+        if not isinstance(value, str) or not value:
+            raise TestExecutionIdentityError("CID must be a nonempty lowercase string")
+        if value != value.lower():
+            raise TestExecutionIdentityError("CID must be canonical lowercase form")
+        if len(value) < 16 or not value.startswith("b"):
+            raise TestExecutionIdentityError(
+                "CID is truncated or not a CIDv1 base32 address"
+            )
+        allowed = tuple(codecs) if codecs is not None else (CID_CODEC, "raw")
+        try:
+            from multiformats import CID
+
+            parsed = CID.decode(value)
+        except ImportError:
+            # Pure structural admission: formal / multiformats-compatible base32
+            # CIDv1 strings only. Digest extraction still rehashes retained bytes
+            # at ContentIdentity construction time.
+            return value
+        except Exception as exc:
+            raise TestExecutionIdentityError("CID failed to decode") from exc
+        if parsed.version != CID_VERSION:
+            raise TestExecutionIdentityError("CID version must be 1")
+        if parsed.base.name != CID_BASE:
+            raise TestExecutionIdentityError("CID base must be base32")
+        if parsed.hashfun.name != MH_TYPE:
+            raise TestExecutionIdentityError("CID multihash must be sha2-256")
+        if len(parsed.raw_digest) != DIGEST_SIZE:
+            raise TestExecutionIdentityError("CID multihash digest size is not 32 bytes")
+        codec_name = parsed.codec.name
+        if codec_name not in allowed:
+            raise TestExecutionIdentityError(
+                "CID codec %r is not in allowed set %s" % (codec_name, allowed)
+            )
+        # Decode success under the frozen profile implies canonical form for the
+        # multiformats versions we support (lowercase base32 CIDv1).
+        return value
+
+    def digest_hex_from_cid(
+        self,
+        value: str,
+        *,
+        codecs: Any = ("raw", "dag-json"),
+    ) -> str:
+        canonical = self.validate_cid(value, codecs=codecs)
+        try:
+            from multiformats import CID
+
+            parsed = CID.decode(canonical)
+            digest = bytes(parsed.raw_digest)
+            if len(digest) != DIGEST_SIZE:
+                raise TestExecutionIdentityError(
+                    "CID multihash digest size is not 32 bytes"
+                )
+            return digest.hex()
+        except ImportError:
+            # Decode multihash from the CIDv1 binary form produced by formal
+            # content_identity: 0x01 | dag-json varint | 0x12 0x20 | digest.
+            import base64
+
+            padded = canonical[1:] + ("=" * ((8 - len(canonical[1:]) % 8) % 8))
+            try:
+                raw = base64.b32decode(padded.upper())
+            except Exception as exc:
+                raise TestExecutionIdentityError(
+                    "CID could not be base32-decoded for digest extraction"
+                ) from exc
+            # Find sha2-256 multihash header 0x12 0x20.
+            idx = raw.find(b"\x12\x20")
+            if idx < 0 or idx + 2 + DIGEST_SIZE > len(raw):
+                raise TestExecutionIdentityError(
+                    "CID does not carry a sha2-256 multihash digest"
+                )
+            return raw[idx + 2 : idx + 2 + DIGEST_SIZE].hex()
+
+
+def _formal_canonical_json_bytes(value: Any) -> bytes:
+    """Encode with the shared formal DAG-JSON profile (fail-closed)."""
+
+    try:
+        from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+            canonical_json_bytes as formal_canonical_json_bytes,
+        )
+    except ImportError as exc:  # pragma: no cover - in-tree dependency
         raise TestExecutionIdentityError(
-            f"CID mint unavailable: {type(exc).__name__}"
+            "formal verification contracts unavailable for canonicalization"
+        ) from exc
+    try:
+        return formal_canonical_json_bytes(value)
+    except Exception as exc:
+        raise TestExecutionIdentityError(
+            "failed to canonicalize structured value: %s" % exc
         ) from exc
 
 
-def mint_content_identity(value: Any) -> ContentIdentity:
-    """Mint a retained ContentIdentity for a DAG-JSON-compatible value."""
+def _cidv1_for_payload(payload: bytes, *, codec: str) -> str:
+    """Mint CIDv1/base32 for exact payload bytes under ``codec``."""
+
+    # Prefer independent multiformats construction when the package is present.
+    try:
+        from multiformats import CID, multihash
+
+        return str(
+            CID(CID_BASE, CID_VERSION, codec, multihash.digest(payload, MH_TYPE))
+        )
+    except ImportError:
+        pass
+
+    # Pure formal construction (matches formal_verification_contracts.content_identity).
+    import base64
+
+    digest = hashlib.sha256(payload).digest()
+    if codec == CID_CODEC:
+        # CIDv1 + dag-json (0x0129 varint as 0xa9 0x02) + sha2-256 multihash.
+        raw = b"\x01\xa9\x02\x12\x20" + digest
+    elif codec == "raw":
+        # CIDv1 + raw (0x55) + sha2-256 multihash.
+        raw = b"\x01\x55\x12\x20" + digest
+    else:
+        raise TestExecutionIdentityError(
+            "unsupported codec for local CID minting: %s" % codec
+        )
+    return "b" + base64.b32encode(raw).decode("ascii").rstrip("=").lower()
+
+
+_LOCAL_BRIDGE: Final = _LocalContentIdentityBridge()
+
+
+def _import_multiformats_bridge() -> Any:
+    """Return a CID identity bridge (supervisor module or hermetic local fallback).
+
+    The supervisor ``multiformats_identity`` module depends on
+    ``ipfs_datasets_py.utils.cid_utils``.  Under some validation PYTHONPATH
+    orderings an empty ``ipfs_datasets_py`` namespace can shadow that package and
+    break imports.  Fall back to the hermetic local bridge so ContentIdentity
+    remains usable without inventing pseudo-CIDs.
+    """
 
     try:
-        from ipfs_accelerate_py.agent_supervisor.analysis import content_identity_bridge as bridge
+        from ipfs_accelerate_py.agent_supervisor import multiformats_identity as bridge
 
-        identity = bridge.identify_strict_artifact(value)
-        return ContentIdentity(
-            cid=identity.cid,
-            canonical_bytes=identity.canonical_bytes,
-            digest=identity.digest,
-            profile=identity.profile,
-            reason_codes=tuple(identity.reason_codes),
-        )
+        # Cold probe: ensure the module is not only importable but also able to
+        # mint under the frozen profile (cid_utils may be broken after import).
+        bridge.cid_for_dag_json({}, for_identity=True)
+        return bridge
     except Exception:
-        # Prefer bridge; if unavailable attempt only when multiformats/datasets
-        # path failed for non-import reasons after canonicalization.
+        return _LOCAL_BRIDGE
+
+
+def probe_cid_support(
+    *,
+    bridge_import: Optional[Callable[[], Any]] = None,
+) -> CidSupportStatus:
+    """Probe whether strict CIDv1/base32/dag-json/sha2-256 minting is available.
+
+    Cold, deterministic, and free of network or cache side effects. Distinguishes
+    missing imports from incompatible probe results without installing packages
+    or starting daemons.
+    """
+
+    importer = bridge_import or _import_multiformats_bridge
+    try:
+        bridge = importer()
+    except ImportError:
+        return CidSupportStatus.MISSING
+    except Exception:
+        return CidSupportStatus.UNKNOWN
+
+    try:
+        # Minimal known vector: empty object under the frozen profile.
+        encoded = bridge.canonical_dag_json_bytes({}, for_identity=True)
+        cid = bridge.cid_for_dag_json({}, for_identity=True)
+        validated = bridge.validate_cid(cid, codecs=("dag-json",))
+        if validated != cid:
+            return CidSupportStatus.INCOMPATIBLE
+        digest = bridge.digest_hex_from_cid(cid, codecs=("dag-json",))
+        if len(digest) != DIGEST_SIZE * 2:
+            return CidSupportStatus.INCOMPATIBLE
+        if hashlib.sha256(encoded).hexdigest() != digest:
+            return CidSupportStatus.INCOMPATIBLE
+        # Independent multiformats library check when present.
         try:
-            retained = canonical_json_bytes(value)
-            return mint_content_identity_bytes(retained)
-        except TestExecutionIdentityError:
-            raise
-        except Exception as exc:
-            raise TestExecutionIdentityError(
-                f"content identity mint failed: {type(exc).__name__}"
-            ) from exc
+            from multiformats import CID, multihash
+
+            independent = str(
+                CID(CID_BASE, CID_VERSION, CID_CODEC, multihash.digest(encoded, MH_TYPE))
+            )
+            if independent != cid:
+                return CidSupportStatus.INCOMPATIBLE
+        except ImportError:
+            # Bridge itself may still work via formal / local construction; treat
+            # as available if the bridge probe passed. Cross-package vectors are
+            # PTR-012.
+            pass
+        return CidSupportStatus.AVAILABLE
+    except Exception:
+        return CidSupportStatus.INCOMPATIBLE
 
 
-@dataclass(frozen=True, slots=True)
-class LocatorCompileResult:
-    """Result of :meth:`TestExecutionIdentityCompiler.compile_locator`."""
+def cid_support_available(
+    *,
+    bridge_import: Optional[Callable[[], Any]] = None,
+) -> bool:
+    """Return True only when the frozen CID profile can mint and verify."""
 
-    reusable: bool
-    locator: TestLocatorKey | None = None
-    locator_cid: str = ""
-    reason_code: str = ""
-    content_identity: ContentIdentity | None = None
-
-    @property
-    def interface(self) -> str:
-        return TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+    return probe_cid_support(bridge_import=bridge_import) is CidSupportStatus.AVAILABLE
 
 
-@dataclass(frozen=True, slots=True)
-class ExecutionKeyCompileResult:
-    """Result of :meth:`TestExecutionIdentityCompiler.compile_execution_key`."""
+def reject_pseudo_cid(value: str, *, field_name: str = "cid") -> str:
+    """Reject obvious non-profile identifiers that must not be labeled as CIDs.
 
-    reusable: bool
-    execution_key: TestExecutionKey | None = None
-    execution_key_cid: str = ""
-    reason_code: str = ""
-    content_identity: ContentIdentity | None = None
+    Real CIDv1 base32 values are validated through the multiformats bridge
+    separately. This helper only blocks known pseudo / kit forms before any
+    authority boundary labels them as CIDs.
+    """
 
-    @property
-    def interface(self) -> str:
-        return TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+    if not isinstance(value, str) or not value.strip():
+        raise TestExecutionIdentityError("%s must be a nonempty string" % field_name)
+    text = value.strip()
+    # Admitted profile CIDs are lowercase base32 CIDv1 starting with "b" and
+    # long enough to carry version/codec/multihash. Everything else is rejected
+    # when callers insist on a "CID" field for retained identities.
+    if (
+        text.startswith("cid:")
+        or text.startswith("sha256:")
+        or text.startswith("runtime-artifact:")
+        or text.startswith("CID:")
+        or text.startswith("SHA256:")
+    ):
+        raise TestExecutionIdentityError(
+            "%s must not use a pseudo-hash or kit identity label" % field_name
+        )
+    if text.startswith("Qm") or text.startswith("qm"):
+        raise TestExecutionIdentityError(
+            "%s rejects CIDv0 / base58 pseudo forms" % field_name
+        )
+    if text != text.lower():
+        raise TestExecutionIdentityError(
+            "%s must be canonical lowercase CIDv1 base32" % field_name
+        )
+    if len(text) < 16 or not text.startswith("b"):
+        raise TestExecutionIdentityError(
+            "%s is truncated or not a CIDv1 base32 address" % field_name
+        )
+    return text
 
 
-class TestExecutionIdentityCompiler:
-    """Compile exact locator and execution-key artifacts for one pytest item."""
+# ---------------------------------------------------------------------------
+# ContentIdentity@1
+# ---------------------------------------------------------------------------
 
+
+@dataclass(frozen=True)
+class ContentIdentity:
+    """Retained canonical bytes bound to a verified CIDv1 under the frozen profile.
+
+    Construction is closed: use :func:`mint_content_identity` or
+    :func:`content_identity_from_retained_bytes`.  Callers never supply a CID
+    string without the matching retained bytes.
+    """
+
+    # Not a pytest test class.
     __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
 
-    def __init__(
+    SCHEMA: ClassVar[str] = CONTENT_IDENTITY_SCHEMA
+
+    cid: str
+    digest_hex: str
+    canonical_bytes: bytes
+    codec: str = CID_CODEC
+    version: int = CID_VERSION
+    base: str = CID_BASE
+    mh_type: str = MH_TYPE
+    profile: str = CONTENT_IDENTITY_INTERFACE
+
+    def __post_init__(self) -> None:
+        if type(self.canonical_bytes) is not bytes:
+            raise TestExecutionIdentityError(
+                "canonical_bytes must be exact bytes (not str or memoryview)"
+            )
+        if not self.canonical_bytes:
+            raise TestExecutionIdentityError("canonical_bytes must be nonempty")
+        if self.codec != CID_CODEC:
+            raise TestExecutionIdentityError(
+                "only dag-json codec is admitted for ContentIdentity@1"
+            )
+        if self.version != CID_VERSION or self.base != CID_BASE or self.mh_type != MH_TYPE:
+            raise TestExecutionIdentityError(
+                "only CIDv1/base32/sha2-256 is admitted for ContentIdentity@1"
+            )
+        if self.profile != CONTENT_IDENTITY_INTERFACE:
+            raise TestExecutionIdentityError(
+                "content identity profile must be ContentIdentity@1"
+            )
+        if not isinstance(self.cid, str) or not self.cid:
+            raise TestExecutionIdentityError("cid is required")
+        if not isinstance(self.digest_hex, str) or len(self.digest_hex) != DIGEST_SIZE * 2:
+            raise TestExecutionIdentityError(
+                "digest_hex must be 64 lowercase hex characters"
+            )
+        if self.digest_hex != self.digest_hex.lower() or any(
+            ch not in "0123456789abcdef" for ch in self.digest_hex
+        ):
+            raise TestExecutionIdentityError(
+                "digest_hex must be lowercase hex"
+            )
+        # Structural self-check against retained bytes (hash only; full CID
+        # validation is performed at mint time).
+        actual = hashlib.sha256(self.canonical_bytes).hexdigest()
+        if actual != self.digest_hex:
+            raise TestExecutionIdentityError(
+                "digest_hex does not match sha2-256 of retained canonical bytes"
+            )
+
+    @property
+    def interface(self) -> str:
+        return CONTENT_IDENTITY_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return self.SCHEMA
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Public projection (does not re-embed full retained bytes by default)."""
+
+        return {
+            "schema": self.SCHEMA,
+            "interface": CONTENT_IDENTITY_INTERFACE,
+            "profile": self.profile,
+            "cid": self.cid,
+            "digest_hex": self.digest_hex,
+            "codec": self.codec,
+            "version": self.version,
+            "base": self.base,
+            "mh_type": self.mh_type,
+            "byte_length": len(self.canonical_bytes),
+        }
+
+    def rehash_cid(
         self,
         *,
-        cid_probe: Callable[[], CidSupportStatus] | None = None,
-    ) -> None:
-        self._cid_probe = cid_probe or _probe_cid_support
+        bridge_import: Optional[Callable[[], Any]] = None,
+    ) -> str:
+        """Recompute the CIDv1 from retained bytes; must equal ``self.cid``."""
 
-    def cid_support(self) -> CidSupportStatus:
+        importer = bridge_import or _import_multiformats_bridge
+        bridge = importer()
+        recomputed = bridge.cid_for_bytes(
+            self.canonical_bytes,
+            base=self.base,
+            codec=self.codec,
+            mh_type=self.mh_type,
+            version=self.version,
+        )
+        if recomputed != self.cid:
+            raise TestExecutionIdentityError(
+                "retained canonical bytes rehash to a different CID"
+            )
+        return recomputed
+
+    def verify(
+        self,
+        *,
+        bridge_import: Optional[Callable[[], Any]] = None,
+    ) -> "ContentIdentity":
+        """Decode retained bytes, validate the CID, and confirm multihash match."""
+
+        importer = bridge_import or _import_multiformats_bridge
+        bridge = importer()
+        # Canonical form of retained bytes (sorted keys, compact separators).
+        bridge.require_canonical_dag_json_bytes(self.canonical_bytes)
+        validated = bridge.validate_cid(self.cid, codecs=(self.codec,))
+        if validated != self.cid:
+            raise TestExecutionIdentityError("CID is not the validated canonical form")
+        digest = bridge.digest_hex_from_cid(self.cid, codecs=(self.codec,))
+        if digest != self.digest_hex:
+            raise TestExecutionIdentityError(
+                "CID multihash digest does not match retained digest_hex"
+            )
+        actual = hashlib.sha256(self.canonical_bytes).hexdigest()
+        if actual != digest:
+            raise TestExecutionIdentityError(
+                "CID multihash digest does not match sha2-256 of retained bytes"
+            )
+        # Round-trip JSON decode → re-encode must preserve exact bytes.
         try:
-            status = self._cid_probe()
-        except Exception:
-            return CidSupportStatus.UNKNOWN
-        if isinstance(status, CidSupportStatus):
-            return status
+            parsed = json.loads(
+                self.canonical_bytes.decode("utf-8"),
+                parse_constant=_reject_json_constant,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TestExecutionIdentityError(
+                "retained canonical bytes are not valid UTF-8 JSON"
+            ) from exc
+        reencoded = bridge.canonical_dag_json_bytes(parsed, for_identity=True)
+        if reencoded != self.canonical_bytes:
+            raise TestExecutionIdentityError(
+                "retained canonical bytes do not re-encode identically"
+            )
+        self.rehash_cid(bridge_import=importer)
+        return self
+
+
+def _reject_json_constant(name: str) -> None:
+    raise TestExecutionIdentityError(
+        "JSON constant %r is not allowed in retained DAG-JSON identity material"
+        % name
+    )
+
+
+def _structured_canonical_bytes(value: Any) -> bytes:
+    """Encode a structured value to the shared formal DAG-JSON profile.
+
+    ``str`` Enum members (used by PTR contracts) survive ``json.dumps`` but are
+    rejected by the multiformats bridge's pre-validation.  Routing through the
+    formal encoder first yields exact bytes that both ``content_identity`` and
+    multiformats agree on, without labeling any fallback digest as a CID.
+    """
+
+    # CanonicalContract (and siblings) already expose profile-stable bytes.
+    canonical_bytes_fn = getattr(value, "canonical_bytes", None)
+    if callable(canonical_bytes_fn) and not isinstance(value, (dict, list, tuple)):
         try:
-            return CidSupportStatus(str(status))
-        except Exception:
-            return CidSupportStatus.UNKNOWN
+            encoded = canonical_bytes_fn()
+        except Exception as exc:
+            raise TestExecutionIdentityError(
+                "contract canonical_bytes failed: %s" % exc
+            ) from exc
+        if type(encoded) is not bytes or not encoded:
+            raise TestExecutionIdentityError(
+                "contract canonical_bytes must return nonempty bytes"
+            )
+        return encoded
+
+    try:
+        from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+            canonical_json_bytes as formal_canonical_json_bytes,
+        )
+    except ImportError as exc:  # pragma: no cover - in-tree dependency
+        raise TestExecutionIdentityError(
+            "formal verification contracts unavailable for canonicalization"
+        ) from exc
+
+    try:
+        return formal_canonical_json_bytes(value)
+    except Exception as exc:
+        raise TestExecutionIdentityError(
+            "failed to canonicalize structured value: %s" % exc
+        ) from exc
+
+
+def mint_content_identity(
+    value: Any,
+    *,
+    bridge_import: Optional[Callable[[], Any]] = None,
+    for_identity: bool = True,
+) -> ContentIdentity:
+    """Mint a :class:`ContentIdentity` for a structured DAG-JSON value.
+
+    Uses the supervisor multiformats bridge (``cid_utils`` + independent
+    multiformats checks). Never falls back to a pseudo-hash labeled as a CID.
+    """
+
+    del for_identity  # retained for API stability; formal profile is always used
+    importer = bridge_import or _import_multiformats_bridge
+    try:
+        bridge = importer()
+    except ImportError as exc:
+        raise TestExecutionIdentityError(
+            "multiformats content-identity bridge is unavailable"
+        ) from exc
+
+    try:
+        encoded = _structured_canonical_bytes(value)
+        # Multiformats path: require exact canonical form, then mint raw-on-bytes
+        # as dag-json (same as cid_for_dag_json on the decoded object).
+        required = bridge.require_canonical_dag_json_bytes(encoded)
+        cid = bridge.cid_for_bytes(
+            required,
+            base=CID_BASE,
+            codec=CID_CODEC,
+            mh_type=MH_TYPE,
+            version=CID_VERSION,
+        )
+        validated = bridge.validate_cid(cid, codecs=(CID_CODEC,))
+        digest = bridge.digest_hex_from_cid(validated, codecs=(CID_CODEC,))
+    except TestExecutionIdentityError:
+        raise
+    except Exception as exc:
+        raise TestExecutionIdentityError(
+            "failed to mint ContentIdentity@1: %s" % exc
+        ) from exc
+
+    identity = ContentIdentity(
+        cid=validated,
+        digest_hex=digest,
+        canonical_bytes=required,
+    )
+    return identity.verify(bridge_import=importer)
+
+
+def content_identity_from_retained_bytes(
+    canonical_bytes: bytes,
+    *,
+    claimed_cid: str | None = None,
+    bridge_import: Optional[Callable[[], Any]] = None,
+) -> ContentIdentity:
+    """Rebuild and verify a content identity from retained canonical bytes."""
+
+    if type(canonical_bytes) is not bytes:
+        raise TestExecutionIdentityError(
+            "canonical_bytes must be exact bytes"
+        )
+    importer = bridge_import or _import_multiformats_bridge
+    try:
+        bridge = importer()
+    except ImportError as exc:
+        raise TestExecutionIdentityError(
+            "multiformats content-identity bridge is unavailable"
+        ) from exc
+
+    try:
+        required = bridge.require_canonical_dag_json_bytes(canonical_bytes)
+        cid = bridge.cid_for_bytes(
+            required,
+            base=CID_BASE,
+            codec=CID_CODEC,
+            mh_type=MH_TYPE,
+            version=CID_VERSION,
+        )
+        digest = bridge.digest_hex_from_cid(cid, codecs=(CID_CODEC,))
+    except TestExecutionIdentityError:
+        raise
+    except Exception as exc:
+        raise TestExecutionIdentityError(
+            "failed to rehash retained bytes: %s" % exc
+        ) from exc
+
+    if claimed_cid is not None and claimed_cid != cid:
+        raise TestExecutionIdentityError(
+            "claimed CID does not match rehash of retained canonical bytes"
+        )
+
+    identity = ContentIdentity(
+        cid=cid,
+        digest_hex=digest,
+        canonical_bytes=required,
+    )
+    return identity.verify(bridge_import=importer)
+
+
+# ---------------------------------------------------------------------------
+# Compiled artifacts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompiledTestLocator:
+    """Result of compiling a test locator into a content-addressed artifact."""
+
+    # Not a pytest test class.
+    __test__: ClassVar[bool] = False
+    SCHEMA: ClassVar[str] = COMPILED_LOCATOR_SCHEMA
+
+    reusable: bool
+    reason_code: str
+    non_reusable_reason: str = ""
+    locator: Optional[TestLocatorKey] = None
+    content_identity: Optional[ContentIdentity] = None
+    locator_cid: str = ""
+    cid_support: CidSupportStatus = CidSupportStatus.AVAILABLE
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reusable", bool(self.reusable))
+        reason = str(self.reason_code or "").strip()
+        if not self.reusable and not reason:
+            reason = REASON_NON_REUSABLE
+        object.__setattr__(self, "reason_code", reason)
+        object.__setattr__(
+            self,
+            "non_reusable_reason",
+            str(self.non_reusable_reason or "").strip(),
+        )
+        object.__setattr__(
+            self,
+            "locator_cid",
+            str(self.locator_cid or "").strip(),
+        )
+        if not isinstance(self.cid_support, CidSupportStatus):
+            object.__setattr__(
+                self,
+                "cid_support",
+                CidSupportStatus(str(self.cid_support)),
+            )
+        object.__setattr__(
+            self,
+            "diagnostics",
+            dict(self.diagnostics or {}),
+        )
+        if self.reusable:
+            if self.content_identity is None or not self.locator_cid:
+                raise TestExecutionIdentityError(
+                    "reusable compiled locator requires content_identity and locator_cid"
+                )
+            if self.locator is None:
+                raise TestExecutionIdentityError(
+                    "reusable compiled locator requires the TestLocatorKey payload"
+                )
+            if self.locator_cid != self.content_identity.cid:
+                raise TestExecutionIdentityError(
+                    "locator_cid must equal content_identity.cid"
+                )
+            if self.non_reusable_reason:
+                raise TestExecutionIdentityError(
+                    "reusable compiled locator cannot carry non_reusable_reason"
+                )
+        else:
+            # Non-reusable soft path: never invent a CID. Empty locator_cid is
+            # allowed; a retained identity may still be present for diagnostics
+            # when the payload itself was well-formed but policy-marked
+            # non-reusable (parameter serialization failure, etc.).
+            if self.locator_cid and self.content_identity is not None:
+                if self.locator_cid != self.content_identity.cid:
+                    raise TestExecutionIdentityError(
+                        "locator_cid must equal content_identity.cid when both set"
+                    )
+
+    @property
+    def interface(self) -> str:
+        return TEST_LOCATOR_KEY_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return self.SCHEMA
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": self.SCHEMA,
+            "contract_version": TEST_EXECUTION_CONTRACT_VERSION,
+            "interface": TEST_LOCATOR_KEY_INTERFACE,
+            "reusable": self.reusable,
+            "reason_code": self.reason_code,
+            "non_reusable_reason": self.non_reusable_reason,
+            "locator_cid": self.locator_cid,
+            "cid_support": self.cid_support.value,
+            "content_identity": (
+                self.content_identity.to_dict()
+                if self.content_identity is not None
+                else None
+            ),
+            "locator": self.locator.to_dict() if self.locator is not None else None,
+            "diagnostics": dict(self.diagnostics),
+        }
+
+
+@dataclass(frozen=True)
+class CompiledTestExecutionKey:
+    """Result of compiling a test execution key into a content-addressed artifact."""
+
+    # Not a pytest test class.
+    __test__: ClassVar[bool] = False
+    SCHEMA: ClassVar[str] = COMPILED_EXECUTION_KEY_SCHEMA
+
+    reusable: bool
+    reason_code: str
+    non_reusable_reason: str = ""
+    execution_key: Optional[TestExecutionKey] = None
+    content_identity: Optional[ContentIdentity] = None
+    execution_cid: str = ""
+    locator_cid: str = ""
+    cid_support: CidSupportStatus = CidSupportStatus.AVAILABLE
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reusable", bool(self.reusable))
+        reason = str(self.reason_code or "").strip()
+        if not self.reusable and not reason:
+            reason = REASON_NON_REUSABLE
+        object.__setattr__(self, "reason_code", reason)
+        object.__setattr__(
+            self,
+            "non_reusable_reason",
+            str(self.non_reusable_reason or "").strip(),
+        )
+        object.__setattr__(
+            self, "execution_cid", str(self.execution_cid or "").strip()
+        )
+        object.__setattr__(
+            self, "locator_cid", str(self.locator_cid or "").strip()
+        )
+        if not isinstance(self.cid_support, CidSupportStatus):
+            object.__setattr__(
+                self,
+                "cid_support",
+                CidSupportStatus(str(self.cid_support)),
+            )
+        object.__setattr__(
+            self,
+            "diagnostics",
+            dict(self.diagnostics or {}),
+        )
+        if self.reusable:
+            if self.content_identity is None or not self.execution_cid:
+                raise TestExecutionIdentityError(
+                    "reusable compiled execution key requires content_identity "
+                    "and execution_cid"
+                )
+            if self.execution_key is None:
+                raise TestExecutionIdentityError(
+                    "reusable compiled execution key requires the TestExecutionKey"
+                )
+            if self.execution_cid != self.content_identity.cid:
+                raise TestExecutionIdentityError(
+                    "execution_cid must equal content_identity.cid"
+                )
+            if self.non_reusable_reason:
+                raise TestExecutionIdentityError(
+                    "reusable compiled execution key cannot carry non_reusable_reason"
+                )
+        else:
+            if self.execution_cid and self.content_identity is not None:
+                if self.execution_cid != self.content_identity.cid:
+                    raise TestExecutionIdentityError(
+                        "execution_cid must equal content_identity.cid when both set"
+                    )
+
+    @property
+    def interface(self) -> str:
+        return TEST_EXECUTION_KEY_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return self.SCHEMA
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": self.SCHEMA,
+            "contract_version": TEST_EXECUTION_CONTRACT_VERSION,
+            "interface": TEST_EXECUTION_KEY_INTERFACE,
+            "reusable": self.reusable,
+            "reason_code": self.reason_code,
+            "non_reusable_reason": self.non_reusable_reason,
+            "execution_cid": self.execution_cid,
+            "locator_cid": self.locator_cid,
+            "cid_support": self.cid_support.value,
+            "content_identity": (
+                self.content_identity.to_dict()
+                if self.content_identity is not None
+                else None
+            ),
+            "execution_key": (
+                self.execution_key.to_dict()
+                if self.execution_key is not None
+                else None
+            ),
+            "diagnostics": dict(self.diagnostics),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_pytest_node_id(node_id: str) -> str:
+    """Normalize a pytest node ID for stable locator binding.
+
+    Collapses redundant separators, uses POSIX-style path separators, and
+    strips surrounding whitespace. Does not reinterpret parameterization.
+    """
+
+    if not isinstance(node_id, str):
+        raise TestExecutionIdentityError("node_id must be a string")
+    text = node_id.strip().replace("\\", "/")
+    while "//" in text:
+        text = text.replace("//", "/")
+    if not text:
+        raise TestExecutionIdentityError("node_id is required")
+    return text
+
+
+def _non_reusable_locator(
+    *,
+    reason_code: str,
+    non_reusable_reason: str,
+    cid_support: CidSupportStatus,
+    locator: Optional[TestLocatorKey] = None,
+    content_identity: Optional[ContentIdentity] = None,
+    diagnostics: Optional[Mapping[str, Any]] = None,
+) -> CompiledTestLocator:
+    locator_cid = content_identity.cid if content_identity is not None else ""
+    return CompiledTestLocator(
+        reusable=False,
+        reason_code=reason_code,
+        non_reusable_reason=non_reusable_reason,
+        locator=locator,
+        content_identity=content_identity,
+        locator_cid=locator_cid,
+        cid_support=cid_support,
+        diagnostics=dict(diagnostics or {}),
+    )
+
+
+def _non_reusable_execution(
+    *,
+    reason_code: str,
+    non_reusable_reason: str,
+    cid_support: CidSupportStatus,
+    execution_key: Optional[TestExecutionKey] = None,
+    content_identity: Optional[ContentIdentity] = None,
+    locator_cid: str = "",
+    diagnostics: Optional[Mapping[str, Any]] = None,
+) -> CompiledTestExecutionKey:
+    execution_cid = content_identity.cid if content_identity is not None else ""
+    return CompiledTestExecutionKey(
+        reusable=False,
+        reason_code=reason_code,
+        non_reusable_reason=non_reusable_reason,
+        execution_key=execution_key,
+        content_identity=content_identity,
+        execution_cid=execution_cid,
+        locator_cid=locator_cid,
+        cid_support=cid_support,
+        diagnostics=dict(diagnostics or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TestExecutionIdentityCompiler:
+    """Compile locator and execution keys under the frozen ContentIdentity profile.
+
+    Injectable ``bridge_import`` and ``cid_probe`` support hermetic tests of the
+    missing-CID non-reusable path without mutating global imports.
+    """
+
+    # Not a pytest test class.
+    __test__: ClassVar[bool] = False
+
+    SCHEMA: ClassVar[str] = TEST_EXECUTION_IDENTITY_COMPILER_SCHEMA
+
+    bridge_import: Optional[Callable[[], Any]] = None
+    cid_probe: Optional[Callable[[], CidSupportStatus]] = None
+
+    @property
+    def interface(self) -> str:
+        return TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return self.SCHEMA
+
+    def probe(self) -> CidSupportStatus:
+        if self.cid_probe is not None:
+            status = self.cid_probe()
+            return status if isinstance(status, CidSupportStatus) else CidSupportStatus(status)
+        return probe_cid_support(bridge_import=self.bridge_import)
 
     def compile_locator(
         self,
-        *,
-        repository_id: str,
-        package_identity: str,
-        node_id: str,
-        collection_schema_version: str = "1",
-        parameter_id: str = "",
-        parameter_values_cid: str = "",
-        non_reusable_reason: str = "",
-        selection_semantics: str = "exact_node",
-        root_identity: str = "",
-        metadata: Mapping[str, Any] | None = None,
-        **_extra: Any,
-    ) -> LocatorCompileResult:
-        """Compile a stable :class:`TestLocatorKey` identity."""
+        locator: TestLocatorKey | Mapping[str, Any] | None = None,
+        /,
+        **fields: Any,
+    ) -> CompiledTestLocator:
+        """Compile a :class:`TestLocatorKey` into a content-addressed locator."""
 
-        if self.cid_support() is not CidSupportStatus.AVAILABLE:
-            return LocatorCompileResult(
-                reusable=False,
-                reason_code="cid_support_unavailable",
+        status = self.probe()
+        if status is not CidSupportStatus.AVAILABLE:
+            return _non_reusable_locator(
+                reason_code=REASON_CID_PROVIDER_UNAVAILABLE,
+                non_reusable_reason="cid_provider_unavailable:%s" % status.value,
+                cid_support=status,
+                diagnostics={"cid_support": status.value},
             )
+
         try:
-            locator = TestLocatorKey(
-                repository_id=str(repository_id or ""),
-                package_identity=str(package_identity or ""),
-                root_identity=str(root_identity or package_identity or ""),
-                node_id=normalize_pytest_node_id(node_id),
-                collection_schema_version=str(collection_schema_version or "1"),
-                parameter_id=str(parameter_id or ""),
-                parameter_values_cid=str(parameter_values_cid or ""),
-                non_reusable_reason=str(non_reusable_reason or ""),
-                selection_semantics=str(selection_semantics or "exact_node"),
-                metadata=dict(metadata or {}),
+            key = self._coerce_locator(locator, fields)
+        except (TestExecutionContractError, TestExecutionIdentityError, TypeError, ValueError) as exc:
+            return _non_reusable_locator(
+                reason_code=REASON_MALFORMED_ARTIFACT,
+                non_reusable_reason="malformed_locator:%s" % _bounded_reason(exc),
+                cid_support=status,
+                diagnostics={"error": _bounded_reason(exc)},
             )
-            identity = mint_content_identity(locator.to_dict())
-        except Exception as exc:
-            return LocatorCompileResult(
+
+        # Explicit parameter non-reusability is part of the locator payload and
+        # remains content-addressed for index lookup, but marks non-reusable.
+        try:
+            # Prefer contract.canonical_bytes so str-Enum fields match content_id.
+            identity = mint_content_identity(
+                key,
+                bridge_import=self.bridge_import,
+            )
+        except TestExecutionIdentityError as exc:
+            return _non_reusable_locator(
+                reason_code=REASON_CID_PROVIDER_UNAVAILABLE,
+                non_reusable_reason="cid_mint_failed:%s" % _bounded_reason(exc),
+                cid_support=status,
+                locator=key,
+                diagnostics={"error": _bounded_reason(exc)},
+            )
+
+        # Cross-check formal contract content_id (same DAG-JSON profile).
+        if key.content_id != identity.cid:
+            return _non_reusable_locator(
+                reason_code=REASON_MALFORMED_ARTIFACT,
+                non_reusable_reason="locator_content_id_drift",
+                cid_support=status,
+                locator=key,
+                content_identity=identity,
+                diagnostics={
+                    "contract_content_id": key.content_id,
+                    "multiformats_cid": identity.cid,
+                },
+            )
+
+        if key.non_reusable_reason:
+            return CompiledTestLocator(
                 reusable=False,
-                reason_code=f"locator_compile_failed:{type(exc).__name__}"[:96],
+                reason_code=REASON_NON_REUSABLE,
+                non_reusable_reason=key.non_reusable_reason,
+                locator=key,
+                content_identity=identity,
+                locator_cid=identity.cid,
+                cid_support=status,
+                diagnostics={"parameter_non_reusable": True},
             )
-        return LocatorCompileResult(
+
+        return CompiledTestLocator(
             reusable=True,
-            locator=locator,
-            locator_cid=identity.cid,
+            reason_code="",
+            non_reusable_reason="",
+            locator=key,
             content_identity=identity,
+            locator_cid=identity.cid,
+            cid_support=status,
+            diagnostics={},
         )
 
     def compile_execution_key(
         self,
-        *,
-        locator_cid: str,
-        repository_forest_cid: str,
-        git_commit_id: str = "",
-        git_tree_id: str = "",
-        gitlink_state_cid: str = "",
-        dirty_overlay_cid: str = "",
-        test_module_cid: str = "",
-        test_class_cid: str = "",
-        test_function_cid: str = "",
-        decorator_cids: Sequence[str] = (),
-        parameter_source_cid: str = "",
-        test_ast_cid: str = "",
-        fixture_cids: Sequence[str] = (),
-        conftest_closure_cid: str = "",
-        hook_plugin_cids: Sequence[str] = (),
-        static_trace_root_cid: str = "",
-        static_unknown_frontier: Sequence[str] = (),
-        runtime_trace_root_cid: str = "",
-        runtime_completeness_policy: str = "",
-        pytest_version: str = "",
-        python_version: str = "",
-        plugin_versions_cid: str = "",
-        command_semantics_cid: str = "",
-        config_cid: str = "",
-        markers: Sequence[str] = (),
-        dependency_lock_cid: str = "",
-        installed_distributions_cid: str = "",
-        environment_cid: str = "",
-        platform_cid: str = "",
-        interpreter_abi_cid: str = "",
-        hardware_capability_cid: str = "",
-        external_snapshot_cids: Sequence[str] = (),
-        policy_cid: str = "",
-        canonicalization_schema_cid: str = "",
-        tracer_schema_cid: str = "",
-        certificate_schema_cid: str = "",
-        eligibility_class: EligibilityClass | str = EligibilityClass.REPOSITORY_FOREST_BOUND,
-        components: Mapping[str, str] | None = None,
-        metadata: Mapping[str, Any] | None = None,
-        **_extra: Any,
-    ) -> ExecutionKeyCompileResult:
-        """Compile a strict :class:`TestExecutionKey` identity."""
+        execution_key: TestExecutionKey | Mapping[str, Any] | None = None,
+        /,
+        **fields: Any,
+    ) -> CompiledTestExecutionKey:
+        """Compile a :class:`TestExecutionKey` into a content-addressed execution CID."""
 
-        if self.cid_support() is not CidSupportStatus.AVAILABLE:
-            return ExecutionKeyCompileResult(
-                reusable=False,
-                reason_code="cid_support_unavailable",
+        status = self.probe()
+        if status is not CidSupportStatus.AVAILABLE:
+            return _non_reusable_execution(
+                reason_code=REASON_CID_PROVIDER_UNAVAILABLE,
+                non_reusable_reason="cid_provider_unavailable:%s" % status.value,
+                cid_support=status,
+                diagnostics={"cid_support": status.value},
             )
+
         try:
-            reject_pseudo_cid(locator_cid, field_name="locator_cid")
-            reject_pseudo_cid(repository_forest_cid, field_name="repository_forest_cid")
-            if isinstance(eligibility_class, str):
-                eligibility = EligibilityClass(eligibility_class)
-            else:
-                eligibility = eligibility_class
-            execution_key = TestExecutionKey(
-                locator_cid=locator_cid,
-                repository_forest_cid=repository_forest_cid,
-                git_commit_id=str(git_commit_id or ""),
-                git_tree_id=str(git_tree_id or ""),
-                gitlink_state_cid=str(gitlink_state_cid or ""),
-                dirty_overlay_cid=str(dirty_overlay_cid or ""),
-                test_module_cid=str(test_module_cid or ""),
-                test_class_cid=str(test_class_cid or ""),
-                test_function_cid=str(test_function_cid or ""),
-                decorator_cids=tuple(str(item) for item in decorator_cids or ()),
-                parameter_source_cid=str(parameter_source_cid or ""),
-                test_ast_cid=str(test_ast_cid or ""),
-                fixture_cids=tuple(str(item) for item in fixture_cids or ()),
-                conftest_closure_cid=str(conftest_closure_cid or ""),
-                hook_plugin_cids=tuple(str(item) for item in hook_plugin_cids or ()),
-                static_trace_root_cid=str(static_trace_root_cid or ""),
-                static_unknown_frontier=tuple(
-                    str(item) for item in static_unknown_frontier or ()
-                ),
-                runtime_trace_root_cid=str(runtime_trace_root_cid or ""),
-                runtime_completeness_policy=str(runtime_completeness_policy or ""),
-                pytest_version=str(pytest_version or "")[:128],
-                python_version=str(python_version or "")[:64],
-                plugin_versions_cid=str(plugin_versions_cid or ""),
-                command_semantics_cid=str(command_semantics_cid or ""),
-                config_cid=str(config_cid or ""),
-                markers=tuple(str(item) for item in markers or ()),
-                dependency_lock_cid=str(dependency_lock_cid or ""),
-                installed_distributions_cid=str(installed_distributions_cid or ""),
-                environment_cid=str(environment_cid or ""),
-                platform_cid=str(platform_cid or ""),
-                interpreter_abi_cid=str(interpreter_abi_cid or ""),
-                hardware_capability_cid=str(hardware_capability_cid or ""),
-                external_snapshot_cids=tuple(
-                    str(item) for item in external_snapshot_cids or ()
-                ),
-                policy_cid=str(policy_cid or ""),
-                canonicalization_schema_cid=str(canonicalization_schema_cid or ""),
-                tracer_schema_cid=str(tracer_schema_cid or ""),
-                certificate_schema_cid=str(certificate_schema_cid or ""),
-                eligibility_class=eligibility,
-                components=dict(components or {}),
-                metadata=dict(metadata or {}),
+            key = self._coerce_execution_key(execution_key, fields)
+        except (TestExecutionContractError, TestExecutionIdentityError, TypeError, ValueError) as exc:
+            return _non_reusable_execution(
+                reason_code=REASON_MALFORMED_ARTIFACT,
+                non_reusable_reason="malformed_execution_key:%s" % _bounded_reason(exc),
+                cid_support=status,
+                diagnostics={"error": _bounded_reason(exc)},
             )
-            identity = mint_content_identity(execution_key.to_dict())
-        except Exception as exc:
-            return ExecutionKeyCompileResult(
+
+        try:
+            identity = mint_content_identity(
+                key,
+                bridge_import=self.bridge_import,
+            )
+        except TestExecutionIdentityError as exc:
+            return _non_reusable_execution(
+                reason_code=REASON_CID_PROVIDER_UNAVAILABLE,
+                non_reusable_reason="cid_mint_failed:%s" % _bounded_reason(exc),
+                cid_support=status,
+                execution_key=key,
+                locator_cid=key.locator_cid,
+                diagnostics={"error": _bounded_reason(exc)},
+            )
+
+        if key.content_id != identity.cid:
+            return _non_reusable_execution(
+                reason_code=REASON_MALFORMED_ARTIFACT,
+                non_reusable_reason="execution_content_id_drift",
+                cid_support=status,
+                execution_key=key,
+                content_identity=identity,
+                locator_cid=key.locator_cid,
+                diagnostics={
+                    "contract_content_id": key.content_id,
+                    "multiformats_cid": identity.cid,
+                },
+            )
+
+        non_reusable_reason = ""
+        if key.eligibility_class is EligibilityClass.NON_REUSABLE:
+            non_reusable_reason = "eligibility_class:non_reusable"
+        # Explicit component marker for unsupported / uncontrolled inputs.
+        if "non_reusable_reason" in key.components:
+            non_reusable_reason = (
+                non_reusable_reason or key.components["non_reusable_reason"]
+            )
+        if non_reusable_reason:
+            return CompiledTestExecutionKey(
                 reusable=False,
-                reason_code=f"execution_key_compile_failed:{type(exc).__name__}"[:96],
+                reason_code=REASON_NON_REUSABLE,
+                non_reusable_reason=non_reusable_reason,
+                execution_key=key,
+                content_identity=identity,
+                execution_cid=identity.cid,
+                locator_cid=key.locator_cid,
+                cid_support=status,
+                diagnostics={"eligibility_class": key.eligibility_class.value},
             )
-        return ExecutionKeyCompileResult(
+
+        return CompiledTestExecutionKey(
             reusable=True,
-            execution_key=execution_key,
-            execution_key_cid=identity.cid,
+            reason_code="",
+            non_reusable_reason="",
+            execution_key=key,
             content_identity=identity,
+            execution_cid=identity.cid,
+            locator_cid=key.locator_cid,
+            cid_support=status,
+            diagnostics={},
+        )
+
+    # -- coercion ------------------------------------------------------------
+
+    def _coerce_locator(
+        self,
+        locator: TestLocatorKey | Mapping[str, Any] | None,
+        fields: Mapping[str, Any],
+    ) -> TestLocatorKey:
+        if locator is not None and fields:
+            raise TestExecutionIdentityError(
+                "compile_locator accepts either a TestLocatorKey/mapping or fields, not both"
+            )
+        if isinstance(locator, TestLocatorKey):
+            # Re-normalize node id for stability even on prebuilt keys.
+            if locator.node_id != normalize_pytest_node_id(locator.node_id):
+                return TestLocatorKey(
+                    repository_id=locator.repository_id,
+                    package_identity=locator.package_identity,
+                    node_id=normalize_pytest_node_id(locator.node_id),
+                    collection_schema_version=locator.collection_schema_version,
+                    parameter_id=locator.parameter_id,
+                    parameter_values_cid=locator.parameter_values_cid,
+                    non_reusable_reason=locator.non_reusable_reason,
+                    selection_semantics=locator.selection_semantics,
+                    root_identity=locator.root_identity,
+                    metadata=dict(locator.metadata),
+                )
+            return locator
+        if locator is None:
+            raw: Mapping[str, Any] = fields
+        elif isinstance(locator, Mapping):
+            raw = locator
+        else:
+            raise TestExecutionIdentityError(
+                "locator must be a TestLocatorKey, mapping, or field kwargs"
+            )
+
+        node_id = raw.get("node_id", "")
+        if node_id:
+            node_id = normalize_pytest_node_id(str(node_id))
+        return TestLocatorKey(
+            repository_id=raw.get("repository_id", ""),
+            package_identity=raw.get("package_identity", ""),
+            node_id=node_id,
+            collection_schema_version=raw.get("collection_schema_version", "1"),
+            parameter_id=raw.get("parameter_id", ""),
+            parameter_values_cid=raw.get("parameter_values_cid", ""),
+            non_reusable_reason=raw.get("non_reusable_reason", ""),
+            selection_semantics=raw.get("selection_semantics", "exact_node"),
+            root_identity=raw.get("root_identity", ""),
+            metadata=raw.get("metadata") or {},
+        )
+
+    def _coerce_execution_key(
+        self,
+        execution_key: TestExecutionKey | Mapping[str, Any] | None,
+        fields: Mapping[str, Any],
+    ) -> TestExecutionKey:
+        if execution_key is not None and fields:
+            raise TestExecutionIdentityError(
+                "compile_execution_key accepts either a TestExecutionKey/mapping "
+                "or fields, not both"
+            )
+        if isinstance(execution_key, TestExecutionKey):
+            return execution_key
+        if execution_key is None:
+            raw: Mapping[str, Any] = fields
+        elif isinstance(execution_key, Mapping):
+            raw = execution_key
+        else:
+            raise TestExecutionIdentityError(
+                "execution_key must be a TestExecutionKey, mapping, or field kwargs"
+            )
+
+        eligibility = raw.get(
+            "eligibility_class", EligibilityClass.REPOSITORY_FOREST_BOUND
+        )
+        return TestExecutionKey(
+            locator_cid=raw.get("locator_cid", ""),
+            repository_forest_cid=raw.get("repository_forest_cid", ""),
+            git_commit_id=raw.get("git_commit_id", ""),
+            git_tree_id=raw.get("git_tree_id", ""),
+            gitlink_state_cid=raw.get("gitlink_state_cid", ""),
+            dirty_overlay_cid=raw.get("dirty_overlay_cid", ""),
+            test_module_cid=raw.get("test_module_cid", ""),
+            test_class_cid=raw.get("test_class_cid", ""),
+            test_function_cid=raw.get("test_function_cid", ""),
+            decorator_cids=tuple(raw.get("decorator_cids") or ()),
+            parameter_source_cid=raw.get("parameter_source_cid", ""),
+            test_ast_cid=raw.get("test_ast_cid", ""),
+            fixture_cids=tuple(raw.get("fixture_cids") or ()),
+            conftest_closure_cid=raw.get("conftest_closure_cid", ""),
+            hook_plugin_cids=tuple(raw.get("hook_plugin_cids") or ()),
+            static_trace_root_cid=raw.get("static_trace_root_cid", ""),
+            static_unknown_frontier=tuple(raw.get("static_unknown_frontier") or ()),
+            runtime_trace_root_cid=raw.get("runtime_trace_root_cid", ""),
+            runtime_completeness_policy=raw.get("runtime_completeness_policy", ""),
+            pytest_version=raw.get("pytest_version", ""),
+            python_version=raw.get("python_version", ""),
+            plugin_versions_cid=raw.get("plugin_versions_cid", ""),
+            command_semantics_cid=raw.get("command_semantics_cid", ""),
+            config_cid=raw.get("config_cid", ""),
+            markers=tuple(raw.get("markers") or ()),
+            dependency_lock_cid=raw.get("dependency_lock_cid", ""),
+            installed_distributions_cid=raw.get("installed_distributions_cid", ""),
+            environment_cid=raw.get("environment_cid", ""),
+            platform_cid=raw.get("platform_cid", ""),
+            interpreter_abi_cid=raw.get("interpreter_abi_cid", ""),
+            hardware_capability_cid=raw.get("hardware_capability_cid", ""),
+            external_snapshot_cids=tuple(raw.get("external_snapshot_cids") or ()),
+            policy_cid=raw.get("policy_cid", ""),
+            canonicalization_schema_cid=raw.get("canonicalization_schema_cid", ""),
+            tracer_schema_cid=raw.get("tracer_schema_cid", ""),
+            certificate_schema_cid=raw.get("certificate_schema_cid", ""),
+            eligibility_class=eligibility,
+            components=raw.get("components") or {},
+            metadata=raw.get("metadata") or {},
         )
 
 
-# Compatibility aliases used by plan docs / older call sites.
-compile_test_locator = TestExecutionIdentityCompiler.compile_locator
-compile_test_execution_key = TestExecutionIdentityCompiler.compile_execution_key
+def _bounded_reason(exc: BaseException, *, max_chars: int = 200) -> str:
+    text = str(exc).strip().replace("\n", " ")
+    if not text:
+        text = type(exc).__name__
+    if len(text) > max_chars:
+        return text[: max_chars - 3] + "..."
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Module-level entry points (predicted symbols)
+# ---------------------------------------------------------------------------
+
+
+def compile_test_locator(
+    locator: TestLocatorKey | Mapping[str, Any] | None = None,
+    /,
+    **fields: Any,
+) -> CompiledTestLocator:
+    """Compile a test locator key into a stable ContentIdentity-backed artifact."""
+
+    return TestExecutionIdentityCompiler().compile_locator(locator, **fields)
+
+
+def compile_test_execution_key(
+    execution_key: TestExecutionKey | Mapping[str, Any] | None = None,
+    /,
+    **fields: Any,
+) -> CompiledTestExecutionKey:
+    """Compile a test execution key into a stable ContentIdentity-backed artifact."""
+
+    return TestExecutionIdentityCompiler().compile_execution_key(
+        execution_key, **fields
+    )
+
 
 __all__ = (
+    "CID_BASE",
+    "CID_CODEC",
+    "CID_VERSION",
+    "COMPILED_EXECUTION_KEY_SCHEMA",
+    "COMPILED_LOCATOR_SCHEMA",
     "CONTENT_IDENTITY_INTERFACE",
+    "CONTENT_IDENTITY_SCHEMA",
     "CidSupportStatus",
+    "CompiledTestExecutionKey",
+    "CompiledTestLocator",
     "ContentIdentity",
-    "ExecutionKeyCompileResult",
-    "LocatorCompileResult",
+    "DIGEST_SIZE",
+    "MH_TYPE",
+    "REASON_CID_PROVIDER_UNAVAILABLE",
+    "REASON_MALFORMED_ARTIFACT",
+    "REASON_NON_REUSABLE",
+    "REASON_UNSUPPORTED",
     "TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE",
+    "TEST_EXECUTION_IDENTITY_COMPILER_SCHEMA",
     "TestExecutionIdentityCompiler",
     "TestExecutionIdentityError",
+    "cid_support_available",
+    "compile_test_execution_key",
+    "compile_test_locator",
+    "content_identity_from_retained_bytes",
     "mint_content_identity",
-    "mint_content_identity_bytes",
     "normalize_pytest_node_id",
+    "probe_cid_support",
     "reject_pseudo_cid",
 )

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_identity_components.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_identity_components.py
@@ -1,348 +1,1192 @@
-"""Component identity compiler for fixtures, hooks, env, and parameters (PTR-011)."""
+"""Fail-closed identity components for proof-backed pytest reuse.
+
+This module implements the component side of ``TestExecutionKey@1``.  It does
+not decide whether a cached result may skip a test.  Instead, it produces
+content identities for behavior-affecting pytest inputs and reports inputs
+that cannot be represented safely as explicit non-reusable reasons.
+
+Privacy is part of the identity contract:
+
+* environment variable names come from a fixed, reviewed allowlist;
+* raw environment and fixture values are reduced to content identities;
+* absolute host paths, distribution locations, host names, device serials,
+  and network identifiers are never retained;
+* callers must explicitly allow every capability identifier.
+
+Only finite, reviewed parameter types are canonical.  There is deliberately no
+``repr``/``str``/pickle fallback: such fallbacks are unstable and can execute
+user code or disclose private state.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+import os
+import platform as _platform
+import re
+import struct
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Any, ClassVar, Final
 
-from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
-    mint_content_identity,
+from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+    canonical_json_bytes,
+    content_identity,
 )
 
 TEST_IDENTITY_COMPONENTS_INTERFACE: Final = "TestIdentityComponents@1"
 TEST_IDENTITY_COMPONENTS_SCHEMA: Final = (
     "ipfs_accelerate_py/agent-supervisor/test-identity-components@1"
 )
-_MAX_ITEMS: Final = 512
-_MAX_REASON: Final = 128
-
-# Privacy-safe environment variables that may participate in item identity.
-# Secrets, credentials, and host-local absolute paths must never appear here.
-DEFAULT_ENVIRONMENT_ALLOWLIST: Final[tuple[str, ...]] = (
-    "LANG",
-    "LC_ALL",
-    "LC_CTYPE",
-    "PYTHONHASHSEED",
-    "PYTHONIOENCODING",
-    "PYTHONNOUSERSITE",
-    "PYTHONPATH",
-    "PYTHONSAFEPATH",
-    "PYTHONUTF8",
-    "PYTHONWARNINGS",
-    "PYTEST_ADDOPTS",
-    "PYTEST_CURRENT_TEST",
-    "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
-    "PYTEST_PLUGINS",
-    "TZ",
-    "IPFS_TEST_PROOF_REUSE_MODE",
+PARAMETER_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/pytest-parameter@1"
+)
+FIXTURE_SCHEMA: Final = "ipfs_accelerate_py/agent-supervisor/pytest-fixture@1"
+HOOK_PLUGIN_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/pytest-hook-plugin@1"
+)
+DEPENDENCY_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-dependency-identity@1"
+)
+ENVIRONMENT_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-environment-identity@1"
 )
 
+MAX_PARAMETER_DEPTH: Final = 16
+MAX_PARAMETER_ITEMS: Final = 1_024
+MAX_PARAMETER_TEXT_CHARS: Final = 16_384
+MAX_PARAMETER_BYTES: Final = 1_048_576
+MAX_RECORDS: Final = 512
+MAX_SOURCE_BYTES: Final = 4 * 1_048_576
+MAX_LOCK_BYTES: Final = 16 * 1_048_576
+MAX_ENV_VALUE_CHARS: Final = 256
 
-def _bounded_mapping(value: Any, *, name: str) -> dict[str, Any]:
-    if value is None:
-        return {}
-    if not isinstance(value, Mapping):
-        raise TypeError(f"{name} must be a mapping")
-    return {str(key): value[key] for key in list(value)[:_MAX_ITEMS]}
+_CID_RE: Final = re.compile(r"^b[a-z2-7]{20,}$")
+_SAFE_NAME_RE: Final = re.compile(r"^[A-Za-z0-9_.:@/+ -]{1,256}$")
+_CAPABILITY_ID_RE: Final = re.compile(r"^[a-z0-9][a-z0-9._:/+-]{0,127}$")
+_DISTRIBUTION_NAME_RE: Final = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_INTEGER_TEXT_RE: Final = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+_NONNEGATIVE_INTEGER_TEXT_RE: Final = re.compile(r"^(?:0|[1-9][0-9]*)$")
+_LOCALE_RE: Final = re.compile(r"^[A-Za-z0-9_.@-]{1,64}$")
+_DEVICE_SELECTION_RE: Final = re.compile(r"^(?:-1|none|void|[0-9]+(?:,[0-9]+)*)$", re.I)
+_VERSION_RE: Final = re.compile(r"^[A-Za-z0-9_.+!~-]{1,128}$")
+
+_MISSING: Final = object()
+_NO_PARAMETER: Final = object()
+
+FIXTURE_SCOPES: Final = frozenset(
+    {"function", "class", "module", "package", "session"}
+)
+HOOK_KINDS: Final = frozenset({"hook", "plugin"})
+
+# Values are validation policies, not merely documented suggestions.  A caller
+# cannot add an arbitrary name to this set.
+ENVIRONMENT_VALUE_POLICIES: Final = MappingProxyType(
+    {
+        "CI": "boolean",
+        "CUDA_VISIBLE_DEVICES": "device_selection",
+        "HIP_VISIBLE_DEVICES": "device_selection",
+        "IPFS_TEST_PROOF_REUSE_MODE": "reuse_mode",
+        "LANG": "locale",
+        "LC_ALL": "locale",
+        "MKL_NUM_THREADS": "positive_integer",
+        "OMP_NUM_THREADS": "positive_integer",
+        "PYTHONHASHSEED": "hash_seed",
+        "PYTHONUTF8": "boolean",
+        "TZ": "timezone",
+    }
+)
+DEFAULT_ENVIRONMENT_ALLOWLIST: Final = tuple(sorted(ENVIRONMENT_VALUE_POLICIES))
+
+INTERPRETER_FACT_ALLOWLIST: Final = frozenset(
+    {
+        "implementation",
+        "version",
+        "cache_tag",
+        "abi_flags",
+        "byteorder",
+        "pointer_bits",
+    }
+)
+PLATFORM_FACT_ALLOWLIST: Final = frozenset(
+    {"system", "release", "machine", "python_compiler", "libc"}
+)
+HARDWARE_FACT_ALLOWLIST: Final = frozenset(
+    {
+        "architecture",
+        "cpu_count",
+        "accelerator_backend",
+        "accelerator_count",
+        "accelerator_architectures",
+    }
+)
+LOCK_FILE_NAMES: Final = frozenset(
+    {
+        "cargo.lock",
+        "composer.lock",
+        "conda-lock.yml",
+        "gemfile.lock",
+        "package-lock.json",
+        "pipfile.lock",
+        "pnpm-lock.yaml",
+        "poetry.lock",
+        "requirements.lock",
+        "uv.lock",
+        "yarn.lock",
+    }
+)
+LOCK_FILE_SUFFIXES: Final = (".lock", ".lock.json")
 
 
-def _bounded_records(value: Any, *, name: str) -> tuple[dict[str, Any], ...]:
-    if value is None:
-        return ()
-    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
-        raise TypeError(f"{name} must be a sequence of mappings")
-    rows: list[dict[str, Any]] = []
-    for item in list(value)[:_MAX_ITEMS]:
-        if not isinstance(item, Mapping):
-            raise TypeError(f"{name} entries must be mappings")
-        rows.append(dict(item))
-    return tuple(rows)
+class TestIdentityComponentError(ValueError):
+    """Base error for malformed or unsafe identity-component input."""
+
+    __test__ = False
 
 
-def _bounded_pairs(value: Any, *, name: str) -> tuple[tuple[str, str], ...]:
-    if value is None:
-        return ()
-    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
-        raise TypeError(f"{name} must be a sequence of pairs")
-    pairs: list[tuple[str, str]] = []
-    for item in list(value)[:_MAX_ITEMS]:
-        if not isinstance(item, (tuple, list)) or len(item) != 2:
-            raise TypeError(f"{name} entries must be (name, version) pairs")
-        pairs.append((str(item[0]), str(item[1])))
-    return tuple(pairs)
+class UnsupportedPytestParameter(TestIdentityComponentError):
+    """A pytest parameter cannot be represented by the reviewed finite profile."""
 
 
-def canonicalize_pytest_parameter(value: Any) -> Any:
-    """Return a JSON-safe parameter value or raise for unsupported types."""
+def _reason(code: str) -> str:
+    """Return one of the bounded public reason codes used by this module."""
 
-    if value is None or isinstance(value, (bool, int, str)):
-        return value
-    if isinstance(value, float):
-        raise ValueError("floating-point parameters are not reusable")
-    if isinstance(value, (bytes, bytearray)):
-        raise ValueError("bytes parameters are not reusable")
-    if isinstance(value, Mapping):
-        return {
-            str(key): canonicalize_pytest_parameter(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return [canonicalize_pytest_parameter(item) for item in value]
-    raise ValueError(f"unsupported parameter type: {type(value).__name__}")
+    if not isinstance(code, str) or not re.fullmatch(
+        r"[a-z][a-z0-9_]{0,95}", code
+    ):
+        return "identity_component_rejected"
+    return code
 
 
-@dataclass(frozen=True, slots=True)
-class TestIdentityComponents:
-    """Compiled identity roots for one pytest item's non-AST components."""
-
-    __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = TEST_IDENTITY_COMPONENTS_INTERFACE
-
-    reusable: bool
-    component_root_cid: str
-    parameter_cid: str = ""
-    non_reusable_reasons: tuple[str, ...] = ()
-    fixture_cids: tuple[str, ...] = ()
-    conftest_closure_cid: str = ""
-    hook_plugin_cids: tuple[str, ...] = ()
-    dependency_lock_cid: str = ""
-    installed_distributions_cid: str = ""
-    environment_cid: str = ""
-    platform_cid: str = ""
-    interpreter_abi_cid: str = ""
-    hardware_capability_cid: str = ""
-    parameter_source_cid: str = ""
-    components: Mapping[str, str] = field(default_factory=dict)
-
-    @classmethod
-    def compile(
-        cls,
-        *,
-        parameter_id: str = "",
-        parameter_value: Any = None,
-        fixtures: Sequence[Mapping[str, Any]] | None = None,
-        conftests: Sequence[Mapping[str, Any]] | None = None,
-        hooks: Sequence[Mapping[str, Any]] | None = None,
-        plugins: Sequence[Mapping[str, Any]] | None = None,
-        lock_files: Sequence[Mapping[str, Any]] | None = None,
-        installed_distributions: Sequence[Sequence[str]] | None = None,
-        environment: Mapping[str, Any] | None = None,
-        environment_allowlist: Sequence[str] | None = None,
-        interpreter_facts: Mapping[str, Any] | None = None,
-        platform_facts: Mapping[str, Any] | None = None,
-        hardware_facts: Mapping[str, Any] | None = None,
-        capability_facts: Mapping[str, Any] | None = None,
-        capability_allowlist: Sequence[str] | None = None,
-        **_extra: Any,
-    ) -> "TestIdentityComponents":
-        """Compile component CIDs; unsupported inputs become non-reusable reasons."""
-
-        reasons: list[str] = []
-        fixture_rows = _bounded_records(fixtures, name="fixtures")
-        conftest_rows = _bounded_records(conftests, name="conftests")
-        hook_rows = _bounded_records(hooks, name="hooks")
-        plugin_rows = _bounded_records(plugins, name="plugins")
-        lock_rows = _bounded_records(lock_files, name="lock_files")
-        dist_pairs = _bounded_pairs(
-            installed_distributions, name="installed_distributions"
+def _safe_name(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _SAFE_NAME_RE.fullmatch(value):
+        raise TestIdentityComponentError(
+            f"{field_name} must be a bounded, privacy-safe name"
         )
-        env_map = _bounded_mapping(environment, name="environment")
-        allowlist = tuple(
-            str(item) for item in (environment_allowlist or ()) if str(item).strip()
-        )[:_MAX_ITEMS]
-        if allowlist:
-            env_map = {
-                key: value for key, value in env_map.items() if key in set(allowlist)
-            }
+    return value
 
-        parameter_cid = ""
-        parameter_source_cid = ""
-        if parameter_id:
-            try:
-                canonical_parameter = canonicalize_pytest_parameter(parameter_value)
-                parameter_identity = mint_content_identity(
+
+def _require_mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TestIdentityComponentError(f"{field_name} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise TestIdentityComponentError(f"{field_name} keys must be strings")
+    return value
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, Any], allowed: Iterable[str], *, field_name: str
+) -> None:
+    if set(value).difference(allowed):
+        raise TestIdentityComponentError(
+            f"{field_name} contains unsupported fields"
+        )
+
+
+def _require_cid(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _CID_RE.fullmatch(value):
+        raise TestIdentityComponentError(
+            f"{field_name} must be a lowercase base32 CIDv1"
+        )
+    return value
+
+
+def _canonical_parameter(
+    value: Any,
+    *,
+    depth: int,
+    budget: list[int],
+    active_ids: set[int],
+) -> dict[str, Any]:
+    if depth > MAX_PARAMETER_DEPTH:
+        raise UnsupportedPytestParameter("pytest_parameter_too_deep")
+    budget[0] += 1
+    if budget[0] > MAX_PARAMETER_ITEMS:
+        raise UnsupportedPytestParameter("pytest_parameter_too_many_items")
+
+    value_type = type(value)
+    if value is None:
+        return {"type": "none"}
+    if value_type is bool:
+        return {"type": "bool", "value": value}
+    if value_type is int:
+        if value.bit_length() > 256:
+            raise UnsupportedPytestParameter("pytest_parameter_integer_too_large")
+        return {"type": "int", "value": value}
+    if value_type is str:
+        if len(value) > MAX_PARAMETER_TEXT_CHARS:
+            raise UnsupportedPytestParameter("pytest_parameter_text_too_large")
+        return {"type": "str", "value": value}
+    if value_type is bytes:
+        if len(value) > MAX_PARAMETER_BYTES:
+            raise UnsupportedPytestParameter("pytest_parameter_bytes_too_large")
+        return {"type": "bytes", "hex": value.hex()}
+    if value_type is float:
+        # Even finite IEEE values have several non-portable edge cases (-0,
+        # NaN payloads, JSON formatting).  The v1 profile rejects all floats.
+        raise UnsupportedPytestParameter("unsupported_pytest_parameter_float")
+
+    container_types = {list, tuple, dict, set, frozenset}
+    if value_type not in container_types:
+        raise UnsupportedPytestParameter("unsupported_pytest_parameter_type")
+
+    object_id = id(value)
+    if object_id in active_ids:
+        raise UnsupportedPytestParameter("cyclic_pytest_parameter")
+    active_ids.add(object_id)
+    try:
+        if value_type in (list, tuple):
+            if len(value) > MAX_PARAMETER_ITEMS:
+                raise UnsupportedPytestParameter(
+                    "pytest_parameter_too_many_items"
+                )
+            return {
+                "type": "tuple" if value_type is tuple else "list",
+                "items": [
+                    _canonical_parameter(
+                        item,
+                        depth=depth + 1,
+                        budget=budget,
+                        active_ids=active_ids,
+                    )
+                    for item in value
+                ],
+            }
+        if value_type is dict:
+            if len(value) > MAX_PARAMETER_ITEMS:
+                raise UnsupportedPytestParameter(
+                    "pytest_parameter_too_many_items"
+                )
+            if not all(type(key) is str for key in value):
+                raise UnsupportedPytestParameter(
+                    "pytest_parameter_mapping_key_not_string"
+                )
+            entries = []
+            for key in sorted(value):
+                if len(key) > MAX_PARAMETER_TEXT_CHARS:
+                    raise UnsupportedPytestParameter(
+                        "pytest_parameter_text_too_large"
+                    )
+                entries.append(
                     {
-                        "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/parameter",
-                        "parameter_id": str(parameter_id),
-                        "value": canonical_parameter,
+                        "key": key,
+                        "value": _canonical_parameter(
+                            value[key],
+                            depth=depth + 1,
+                            budget=budget,
+                            active_ids=active_ids,
+                        ),
                     }
                 )
-                parameter_cid = parameter_identity.cid
-                parameter_source_cid = parameter_cid
-            except Exception as exc:
-                reasons.append(f"parameter_unsupported:{type(exc).__name__}"[:_MAX_REASON])
+            return {"type": "mapping", "items": entries}
 
-        fixture_cids: list[str] = []
-        for row in fixture_rows:
-            try:
-                fixture_cids.append(
-                    mint_content_identity(
-                        {
-                            "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/fixture",
-                            "fixture": row,
-                        }
-                    ).cid
-                )
-            except Exception as exc:
-                reasons.append(f"fixture_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        try:
-            conftest_closure_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/conftests",
-                    "conftests": list(conftest_rows),
-                }
-            ).cid
-        except Exception as exc:
-            conftest_closure_cid = ""
-            reasons.append(f"conftest_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        hook_plugin_cids: list[str] = []
-        for row in list(hook_rows) + list(plugin_rows):
-            try:
-                hook_plugin_cids.append(
-                    mint_content_identity(
-                        {
-                            "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/hook-plugin",
-                            "record": row,
-                        }
-                    ).cid
-                )
-            except Exception as exc:
-                reasons.append(
-                    f"hook_plugin_mint_failed:{type(exc).__name__}"[:_MAX_REASON]
-                )
-
-        try:
-            dependency_lock_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/locks",
-                    "lock_files": list(lock_rows),
-                }
-            ).cid
-        except Exception as exc:
-            dependency_lock_cid = ""
-            reasons.append(f"lock_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        try:
-            installed_distributions_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/distributions",
-                    "installed_distributions": [
-                        [name, version] for name, version in dist_pairs
-                    ],
-                }
-            ).cid
-        except Exception as exc:
-            installed_distributions_cid = ""
-            reasons.append(
-                f"distribution_mint_failed:{type(exc).__name__}"[:_MAX_REASON]
+        encoded_items = [
+            _canonical_parameter(
+                item,
+                depth=depth + 1,
+                budget=budget,
+                active_ids=active_ids,
             )
-
-        try:
-            environment_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/environment",
-                    "environment": env_map,
-                    "allowlist": list(allowlist),
-                }
-            ).cid
-        except Exception as exc:
-            environment_cid = ""
-            reasons.append(f"environment_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        try:
-            interpreter_abi_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/interpreter",
-                    "facts": _bounded_mapping(
-                        interpreter_facts, name="interpreter_facts"
-                    ),
-                }
-            ).cid
-        except Exception as exc:
-            interpreter_abi_cid = ""
-            reasons.append(f"interpreter_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        try:
-            platform_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/platform",
-                    "facts": _bounded_mapping(platform_facts, name="platform_facts"),
-                }
-            ).cid
-        except Exception as exc:
-            platform_cid = ""
-            reasons.append(f"platform_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        try:
-            hardware_capability_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA + "/hardware",
-                    "hardware": _bounded_mapping(hardware_facts, name="hardware_facts"),
-                    "capabilities": _bounded_mapping(
-                        capability_facts, name="capability_facts"
-                    ),
-                    "allowlist": [
-                        str(item)
-                        for item in (capability_allowlist or ())
-                        if str(item).strip()
-                    ][:_MAX_ITEMS],
-                }
-            ).cid
-        except Exception as exc:
-            hardware_capability_cid = ""
-            reasons.append(f"hardware_mint_failed:{type(exc).__name__}"[:_MAX_REASON])
-
-        component_map = {
-            "fixtures": ",".join(fixture_cids),
-            "conftests": conftest_closure_cid,
-            "hooks_plugins": ",".join(hook_plugin_cids),
-            "locks": dependency_lock_cid,
-            "distributions": installed_distributions_cid,
-            "environment": environment_cid,
-            "interpreter": interpreter_abi_cid,
-            "platform": platform_cid,
-            "hardware": hardware_capability_cid,
-            "parameter": parameter_cid,
+            for item in value
+        ]
+        encoded_items.sort(key=canonical_json_bytes)
+        for previous, current in zip(
+            encoded_items, encoded_items[1:], strict=False
+        ):
+            if canonical_json_bytes(previous) == canonical_json_bytes(current):
+                raise UnsupportedPytestParameter(
+                    "pytest_parameter_set_has_canonical_collision"
+                )
+        return {
+            "type": "frozenset" if value_type is frozenset else "set",
+            "items": encoded_items,
         }
-        try:
-            component_root_cid = mint_content_identity(
-                {
-                    "schema": TEST_IDENTITY_COMPONENTS_SCHEMA,
-                    "interface": TEST_IDENTITY_COMPONENTS_INTERFACE,
-                    "components": component_map,
-                }
-            ).cid
-        except Exception as exc:
-            component_root_cid = ""
-            reasons.append(f"component_root_failed:{type(exc).__name__}"[:_MAX_REASON])
+    finally:
+        active_ids.remove(object_id)
 
-        reusable = not reasons and bool(component_root_cid)
-        return cls(
-            reusable=reusable,
-            component_root_cid=component_root_cid,
-            parameter_cid=parameter_cid,
-            non_reusable_reasons=tuple(reasons),
-            fixture_cids=tuple(fixture_cids),
-            conftest_closure_cid=conftest_closure_cid,
-            hook_plugin_cids=tuple(hook_plugin_cids),
-            dependency_lock_cid=dependency_lock_cid,
-            installed_distributions_cid=installed_distributions_cid,
-            environment_cid=environment_cid,
-            platform_cid=platform_cid,
-            interpreter_abi_cid=interpreter_abi_cid,
-            hardware_capability_cid=hardware_capability_cid,
-            parameter_source_cid=parameter_source_cid,
-            components=MappingProxyType(component_map),
+
+def canonicalize_pytest_parameter(value: Any) -> dict[str, Any]:
+    """Return a type-preserving canonical parameter or raise explicitly.
+
+    Supported values are ``None``, booleans, bounded integers, strings, bytes,
+    lists, tuples, string-keyed dictionaries, sets, and frozensets.  Container
+    type is retained, mapping keys and set members are deterministically
+    ordered, and cycles/canonical set collisions are rejected.
+    """
+
+    return _canonical_parameter(value, depth=0, budget=[0], active_ids=set())
+
+
+def _private_value_cid(value: Any, *, domain: str) -> str:
+    """Content-address a value without returning the value in public records."""
+
+    return content_identity(
+        {
+            "schema": "ipfs_accelerate_py/agent-supervisor/private-value@1",
+            "domain": domain,
+            "value": canonicalize_pytest_parameter(value),
+        }
+    )
+
+
+def _source_cid(value: Any, *, field_name: str) -> str:
+    if isinstance(value, str):
+        raw = value.encode("utf-8")
+        media_type = "text/x-python"
+    elif isinstance(value, bytes):
+        raw = value
+        media_type = "application/octet-stream"
+    else:
+        raise TestIdentityComponentError(
+            f"{field_name} must be source text, bytes, or a CID"
+        )
+    if len(raw) > MAX_SOURCE_BYTES:
+        raise TestIdentityComponentError(f"{field_name} exceeds the source bound")
+    return content_identity(
+        {
+            "schema": "ipfs_accelerate_py/agent-supervisor/source-blob@1",
+            "media_type": media_type,
+            "bytes": raw.hex(),
+        }
+    )
+
+
+def _record_content_cid(
+    record: Mapping[str, Any],
+    *,
+    cid_field: str,
+    content_field: str,
+    field_name: str,
+) -> str:
+    cid = record.get(cid_field)
+    content = record.get(content_field, _MISSING)
+    if (cid in (None, "")) == (content is _MISSING):
+        raise TestIdentityComponentError(
+            f"{field_name} requires exactly one of {cid_field} or {content_field}"
+        )
+    return (
+        _require_cid(cid, field_name=cid_field)
+        if content is _MISSING
+        else _source_cid(content, field_name=content_field)
+    )
+
+
+@dataclass(frozen=True)
+class FixtureHookIdentity:
+    """Content roots for fixtures, conftests, and hook/plugin code."""
+
+    fixture_cids: tuple[str, ...]
+    conftest_closure_cid: str
+    hook_plugin_cids: tuple[str, ...]
+    non_reusable_reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fixture_cids", tuple(sorted(set(self.fixture_cids))))
+        object.__setattr__(
+            self, "hook_plugin_cids", tuple(sorted(set(self.hook_plugin_cids)))
+        )
+        for name, values in (
+            ("fixture_cids", self.fixture_cids),
+            ("hook_plugin_cids", self.hook_plugin_cids),
+        ):
+            if len(values) > MAX_RECORDS:
+                raise TestIdentityComponentError(f"{name} exceeds its record bound")
+            for value in values:
+                _require_cid(value, field_name=name)
+        _require_cid(self.conftest_closure_cid, field_name="conftest_closure_cid")
+        object.__setattr__(
+            self,
+            "non_reusable_reasons",
+            tuple(
+                sorted(
+                    {
+                        _reason(reason)
+                        for reason in self.non_reusable_reasons
+                    }
+                )
+            ),
         )
 
+
+def _fixture_cid(raw: Any) -> tuple[str, str, tuple[str, ...]]:
+    record = _require_mapping(raw, field_name="fixture")
+    allowed = {
+        "name",
+        "scope",
+        "definition",
+        "definition_cid",
+        "value",
+        "value_cid",
+        "value_adapter_cid",
+        "dependencies",
+        "autouse",
+        "parameter_values",
+    }
+    _reject_unknown_fields(record, allowed, field_name="fixture")
+    name = _safe_name(record.get("name"), field_name="fixture.name")
+    scope = record.get("scope")
+    if scope not in FIXTURE_SCOPES:
+        raise TestIdentityComponentError("fixture.scope is not a supported pytest scope")
+    definition_cid = _record_content_cid(
+        record,
+        cid_field="definition_cid",
+        content_field="definition",
+        field_name="fixture definition",
+    )
+    dependencies = record.get("dependencies", ())
+    if isinstance(dependencies, str) or not isinstance(dependencies, Sequence):
+        raise TestIdentityComponentError("fixture.dependencies must be a sequence")
+    dependency_names = tuple(
+        sorted({_safe_name(item, field_name="fixture dependency") for item in dependencies})
+    )
+    if len(dependency_names) > MAX_RECORDS:
+        raise TestIdentityComponentError("fixture dependencies exceed their bound")
+    autouse = record.get("autouse", False)
+    if not isinstance(autouse, bool):
+        raise TestIdentityComponentError("fixture.autouse must be boolean")
+
+    value_modes = sum(
+        (
+            "value" in record,
+            record.get("value_cid") not in (None, ""),
+            record.get("value_adapter_cid") not in (None, ""),
+        )
+    )
+    if value_modes > 1:
+        raise TestIdentityComponentError(
+            "fixture value must use one value, value_cid, or value_adapter_cid"
+        )
+    reasons: list[str] = []
+    if "value" in record:
+        try:
+            value_cid = _private_value_cid(
+                record["value"], domain=f"fixture:{name}"
+            )
+        except UnsupportedPytestParameter:
+            reasons.append("unsupported_fixture_value")
+            value_identity = {"kind": "unsupported"}
+        else:
+            value_identity = {"kind": "canonical_value", "cid": value_cid}
+    elif record.get("value_cid") not in (None, ""):
+        value_identity = {
+            "kind": "content",
+            "cid": _require_cid(record["value_cid"], field_name="fixture.value_cid"),
+        }
+    elif record.get("value_adapter_cid") not in (None, ""):
+        value_identity = {
+            "kind": "adapter",
+            "cid": _require_cid(
+                record["value_adapter_cid"], field_name="fixture.value_adapter_cid"
+            ),
+        }
+    else:
+        # A fixture definition alone does not control the object supplied to a
+        # test.  Preserve a deterministic identity for diagnostics but prevent
+        # it from authorizing reuse.
+        value_identity = {"kind": "uncontrolled"}
+        reasons.append("uncontrolled_fixture_value")
+
+    parameter_values = record.get("parameter_values", ())
+    if isinstance(parameter_values, (str, bytes)) or not isinstance(
+        parameter_values, Sequence
+    ):
+        raise TestIdentityComponentError("fixture.parameter_values must be a sequence")
+    if len(parameter_values) > MAX_RECORDS:
+        raise TestIdentityComponentError("fixture.parameter_values exceeds its bound")
+    parameter_cids = []
+    for item in parameter_values:
+        try:
+            parameter_cids.append(
+                _private_value_cid(item, domain=f"fixture-parameter:{name}")
+            )
+        except UnsupportedPytestParameter:
+            reasons.append("unsupported_fixture_parameter")
+            parameter_cids.append(
+                content_identity(
+                    {
+                        "schema": (
+                            "ipfs_accelerate_py/agent-supervisor/"
+                            "unsupported-fixture-parameter@1"
+                        ),
+                        "fixture_name": name,
+                    }
+                )
+            )
+    fixture_cid = content_identity(
+        {
+            "schema": FIXTURE_SCHEMA,
+            "name": name,
+            "scope": scope,
+            "definition_cid": definition_cid,
+            "value_identity": value_identity,
+            "dependencies": list(dependency_names),
+            "autouse": autouse,
+            "parameter_cids": list(parameter_cids),
+        }
+    )
+    return name, fixture_cid, tuple(sorted(set(reasons)))
+
+
+def _normalized_relative_path(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, (str, os.PathLike)):
+        raise TestIdentityComponentError(f"{field_name} must be a relative path")
+    raw = os.fspath(value).replace("\\", "/")
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or raw.startswith("/")
+        or re.match(r"^[A-Za-z]:/", raw)
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        raise TestIdentityComponentError(
+            f"{field_name} must not contain an absolute path or traversal"
+        )
+    normalized = path.as_posix()
+    if len(normalized) > 1_024:
+        raise TestIdentityComponentError(f"{field_name} is too long")
+    return normalized
+
+
+def _conftest_cid(raw: Any) -> tuple[str, str]:
+    record = _require_mapping(raw, field_name="conftest")
+    _reject_unknown_fields(
+        record, {"path", "content", "content_cid"}, field_name="conftest"
+    )
+    path = _normalized_relative_path(record.get("path"), field_name="conftest.path")
+    if PurePosixPath(path).name != "conftest.py":
+        raise TestIdentityComponentError("conftest.path must name conftest.py")
+    source_cid = _record_content_cid(
+        record,
+        cid_field="content_cid",
+        content_field="content",
+        field_name="conftest content",
+    )
+    return path, content_identity(
+        {
+            "schema": "ipfs_accelerate_py/agent-supervisor/conftest@1",
+            "path": path,
+            "content_cid": source_cid,
+        }
+    )
+
+
+def _hook_plugin_cid(raw: Any) -> str:
+    record = _require_mapping(raw, field_name="hook/plugin")
+    allowed = {
+        "kind",
+        "name",
+        "implementation",
+        "implementation_cid",
+        "distribution",
+        "version",
+        "registered",
+        "order",
+    }
+    _reject_unknown_fields(record, allowed, field_name="hook/plugin")
+    kind = record.get("kind")
+    if kind not in HOOK_KINDS:
+        raise TestIdentityComponentError("hook/plugin.kind must be hook or plugin")
+    name = _safe_name(record.get("name"), field_name="hook/plugin.name")
+    implementation_cid = _record_content_cid(
+        record,
+        cid_field="implementation_cid",
+        content_field="implementation",
+        field_name="hook/plugin implementation",
+    )
+    distribution = record.get("distribution", "")
+    if distribution:
+        distribution = _normalize_distribution_name(distribution)
+    version = record.get("version", "")
+    if version and (not isinstance(version, str) or not _VERSION_RE.fullmatch(version)):
+        raise TestIdentityComponentError("hook/plugin.version is invalid")
+    registered = record.get("registered", True)
+    if not isinstance(registered, bool):
+        raise TestIdentityComponentError("hook/plugin.registered must be boolean")
+    order = record.get("order", 0)
+    if isinstance(order, bool) or not isinstance(order, int) or abs(order) > 1_000_000:
+        raise TestIdentityComponentError("hook/plugin.order must be a bounded integer")
+    return content_identity(
+        {
+            "schema": HOOK_PLUGIN_SCHEMA,
+            "kind": kind,
+            "name": name,
+            "implementation_cid": implementation_cid,
+            "distribution": distribution,
+            "version": version,
+            "registered": registered,
+            "order": order,
+        }
+    )
+
+
+def collect_fixture_hook_identity(
+    *,
+    fixtures: Iterable[Mapping[str, Any]] = (),
+    conftests: Iterable[Mapping[str, Any]] = (),
+    hooks: Iterable[Mapping[str, Any]] = (),
+    plugins: Iterable[Mapping[str, Any]] = (),
+) -> FixtureHookIdentity:
+    """Compile fixture definitions/values and the active hook/plugin closure."""
+
+    fixture_records = tuple(fixtures)
+    conftest_records = tuple(conftests)
+    hook_records = tuple(hooks)
+    plugin_records = tuple(plugins)
+    if any(
+        len(records) > MAX_RECORDS
+        for records in (fixture_records, conftest_records, hook_records, plugin_records)
+    ):
+        raise TestIdentityComponentError("fixture/hook input exceeds its record bound")
+    compiled_fixtures = [_fixture_cid(item) for item in fixture_records]
+    fixture_names = [name for name, _, _ in compiled_fixtures]
+    if len(fixture_names) != len(set(fixture_names)):
+        raise TestIdentityComponentError("duplicate fixture name")
+    fixture_cids = tuple(sorted(cid for _, cid, _ in compiled_fixtures))
+    fixture_reasons = tuple(
+        sorted(
+            {
+                reason
+                for _, _, reasons in compiled_fixtures
+                for reason in reasons
+            }
+        )
+    )
+    normalized_conftests = sorted(_conftest_cid(item) for item in conftest_records)
+    conftest_paths = [path for path, _ in normalized_conftests]
+    if len(conftest_paths) != len(set(conftest_paths)):
+        raise TestIdentityComponentError("duplicate conftest path")
+    conftest_closure_cid = content_identity(
+        {
+            "schema": "ipfs_accelerate_py/agent-supervisor/conftest-closure@1",
+            "entries": [
+                {"path": path, "cid": cid} for path, cid in normalized_conftests
+            ],
+        }
+    )
+    normalized_hook_records = []
+    for kind, records in (("hook", hook_records), ("plugin", plugin_records)):
+        for item in records:
+            record = _require_mapping(item, field_name=kind)
+            normalized_hook_records.append(
+                _hook_plugin_cid(
+                    {**record, "kind": record.get("kind", kind)}
+                )
+            )
+    if len(normalized_hook_records) != len(set(normalized_hook_records)):
+        raise TestIdentityComponentError("duplicate hook/plugin identity")
+    hook_plugin_cids = tuple(sorted(normalized_hook_records))
+    return FixtureHookIdentity(
+        fixture_cids=fixture_cids,
+        conftest_closure_cid=conftest_closure_cid,
+        hook_plugin_cids=hook_plugin_cids,
+        non_reusable_reasons=fixture_reasons,
+    )
+
+
+@dataclass(frozen=True)
+class DependencyIdentity:
+    """Lock-file and installed-distribution content roots."""
+
+    dependency_lock_cid: str
+    installed_distributions_cid: str
+
+    def __post_init__(self) -> None:
+        _require_cid(self.dependency_lock_cid, field_name="dependency_lock_cid")
+        _require_cid(
+            self.installed_distributions_cid,
+            field_name="installed_distributions_cid",
+        )
+
+
+def _is_lock_file(path: str) -> bool:
+    name = PurePosixPath(path).name.lower()
+    return name in LOCK_FILE_NAMES or any(name.endswith(suffix) for suffix in LOCK_FILE_SUFFIXES)
+
+
+def _lock_records(
+    lock_files: Mapping[Any, Any] | Iterable[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    if isinstance(lock_files, Mapping):
+        raw_records = [
+            {"path": path, "content": content} for path, content in lock_files.items()
+        ]
+    else:
+        raw_records = list(lock_files)
+    if len(raw_records) > MAX_RECORDS:
+        raise TestIdentityComponentError("lock_files exceeds its record bound")
+    records: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw in raw_records:
+        record = _require_mapping(raw, field_name="lock file")
+        _reject_unknown_fields(
+            record, {"path", "content", "content_cid"}, field_name="lock file"
+        )
+        path = _normalized_relative_path(record.get("path"), field_name="lock file.path")
+        if not _is_lock_file(path):
+            raise TestIdentityComponentError("lock file path is not allowlisted")
+        if path in seen:
+            raise TestIdentityComponentError("duplicate normalized lock file path")
+        seen.add(path)
+        content = record.get("content", _MISSING)
+        if content is not _MISSING:
+            if isinstance(content, str):
+                raw_content = content.encode("utf-8")
+            elif isinstance(content, bytes):
+                raw_content = content
+            else:
+                raise TestIdentityComponentError("lock file content must be text or bytes")
+            if len(raw_content) > MAX_LOCK_BYTES:
+                raise TestIdentityComponentError("lock file exceeds its byte bound")
+            content_cid = content_identity(
+                {
+                    "schema": "ipfs_accelerate_py/agent-supervisor/lock-bytes@1",
+                    "bytes": raw_content.hex(),
+                }
+            )
+            if record.get("content_cid") not in (None, ""):
+                raise TestIdentityComponentError(
+                    "lock file must not provide both content and content_cid"
+                )
+        else:
+            content_cid = _require_cid(
+                record.get("content_cid"), field_name="lock file.content_cid"
+            )
+        records.append({"path": path, "content_cid": content_cid})
+    return sorted(records, key=lambda item: item["path"])
+
+
+def _normalize_distribution_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise TestIdentityComponentError("distribution name must be a string")
+    normalized = re.sub(r"[-_.]+", "-", value.strip().lower())
+    if not _DISTRIBUTION_NAME_RE.fullmatch(normalized):
+        raise TestIdentityComponentError("distribution name is invalid")
+    return normalized
+
+
+def _distribution_records(
+    installed_distributions: Mapping[str, str] | Iterable[tuple[str, str]],
+) -> list[dict[str, str]]:
+    items = (
+        list(installed_distributions.items())
+        if isinstance(installed_distributions, Mapping)
+        else list(installed_distributions)
+    )
+    if len(items) > MAX_RECORDS:
+        raise TestIdentityComponentError(
+            "installed_distributions exceeds its record bound"
+        )
+    normalized: dict[str, str] = {}
+    for item in items:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            raise TestIdentityComponentError(
+                "installed distributions must contain name/version pairs"
+            )
+        name = _normalize_distribution_name(item[0])
+        version = item[1]
+        if not isinstance(version, str) or not _VERSION_RE.fullmatch(version):
+            raise TestIdentityComponentError("distribution version is invalid")
+        previous = normalized.get(name)
+        if previous is not None and previous != version:
+            raise TestIdentityComponentError(
+                "normalized distribution names collide"
+            )
+        normalized[name] = version
+    return [
+        {"name": name, "version": normalized[name]} for name in sorted(normalized)
+    ]
+
+
+def collect_dependency_identity(
+    *,
+    lock_files: Mapping[Any, Any] | Iterable[Mapping[str, Any]] = (),
+    installed_distributions: (
+        Mapping[str, str] | Iterable[tuple[str, str]]
+    ) = (),
+) -> DependencyIdentity:
+    """Compile normalized lock bytes and distribution name/version pairs.
+
+    Distribution installation locations and direct-url metadata are
+    intentionally excluded because they can contain user names and credentials.
+    """
+
+    locks = _lock_records(lock_files)
+    distributions = _distribution_records(installed_distributions)
+    return DependencyIdentity(
+        dependency_lock_cid=content_identity(
+            {
+                "schema": DEPENDENCY_SCHEMA,
+                "kind": "lock_files",
+                "entries": locks,
+            }
+        ),
+        installed_distributions_cid=content_identity(
+            {
+                "schema": DEPENDENCY_SCHEMA,
+                "kind": "installed_distributions",
+                "entries": distributions,
+            }
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class EnvironmentIdentity:
+    """Privacy-safe execution environment roots."""
+
+    environment_cid: str
+    platform_cid: str
+    interpreter_abi_cid: str
+    hardware_capability_cid: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "environment_cid",
+            "platform_cid",
+            "interpreter_abi_cid",
+            "hardware_capability_cid",
+        ):
+            _require_cid(getattr(self, name), field_name=name)
+
+
+def _validate_environment_value(name: str, value: Any) -> str:
+    if not isinstance(value, str) or len(value) > MAX_ENV_VALUE_CHARS:
+        raise TestIdentityComponentError(
+            f"allowlisted environment value for {name} is invalid"
+        )
+    policy = ENVIRONMENT_VALUE_POLICIES[name]
+    stripped = value.strip()
+    if policy == "boolean" and stripped.lower() not in {
+        "",
+        "0",
+        "1",
+        "false",
+        "true",
+        "no",
+        "yes",
+    }:
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if (
+        policy == "device_selection"
+        and stripped
+        and not _DEVICE_SELECTION_RE.fullmatch(stripped)
+    ):
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if policy == "reuse_mode" and stripped.lower() not in {
+        "off",
+        "shadow",
+        "read",
+        "write",
+        "readwrite",
+    }:
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if policy == "locale" and not _LOCALE_RE.fullmatch(stripped):
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if policy == "positive_integer" and (
+        not _NONNEGATIVE_INTEGER_TEXT_RE.fullmatch(stripped) or int(stripped) < 1
+    ):
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if policy == "hash_seed" and (
+        stripped.lower() != "random"
+        and not _NONNEGATIVE_INTEGER_TEXT_RE.fullmatch(stripped)
+    ):
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    if policy == "timezone" and (
+        len(stripped) > 64
+        or not re.fullmatch(r"[A-Za-z0-9_+./:-]{1,64}", stripped)
+        or ".." in stripped
+    ):
+        raise TestIdentityComponentError(f"environment value for {name} is invalid")
+    return stripped
+
+
+def _current_interpreter_facts() -> dict[str, Any]:
+    return {
+        "implementation": sys.implementation.name,
+        "version": list(sys.version_info[:5]),
+        "cache_tag": sys.implementation.cache_tag or "",
+        "abi_flags": getattr(sys, "abiflags", ""),
+        "byteorder": sys.byteorder,
+        "pointer_bits": struct.calcsize("P") * 8,
+    }
+
+
+def _current_platform_facts() -> dict[str, Any]:
+    libc_name, libc_version = _platform.libc_ver()
+    return {
+        "system": _platform.system().lower(),
+        "release": _platform.release(),
+        "machine": _platform.machine().lower(),
+        "python_compiler": _platform.python_compiler(),
+        "libc": [libc_name, libc_version],
+    }
+
+
+def _current_hardware_facts() -> dict[str, Any]:
+    return {
+        "architecture": _platform.machine().lower(),
+        "cpu_count": os.cpu_count() or 0,
+        "accelerator_backend": "none",
+        "accelerator_count": 0,
+        "accelerator_architectures": [],
+    }
+
+
+def _allowlisted_fact_map(
+    value: Mapping[str, Any],
+    *,
+    allowlist: frozenset[str],
+    field_name: str,
+) -> dict[str, Any]:
+    facts = _require_mapping(value, field_name=field_name)
+    fact_names = set(facts)
+    if fact_names.difference(allowlist):
+        raise TestIdentityComponentError(
+            f"{field_name} contains a non-allowlisted fact"
+        )
+    if fact_names != allowlist:
+        raise TestIdentityComponentError(
+            f"{field_name} is missing a required allowlisted fact"
+        )
+    # The tagged parameter profile supplies finite recursion and type bounds.
+    return {
+        key: canonicalize_pytest_parameter(facts[key]) for key in sorted(facts)
+    }
+
+
+def collect_environment_identity(
+    *,
+    environment: Mapping[str, str] | None = None,
+    environment_allowlist: Iterable[str] = DEFAULT_ENVIRONMENT_ALLOWLIST,
+    interpreter_facts: Mapping[str, Any] | None = None,
+    platform_facts: Mapping[str, Any] | None = None,
+    hardware_facts: Mapping[str, Any] | None = None,
+    capability_facts: Mapping[str, Any] | None = None,
+    capability_allowlist: Iterable[str] = (),
+) -> EnvironmentIdentity:
+    """Collect privacy-safe environment, runtime, and capability roots.
+
+    Raw environment values are not present in the resulting artifacts.  Each
+    value is represented by a domain-separated CID, including an explicit
+    marker for an allowlisted-but-unset variable.  Extra keys in the supplied
+    environment mapping are ignored, so passing ``os.environ`` does not ingest
+    secrets accidentally.
+    """
+
+    source_environment = os.environ if environment is None else environment
+    source_environment = _require_mapping(
+        source_environment, field_name="environment"
+    )
+    try:
+        requested_environment_names_raw = tuple(environment_allowlist)
+    except TypeError as exc:
+        raise TestIdentityComponentError(
+            "environment allowlist must be an iterable of names"
+        ) from exc
+    if any(not isinstance(name, str) for name in requested_environment_names_raw):
+        raise TestIdentityComponentError(
+            "environment allowlist contains a non-reviewed variable"
+        )
+    requested_environment_names = tuple(
+        sorted(set(requested_environment_names_raw))
+    )
+    if len(requested_environment_names) > len(ENVIRONMENT_VALUE_POLICIES):
+        raise TestIdentityComponentError("environment allowlist exceeds its bound")
+    if any(name not in ENVIRONMENT_VALUE_POLICIES for name in requested_environment_names):
+        raise TestIdentityComponentError(
+            "environment allowlist contains a non-reviewed variable"
+        )
+    environment_entries = []
+    for name in requested_environment_names:
+        if name in source_environment:
+            normalized = _validate_environment_value(name, source_environment[name])
+            value_cid = content_identity(
+                {
+                    "schema": "ipfs_accelerate_py/agent-supervisor/environment-value@1",
+                    "name": name,
+                    "state": "set",
+                    "value": normalized,
+                }
+            )
+            state = "set"
+        else:
+            value_cid = content_identity(
+                {
+                    "schema": "ipfs_accelerate_py/agent-supervisor/environment-value@1",
+                    "name": name,
+                    "state": "unset",
+                }
+            )
+            state = "unset"
+        environment_entries.append(
+            {"name": name, "state": state, "value_cid": value_cid}
+        )
+
+    interpreter = _allowlisted_fact_map(
+        _current_interpreter_facts()
+        if interpreter_facts is None
+        else interpreter_facts,
+        allowlist=INTERPRETER_FACT_ALLOWLIST,
+        field_name="interpreter_facts",
+    )
+    platform = _allowlisted_fact_map(
+        _current_platform_facts() if platform_facts is None else platform_facts,
+        allowlist=PLATFORM_FACT_ALLOWLIST,
+        field_name="platform_facts",
+    )
+    hardware = _allowlisted_fact_map(
+        _current_hardware_facts() if hardware_facts is None else hardware_facts,
+        allowlist=HARDWARE_FACT_ALLOWLIST,
+        field_name="hardware_facts",
+    )
+
+    capabilities = {} if capability_facts is None else _require_mapping(
+        capability_facts, field_name="capability_facts"
+    )
+    try:
+        allowed_capabilities_raw = tuple(capability_allowlist)
+    except TypeError as exc:
+        raise TestIdentityComponentError(
+            "capability allowlist must be an iterable of IDs"
+        ) from exc
+    if any(not isinstance(item, str) for item in allowed_capabilities_raw):
+        raise TestIdentityComponentError("capability allowlist ID is invalid")
+    allowed_capabilities = tuple(sorted(set(allowed_capabilities_raw)))
+    if len(allowed_capabilities) > MAX_RECORDS:
+        raise TestIdentityComponentError("capability allowlist exceeds its bound")
+    for capability_id in allowed_capabilities:
+        if not _CAPABILITY_ID_RE.fullmatch(capability_id):
+            raise TestIdentityComponentError("capability allowlist ID is invalid")
+    if set(capabilities).difference(allowed_capabilities):
+        raise TestIdentityComponentError(
+            "capability facts contain a non-allowlisted capability"
+        )
+    capability_entries = []
+    for capability_id in allowed_capabilities:
+        state = "present" if capability_id in capabilities else "absent"
+        payload: dict[str, Any] = {
+            "schema": "ipfs_accelerate_py/agent-supervisor/capability-value@1",
+            "capability_id": capability_id,
+            "state": state,
+        }
+        if capability_id in capabilities:
+            payload["facts"] = canonicalize_pytest_parameter(
+                capabilities[capability_id]
+            )
+        capability_entries.append(
+            {
+                "capability_id": capability_id,
+                "state": state,
+                "facts_cid": content_identity(payload),
+            }
+        )
+
+    return EnvironmentIdentity(
+        environment_cid=content_identity(
+            {
+                "schema": ENVIRONMENT_SCHEMA,
+                "kind": "environment",
+                "entries": environment_entries,
+            }
+        ),
+        interpreter_abi_cid=content_identity(
+            {
+                "schema": ENVIRONMENT_SCHEMA,
+                "kind": "interpreter_abi",
+                "facts": interpreter,
+            }
+        ),
+        platform_cid=content_identity(
+            {
+                "schema": ENVIRONMENT_SCHEMA,
+                "kind": "platform",
+                "facts": platform,
+            }
+        ),
+        hardware_capability_cid=content_identity(
+            {
+                "schema": ENVIRONMENT_SCHEMA,
+                "kind": "hardware_capabilities",
+                "hardware": hardware,
+                "capabilities": capability_entries,
+            }
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class TestIdentityComponents:
+    """Versioned component bundle consumed by ``TestExecutionKey@1``."""
+
+    __test__: ClassVar[bool] = False
+
+    parameter_cid: str
+    fixture_cids: tuple[str, ...]
+    conftest_closure_cid: str
+    hook_plugin_cids: tuple[str, ...]
+    dependency_lock_cid: str
+    installed_distributions_cid: str
+    environment_cid: str
+    platform_cid: str
+    interpreter_abi_cid: str
+    hardware_capability_cid: str
+    non_reusable_reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name in (
+            "parameter_cid",
+            "conftest_closure_cid",
+            "dependency_lock_cid",
+            "installed_distributions_cid",
+            "environment_cid",
+            "platform_cid",
+            "interpreter_abi_cid",
+            "hardware_capability_cid",
+        ):
+            _require_cid(getattr(self, name), field_name=name)
+        for name in ("fixture_cids", "hook_plugin_cids"):
+            values = tuple(sorted(set(getattr(self, name))))
+            if len(values) > MAX_RECORDS:
+                raise TestIdentityComponentError(f"{name} exceeds its record bound")
+            for value in values:
+                _require_cid(value, field_name=name)
+            object.__setattr__(self, name, values)
+        reasons = tuple(sorted({_reason(item) for item in self.non_reusable_reasons}))
+        object.__setattr__(self, "non_reusable_reasons", reasons)
+
+    @property
+    def reusable(self) -> bool:
+        return not self.non_reusable_reasons
+
+    @property
+    def component_root_cid(self) -> str:
+        return content_identity(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": TEST_IDENTITY_COMPONENTS_SCHEMA,
+            "interface": TEST_IDENTITY_COMPONENTS_INTERFACE,
+            "parameter_cid": self.parameter_cid,
+            "fixture_cids": list(self.fixture_cids),
+            "conftest_closure_cid": self.conftest_closure_cid,
+            "hook_plugin_cids": list(self.hook_plugin_cids),
+            "dependency_lock_cid": self.dependency_lock_cid,
+            "installed_distributions_cid": self.installed_distributions_cid,
+            "environment_cid": self.environment_cid,
+            "platform_cid": self.platform_cid,
+            "interpreter_abi_cid": self.interpreter_abi_cid,
+            "hardware_capability_cid": self.hardware_capability_cid,
+            "reusable": self.reusable,
+            "non_reusable_reasons": list(self.non_reusable_reasons),
+        }
+
     def execution_key_fields(self) -> dict[str, Any]:
-        """Fields merged into :meth:`TestExecutionIdentityCompiler.compile_execution_key`."""
+        """Return exactly the fields supplied to ``TestExecutionKey@1``."""
 
         return {
+            "parameter_source_cid": self.parameter_cid,
             "fixture_cids": self.fixture_cids,
             "conftest_closure_cid": self.conftest_closure_cid,
             "hook_plugin_cids": self.hook_plugin_cids,
@@ -352,15 +1196,124 @@ class TestIdentityComponents:
             "platform_cid": self.platform_cid,
             "interpreter_abi_cid": self.interpreter_abi_cid,
             "hardware_capability_cid": self.hardware_capability_cid,
-            "parameter_source_cid": self.parameter_source_cid,
-            "components": dict(self.components),
+            "components": {
+                "identity_components": self.component_root_cid,
+                "parameter": self.parameter_cid,
+            },
         }
 
+    @classmethod
+    def compile(
+        cls,
+        *,
+        parameter_value: Any = _NO_PARAMETER,
+        parameter_id: str = "",
+        fixtures: Iterable[Mapping[str, Any]] = (),
+        conftests: Iterable[Mapping[str, Any]] = (),
+        hooks: Iterable[Mapping[str, Any]] = (),
+        plugins: Iterable[Mapping[str, Any]] = (),
+        lock_files: Mapping[Any, Any] | Iterable[Mapping[str, Any]] = (),
+        installed_distributions: (
+            Mapping[str, str] | Iterable[tuple[str, str]]
+        ) = (),
+        environment: Mapping[str, str] | None = None,
+        environment_allowlist: Iterable[str] = DEFAULT_ENVIRONMENT_ALLOWLIST,
+        interpreter_facts: Mapping[str, Any] | None = None,
+        platform_facts: Mapping[str, Any] | None = None,
+        hardware_facts: Mapping[str, Any] | None = None,
+        capability_facts: Mapping[str, Any] | None = None,
+        capability_allowlist: Iterable[str] = (),
+    ) -> TestIdentityComponents:
+        """Compile every PTR-011 root, explicitly marking unsafe parameters."""
 
-__all__ = (
+        if not isinstance(parameter_id, str) or len(parameter_id) > 1_024:
+            raise TestIdentityComponentError("parameter_id must be bounded text")
+        reasons: tuple[str, ...] = ()
+        if parameter_value is _NO_PARAMETER:
+            parameter_payload: dict[str, Any] = {
+                "schema": PARAMETER_SCHEMA,
+                "parameter_id": parameter_id,
+                "value": {"type": "not_parameterized"},
+            }
+        else:
+            try:
+                canonical_parameter = canonicalize_pytest_parameter(parameter_value)
+            except UnsupportedPytestParameter as exc:
+                # Do not reflect repr(value) or exception details.  The exception
+                # itself contains only one of this module's bounded reason codes.
+                reasons = (_reason(str(exc)),)
+                canonical_parameter = {
+                    "type": "unsupported",
+                    "reason": reasons[0],
+                }
+            parameter_payload = {
+                "schema": PARAMETER_SCHEMA,
+                "parameter_id": parameter_id,
+                "value": canonical_parameter,
+            }
+
+        fixture_hook = collect_fixture_hook_identity(
+            fixtures=fixtures,
+            conftests=conftests,
+            hooks=hooks,
+            plugins=plugins,
+        )
+        dependency = collect_dependency_identity(
+            lock_files=lock_files,
+            installed_distributions=installed_distributions,
+        )
+        environment_identity = collect_environment_identity(
+            environment=environment,
+            environment_allowlist=environment_allowlist,
+            interpreter_facts=interpreter_facts,
+            platform_facts=platform_facts,
+            hardware_facts=hardware_facts,
+            capability_facts=capability_facts,
+            capability_allowlist=capability_allowlist,
+        )
+        reasons = tuple(
+            sorted(set(reasons).union(fixture_hook.non_reusable_reasons))
+        )
+        return cls(
+            parameter_cid=content_identity(parameter_payload),
+            fixture_cids=fixture_hook.fixture_cids,
+            conftest_closure_cid=fixture_hook.conftest_closure_cid,
+            hook_plugin_cids=fixture_hook.hook_plugin_cids,
+            dependency_lock_cid=dependency.dependency_lock_cid,
+            installed_distributions_cid=dependency.installed_distributions_cid,
+            environment_cid=environment_identity.environment_cid,
+            platform_cid=environment_identity.platform_cid,
+            interpreter_abi_cid=environment_identity.interpreter_abi_cid,
+            hardware_capability_cid=environment_identity.hardware_capability_cid,
+            non_reusable_reasons=reasons,
+        )
+
+
+def compile_test_identity_components(**kwargs: Any) -> TestIdentityComponents:
+    """Functional spelling for :meth:`TestIdentityComponents.compile`."""
+
+    return TestIdentityComponents.compile(**kwargs)
+
+
+__all__ = [
     "DEFAULT_ENVIRONMENT_ALLOWLIST",
+    "DEPENDENCY_SCHEMA",
+    "ENVIRONMENT_SCHEMA",
+    "ENVIRONMENT_VALUE_POLICIES",
+    "FIXTURE_SCHEMA",
+    "HOOK_PLUGIN_SCHEMA",
+    "PARAMETER_SCHEMA",
     "TEST_IDENTITY_COMPONENTS_INTERFACE",
     "TEST_IDENTITY_COMPONENTS_SCHEMA",
+    "DependencyIdentity",
+    "EnvironmentIdentity",
+    "FixtureHookIdentity",
+    "TestIdentityComponentError",
     "TestIdentityComponents",
+    "UnsupportedPytestParameter",
     "canonicalize_pytest_parameter",
-)
+    "collect_dependency_identity",
+    "collect_environment_identity",
+    "collect_fixture_hook_identity",
+    "compile_test_identity_components",
+]

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_runtime_dependency_trace.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_runtime_dependency_trace.py
@@ -1,165 +1,1254 @@
-"""Runtime dependency tracer for controlled preflight evidence (PTR-146 surface)."""
+"""Bounded, privacy-safe runtime dependency tracing for pytest (PTR-021).
+
+``RuntimeTestDependencyTrace@1`` is diagnostic evidence, not skip authority.
+It observes a deliberately small set of dependency/effect facts during a cold
+test execution and binds the observation policy, instrumentation identity, and
+all limits into one canonical ``ContentIdentity@1`` artifact.
+
+The implementation is fail-closed for reuse and fail-open for test execution:
+
+* unsupported, private, over-budget, concurrent, or unhealthy instrumentation
+  makes the trace incomplete;
+* audit/profile callbacks and every public recording method swallow their own
+  failures, so tracer failure cannot replace the test's outcome;
+* raw environment values, absolute/private paths, subprocess arguments,
+  arbitrary output, and exception text are never retained;
+* the process-wide audit hook is a small permanent dispatcher.  It is inactive
+  outside a tracing context and never raises into the audited operation.
+
+This module intentionally does not decide reuse eligibility.  PTR-022 composes
+this typed evidence with the static trace and policy.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+import hashlib
+import json
+import marshal
+import os
+import re
+import sys
+import threading
+import time
+import weakref
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from types import MappingProxyType, TracebackType
+from types import CodeType
 from typing import Any, ClassVar, Final
 
 from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    ContentIdentity,
     mint_content_identity,
 )
+from ipfs_accelerate_py.agent_supervisor.analysis.test_identity_components import (
+    DEFAULT_ENVIRONMENT_ALLOWLIST,
+    ENVIRONMENT_VALUE_POLICIES,
+)
+from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+    canonical_json_bytes,
+)
+from multiformats import CID
 
 RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE: Final = "RuntimeTestDependencyTrace@1"
 RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE: Final = "RuntimeTestDependencyTracer@1"
+RUNTIME_TRACE_INSTRUMENTATION_INTERFACE: Final = "RuntimeTraceInstrumentation@1"
+RUNTIME_TRACE_LIMITS_INTERFACE: Final = "RuntimeTraceLimits@1"
+
 RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA: Final = (
     "ipfs_accelerate_py/agent-supervisor/runtime-test-dependency-trace@1"
 )
+RUNTIME_TRACE_INSTRUMENTATION_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/runtime-trace-instrumentation@1"
+)
+RUNTIME_TRACE_LIMITS_SCHEMA: Final = "ipfs_accelerate_py/agent-supervisor/runtime-trace-limits@1"
+
+_ELIGIBILITY_PROFILES: Final = frozenset({"pure", "snapshot_bound", "repository_forest_bound"})
+_DEPENDENCY_KINDS: Final = (
+    "modules",
+    "code_objects",
+    "files",
+    "environment",
+    "subprocesses",
+    "services",
+    "policies",
+    "capabilities",
+)
+_IGNORED_NO_EFFECT_AUDIT_EVENTS: Final = frozenset({"object.__getattr__"})
+_CID_RE: Final = re.compile(r"^b[a-z2-7]{20,}$")
+_SAFE_NAME_RE: Final = re.compile(r"^[A-Za-z0-9_.:@/+ <>-]{1,256}$")
+_MAX_COUNTER: Final = (1 << 63) - 1
+_MISSING: Final = object()
 
 
-@dataclass(frozen=True, slots=True)
-class RuntimeTestDependencyTrace:
-    """Content-addressed runtime dependency evidence for one test invocation."""
+class RuntimeTraceError(ValueError):
+    """Invalid trace configuration or unavailable trace identity."""
+
+    __test__ = False
+
+
+class RuntimeTraceCompleteness(str, Enum):  # noqa: UP042 - project supports Python 3.8
+    """Closed completeness state consumed by later eligibility policy."""
+
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+
+    @property
+    def complete(self) -> bool:
+        return self is RuntimeTraceCompleteness.COMPLETE
+
+
+@dataclass(frozen=True)
+class RuntimeTraceLimits:
+    """Hard limits which are part of every runtime trace identity."""
 
     __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE
 
-    complete: bool
-    trace_cid: str
-    completeness_reasons: tuple[str, ...] = ()
-    retained_canonical_bytes: bytes = b""
-    eligibility_profile: str = "pure"
-    dependencies: Mapping[str, Any] = field(default_factory=dict)
+    max_events: int = 2_048
+    max_modules: int = 256
+    max_code_objects: int = 512
+    max_files: int = 256
+    max_environment: int = len(ENVIRONMENT_VALUE_POLICIES)
+    max_subprocesses: int = 64
+    max_services: int = 64
+    max_policies: int = 32
+    max_capabilities: int = 128
+    max_file_bytes: int = 8 * 1_048_576
+    max_trace_seconds: int = 900
+    max_text_chars: int = 512
 
-    def verify(self) -> None:
-        if not self.trace_cid:
-            raise ValueError("runtime trace is missing trace_cid")
-        if self.retained_canonical_bytes:
-            expected = mint_content_identity(
-                # Re-parse retained bytes through JSON identity mint path.
-                __import__("json").loads(
-                    self.retained_canonical_bytes.decode("utf-8")
-                )
-            )
-            if expected.cid != self.trace_cid:
-                raise ValueError("runtime trace CID does not match retained bytes")
+    _BOUNDS: ClassVar[Mapping[str, tuple[int, int]]] = {
+        "max_events": (1, 65_536),
+        "max_modules": (1, 4_096),
+        "max_code_objects": (1, 8_192),
+        "max_files": (1, 4_096),
+        "max_environment": (1, len(ENVIRONMENT_VALUE_POLICIES)),
+        "max_subprocesses": (1, 1_024),
+        "max_services": (1, 1_024),
+        "max_policies": (1, 256),
+        "max_capabilities": (1, 2_048),
+        "max_file_bytes": (1, 64 * 1_048_576),
+        "max_trace_seconds": (1, 7_200),
+        "max_text_chars": (32, 4_096),
+    }
+
+    def __post_init__(self) -> None:
+        for name, (minimum, maximum) in self._BOUNDS.items():
+            value = getattr(self, name)
+            if type(value) is not int or not minimum <= value <= maximum:
+                raise RuntimeTraceError(f"{name} must be an integer in [{minimum}, {maximum}]")
+
+    @property
+    def interface(self) -> str:
+        return RUNTIME_TRACE_LIMITS_INTERFACE
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
-            "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
-            "complete": self.complete,
-            "trace_cid": self.trace_cid,
-            "completeness_reasons": list(self.completeness_reasons),
-            "eligibility_profile": self.eligibility_profile,
-            "dependencies": dict(self.dependencies),
+            "schema": RUNTIME_TRACE_LIMITS_SCHEMA,
+            "interface": RUNTIME_TRACE_LIMITS_INTERFACE,
+            **{name: getattr(self, name) for name in sorted(self._BOUNDS)},
         }
 
 
-class RuntimeTestDependencyTracer:
-    """Context-managed runtime observer used for controlled preflight traces.
-
-    This production default records an empty pure profile when no impure
-    activity is observed.  Callers that need deeper instrumentation inject a
-    custom tracer factory through the lifecycle/plugin seam.
-    """
+@dataclass(frozen=True)
+class RuntimeTestDependencyTrace:
+    """Immutable canonical result of a bounded tracing session."""
 
     __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE
+
+    content_identity: ContentIdentity | None
+    retained_canonical_bytes: bytes
+    completeness: RuntimeTraceCompleteness
+    completeness_reasons: tuple[str, ...]
+    observed_event_count: int
+    recorded_fact_count: int
+    dropped_event_count: int
+
+    def __post_init__(self) -> None:
+        if type(self.retained_canonical_bytes) is not bytes:
+            raise RuntimeTraceError("retained_canonical_bytes must be exact bytes")
+        if self.content_identity is not None:
+            if self.retained_canonical_bytes != self.content_identity.canonical_bytes:
+                raise RuntimeTraceError("trace bytes do not match ContentIdentity")
+        if self.completeness.complete and self.completeness_reasons:
+            raise RuntimeTraceError("a complete trace cannot carry incomplete reasons")
+        for value in (
+            self.observed_event_count,
+            self.recorded_fact_count,
+            self.dropped_event_count,
+        ):
+            if type(value) is not int or value < 0 or value > _MAX_COUNTER:
+                raise RuntimeTraceError("trace counters must be bounded integers")
+
+    @property
+    def interface(self) -> str:
+        return RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA
+
+    @property
+    def complete(self) -> bool:
+        return self.completeness.complete
+
+    @property
+    def cid(self) -> str:
+        return self.content_identity.cid if self.content_identity is not None else ""
+
+    @property
+    def trace_cid(self) -> str:
+        return self.cid
+
+    @property
+    def root_cid(self) -> str:
+        return self.cid
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return self.retained_canonical_bytes
+
+    def to_dict(self) -> dict[str, Any]:
+        if not self.retained_canonical_bytes:
+            return {}
+        value = json.loads(self.retained_canonical_bytes.decode("utf-8"))
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise RuntimeTraceError("runtime trace canonical bytes are not an object")
+        return value
+
+    def verify(self) -> RuntimeTestDependencyTrace:
+        if self.content_identity is None:
+            raise RuntimeTraceError("runtime trace has no CID-capable identity")
+        self.content_identity.verify()
+        if canonical_json_bytes(self.to_dict()) != self.retained_canonical_bytes:
+            raise RuntimeTraceError("runtime trace bytes are not canonical")
+        return self
+
+
+_AUDIT_LOCK = threading.RLock()
+_ACTIVE_TRACERS: weakref.WeakSet[RuntimeTestDependencyTracer] = weakref.WeakSet()
+_AUDIT_HOOK_INSTALLED = False
+_AUDIT_HOOK_INSTALL_ATTEMPTED = False
+_AUDIT_INSTALL_PROBE_EVENT = "ipfs_accelerate_py.agent_supervisor.runtime_trace.audit_install_probe"
+_AUDIT_INSTALL_PROBE_TOKEN = object()
+_AUDIT_INSTALL_PROBE_ACKS = 0
+
+
+def _audit_dispatch(event: str, arguments: tuple[Any, ...]) -> None:
+    """Permanent process hook; must never raise into the audited operation."""
+
+    global _AUDIT_INSTALL_PROBE_ACKS
+    try:
+        if (
+            event == _AUDIT_INSTALL_PROBE_EVENT
+            and len(arguments) == 1
+            and arguments[0] is _AUDIT_INSTALL_PROBE_TOKEN
+        ):
+            with _AUDIT_LOCK:
+                _AUDIT_INSTALL_PROBE_ACKS += 1
+            return
+        with _AUDIT_LOCK:
+            active = tuple(_ACTIVE_TRACERS)
+        for tracer in active:
+            try:
+                tracer._observe_audit_event(event, arguments, synthetic=False)
+            except BaseException:
+                # An audit hook exception can alter the operation under test.
+                # This boundary therefore catches BaseException deliberately.
+                try:
+                    tracer._mark_internal_failure("audit_callback")
+                except BaseException:
+                    pass
+    except BaseException:
+        pass
+
+
+def _install_audit_dispatch() -> bool:
+    global _AUDIT_HOOK_INSTALLED, _AUDIT_HOOK_INSTALL_ATTEMPTED
+    with _AUDIT_LOCK:
+        if _AUDIT_HOOK_INSTALLED:
+            return True
+        if _AUDIT_HOOK_INSTALL_ATTEMPTED:
+            return False
+        _AUDIT_HOOK_INSTALL_ATTEMPTED = True
+        acknowledgements_before = _AUDIT_INSTALL_PROBE_ACKS
+        try:
+            sys.addaudithook(_audit_dispatch)
+            # CPython permits an existing hook to suppress ``addaudithook`` by
+            # raising RuntimeError without propagating it to this caller.
+            # Prove our dispatcher was actually registered before it can
+            # contribute complete trace authority.
+            sys.audit(
+                _AUDIT_INSTALL_PROBE_EVENT,
+                _AUDIT_INSTALL_PROBE_TOKEN,
+            )
+        except BaseException:
+            return False
+        if _AUDIT_INSTALL_PROBE_ACKS != acknowledgements_before + 1:
+            return False
+        _AUDIT_HOOK_INSTALLED = True
+        return True
+
+
+class RuntimeTestDependencyTracer:
+    """Observe bounded runtime facts without acquiring outcome authority.
+
+    ``allowed_roots`` maps public root identifiers to admitted filesystem roots.
+    Only relative paths beneath those roots can enter evidence.  If omitted,
+    filesystem observations are classified private and make the trace
+    incomplete.
+
+    Environment names must be a subset of the repository-wide reviewed
+    allowlist.  ``subprocess_allowlist`` maps executable basenames to stable,
+    public tool identities (normally CIDs).  Arguments are always reduced to a
+    digest and count; their text is never retained.
+    """
+
+    __test__ = False
 
     def __init__(
         self,
         *,
-        allowed_roots: Mapping[str, Any] | None = None,
-        capture_code_objects: bool = False,
+        limits: RuntimeTraceLimits | None = None,
+        allowed_roots: Mapping[str, os.PathLike[str] | str] | None = None,
+        environment_allowlist: Iterable[str] = DEFAULT_ENVIRONMENT_ALLOWLIST,
+        subprocess_allowlist: Mapping[str, str] | None = None,
+        eligibility_profile: str = "pure",
+        capture_code_objects: bool = True,
+        identity_minter: Callable[[Any], ContentIdentity] = mint_content_identity,
     ) -> None:
-        self.allowed_roots = {
-            str(key): Path(value)
-            for key, value in dict(allowed_roots or {}).items()
-        }
+        self.limits = limits or RuntimeTraceLimits()
+        if eligibility_profile not in _ELIGIBILITY_PROFILES:
+            raise RuntimeTraceError("eligibility_profile is not admitted")
+        self.eligibility_profile = eligibility_profile
         self.capture_code_objects = bool(capture_code_objects)
+        if not callable(identity_minter):
+            raise RuntimeTraceError("identity_minter must be callable")
+        self._identity_minter = identity_minter
+
+        requested_env = tuple(environment_allowlist)
+        if any(type(name) is not str for name in requested_env):
+            raise RuntimeTraceError("environment allowlist contains a non-string")
+        if any(name not in ENVIRONMENT_VALUE_POLICIES for name in requested_env):
+            raise RuntimeTraceError("environment allowlist contains a non-reviewed variable")
+        if len(set(requested_env)) > self.limits.max_environment:
+            raise RuntimeTraceError("environment allowlist exceeds trace limit")
+        self.environment_allowlist = frozenset(requested_env)
+
+        roots: list[tuple[str, Path]] = []
+        for root_id, raw_path in (allowed_roots or {}).items():
+            safe_root_id = self._checked_name(root_id, field="root identifier")
+            try:
+                resolved = Path(os.fspath(raw_path)).resolve(strict=True)
+            except (OSError, TypeError, ValueError) as exc:
+                raise RuntimeTraceError("allowed root is unavailable") from exc
+            if not resolved.is_dir():
+                raise RuntimeTraceError("allowed root must be a directory")
+            roots.append((safe_root_id, resolved))
+        if len({root_id for root_id, _ in roots}) != len(roots):
+            raise RuntimeTraceError("allowed root identifiers must be unique")
+        # Longest path first gives deterministic behavior for nested roots.
+        self._allowed_roots = tuple(sorted(roots, key=lambda item: (-len(item[1].parts), item[0])))
+
+        tools: dict[str, str] = {}
+        for executable, identity in (subprocess_allowlist or {}).items():
+            name = self._executable_name(executable)
+            tools[name] = self._checked_identity(identity, field="tool identity")
+        self._subprocess_allowlist = tools
+
+        self._lock = threading.RLock()
+        self._facts: dict[str, dict[bytes, dict[str, Any]]] = {
+            kind: {} for kind in _DEPENDENCY_KINDS
+        }
+        self._reasons: set[str] = set()
+        self._unsupported_kinds: set[str] = set()
+        self._private_kinds: set[str] = set()
+        self._internal_failure_kinds: set[str] = set()
+        self._observed_event_count = 0
+        self._dropped_event_count = 0
+        self._started = False
+        self._stopped = False
         self._active = False
+        self._start_monotonic = 0.0
+        self._audit_hook_healthy = False
+        self._profile_healthy = not self.capture_code_objects
+        self._profile_callback = self._profile_dispatch
+        self._previous_profile: Any = None
+        self._previous_thread_profile: Any = None
+        self._profile_installed = False
+        self._thread_profile_installed = False
+        self._inside_callback = threading.local()
+        self._instrumentation: dict[str, Any] = {}
+        self._instrumentation_cid = ""
         self._result: RuntimeTestDependencyTrace | None = None
-        self._events: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _checked_name(value: Any, *, field: str) -> str:
+        if type(value) is not str or not _SAFE_NAME_RE.fullmatch(value):
+            raise RuntimeTraceError(f"{field} is not a bounded public name")
+        return value
+
+    @staticmethod
+    def _checked_identity(value: Any, *, field: str) -> str:
+        if type(value) is not str or not _CID_RE.fullmatch(value):
+            raise RuntimeTraceError(f"{field} must be a canonical CIDv1/base32 identity")
+        try:
+            parsed = CID.decode(value)
+        except Exception as exc:
+            raise RuntimeTraceError(f"{field} must be a canonical CIDv1/base32 identity") from exc
+        if (
+            str(parsed) != value
+            or parsed.version != 1
+            or parsed.base.name != "base32"
+            or parsed.codec.name not in {"dag-json", "raw"}
+            or parsed.hashfun.name != "sha2-256"
+            or len(parsed.raw_digest) != 32
+        ):
+            raise RuntimeTraceError(f"{field} must use CIDv1/base32/(dag-json|raw)/sha2-256")
+        return value
+
+    @staticmethod
+    def _executable_name(value: Any) -> str:
+        if type(value) is not str or not value or "\x00" in value:
+            raise RuntimeTraceError("executable must be bounded text")
+        name = value.replace("\\", "/").rsplit("/", 1)[-1]
+        if not _SAFE_NAME_RE.fullmatch(name):
+            raise RuntimeTraceError("executable basename is not a public name")
+        return name
 
     @property
     def result(self) -> RuntimeTestDependencyTrace | None:
         return self._result
 
-    def __enter__(self) -> "RuntimeTestDependencyTracer":
-        self._active = True
-        self._events = []
-        self._result = None
-        return self
+    @property
+    def trace(self) -> RuntimeTestDependencyTrace | None:
+        return self._result
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: TracebackType | None,
-    ) -> bool:
-        del tb
-        self._active = False
-        reasons: list[str] = []
-        if exc_type is not None:
-            reasons.append(f"preflight_exception:{exc_type.__name__}")
-        profile = "pure"
-        deps = {
-            "services": [],
-            "capabilities": [],
-            "subprocesses": [],
-            "environment": [],
-            "policies": [],
-            "events": list(self._events),
-            "allowed_roots": {
-                key: str(path) for key, path in self.allowed_roots.items()
-            },
-            "capture_code_objects": self.capture_code_objects,
-        }
-        payload = {
-            "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
-            "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
-            "eligibility_profile": profile,
-            "completeness_reasons": reasons,
-            "dependencies": deps,
-        }
+    def __enter__(self) -> RuntimeTestDependencyTracer:
+        return self.start()
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+        del exc_type, exc, traceback
         try:
-            identity = mint_content_identity(payload)
-            complete = not reasons
-            self._result = RuntimeTestDependencyTrace(
-                complete=complete,
-                trace_cid=identity.cid,
-                completeness_reasons=tuple(reasons),
-                retained_canonical_bytes=identity.canonical_bytes,
-                eligibility_profile=profile,
-                dependencies=MappingProxyType(deps),
-            )
-        except Exception as mint_exc:
-            reasons.append(f"runtime_trace_mint_failed:{type(mint_exc).__name__}")
-            self._result = RuntimeTestDependencyTrace(
-                complete=False,
-                trace_cid="",
-                completeness_reasons=tuple(reasons),
-                eligibility_profile="unknown",
-                dependencies=MappingProxyType(deps),
-            )
-        # Never suppress the original exception.
+            self.stop()
+        except BaseException:
+            # Never suppress or replace an exception from the test body.
+            pass
         return False
 
-    def note(self, event: Mapping[str, Any]) -> None:
-        """Optional observer hook for injected instrumentation."""
+    def start(self) -> RuntimeTestDependencyTracer:
+        """Activate observation.  Instrumentation failure is evidence, not an error."""
 
-        if not self._active:
+        with self._lock:
+            if self._started:
+                self._mark_unsupported("invalid_lifecycle")
+                return self
+            self._started = True
+            self._active = True
+            self._start_monotonic = time.monotonic()
+        try:
+            self._build_instrumentation_identity()
+        except BaseException:
+            self._mark_internal_failure("instrumentation_identity")
+
+        self._audit_hook_healthy = _install_audit_dispatch()
+        if not self._audit_hook_healthy:
+            self._mark_internal_failure("audit_hook_install")
+        with _AUDIT_LOCK:
+            existing = tuple(_ACTIVE_TRACERS)
+            if existing:
+                self._mark_unsupported("concurrent_trace")
+                for tracer in existing:
+                    tracer._mark_unsupported("concurrent_trace")
+            _ACTIVE_TRACERS.add(self)
+
+        if self.capture_code_objects:
+            self._install_profile()
+        return self
+
+    def stop(self) -> RuntimeTestDependencyTrace:
+        """Stop observation and return canonical evidence; this method never raises."""
+
+        with self._lock:
+            if self._result is not None:
+                return self._result
+            if not self._started:
+                self._started = True
+                self._mark_unsupported("not_started")
+            self._active = False
+            self._stopped = True
+        with _AUDIT_LOCK:
+            _ACTIVE_TRACERS.discard(self)
+        self._restore_profile()
+        try:
+            if self._start_monotonic:
+                elapsed = time.monotonic() - self._start_monotonic
+                if elapsed > self.limits.max_trace_seconds:
+                    self._mark_overflow("duration")
+            result = self._build_result()
+        except BaseException:
+            self._mark_internal_failure("result_build")
+            result = self._build_fallback_result()
+        with self._lock:
+            self._result = result
+        return result
+
+    finish = stop
+
+    def _install_profile(self) -> None:
+        try:
+            self._previous_profile = sys.getprofile()
+            get_thread_profile = getattr(threading, "getprofile", lambda: None)
+            self._previous_thread_profile = get_thread_profile()
+            if self._previous_profile is not None or self._previous_thread_profile is not None:
+                self._mark_unsupported("preexisting_profiler")
+                return
+            self._inside_callback.active = True
+            try:
+                sys.setprofile(self._profile_callback)
+                self._profile_installed = True
+                threading.setprofile(self._profile_callback)
+                self._thread_profile_installed = True
+                self._profile_healthy = True
+            finally:
+                self._inside_callback.active = False
+        except BaseException:
+            self._profile_healthy = False
+            self._mark_internal_failure("profile_install")
+
+    def _restore_profile(self) -> None:
+        try:
+            self._inside_callback.active = True
+            try:
+                if self._profile_installed and sys.getprofile() is self._profile_callback:
+                    sys.setprofile(self._previous_profile)
+                if self._thread_profile_installed:
+                    get_thread_profile = getattr(threading, "getprofile", lambda: None)
+                    if get_thread_profile() is self._profile_callback:
+                        threading.setprofile(self._previous_thread_profile)
+            finally:
+                self._inside_callback.active = False
+        except BaseException:
+            self._profile_healthy = False
+            self._mark_internal_failure("profile_restore")
+
+    def _profile_dispatch(self, frame: Any, event: str, argument: Any) -> None:
+        del argument
+        try:
+            if event != "call" or not self._active:
+                return
+            if getattr(self._inside_callback, "active", False):
+                return
+            self._inside_callback.active = True
+            try:
+                code = frame.f_code
+                if isinstance(code, CodeType) and Path(code.co_filename) != Path(__file__):
+                    self._record_code_object(code, frame.f_globals.get("__name__", ""))
+            finally:
+                self._inside_callback.active = False
+        except BaseException:
+            try:
+                self._mark_internal_failure("profile_callback")
+            except BaseException:
+                pass
+
+    def _build_instrumentation_identity(self) -> None:
+        source_digest = "unavailable"
+        try:
+            hasher = hashlib.sha256()
+            with open(__file__, "rb") as source:
+                while True:
+                    chunk = source.read(128 * 1_024)
+                    if not chunk:
+                        break
+                    hasher.update(chunk)
+            source_digest = hasher.hexdigest()
+        except (OSError, ValueError):
+            self._mark_internal_failure("instrumentation_source")
+        self._instrumentation = {
+            "schema": RUNTIME_TRACE_INSTRUMENTATION_SCHEMA,
+            "interface": RUNTIME_TRACE_INSTRUMENTATION_INTERFACE,
+            "tracer_interface": RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE,
+            "implementation": "cpython-audit-profile-explicit-adapters",
+            "implementation_source_sha256": source_digest,
+            "python_implementation": sys.implementation.name,
+            "python_version": ".".join(str(value) for value in sys.version_info[:3]),
+            "python_cache_tag": sys.implementation.cache_tag or "",
+            "audit_schema": "cpython-audit-events@1",
+            "ignored_no_effect_audit_events": sorted(_IGNORED_NO_EFFECT_AUDIT_EVENTS),
+            "profile_schema": "python-call-code-objects@1",
+            "adapter_schema": "ptr-runtime-explicit-adapters@1",
+            "captures_code_objects": self.capture_code_objects,
+        }
+        self._instrumentation_cid = self._mint_internal_identity(self._instrumentation).cid
+
+    def _mint_internal_identity(self, value: Any) -> ContentIdentity:
+        """Mint tracer-owned evidence without observing the minter itself."""
+
+        previous_guard = getattr(self._inside_callback, "active", False)
+        self._inside_callback.active = True
+        try:
+            expected_canonical_bytes = canonical_json_bytes(value)
+            identity = self._identity_minter(value)
+            if not isinstance(identity, ContentIdentity):
+                raise RuntimeTraceError("identity provider did not return ContentIdentity")
+            identity.verify()
+            if identity.canonical_bytes != expected_canonical_bytes:
+                raise RuntimeTraceError("identity provider canonical bytes do not match input")
+            return identity
+        finally:
+            self._inside_callback.active = previous_guard
+
+    def _increment(self, attribute: str) -> None:
+        with self._lock:
+            value = getattr(self, attribute)
+            setattr(self, attribute, min(_MAX_COUNTER, value + 1))
+
+    def _mark_unsupported(self, kind: str) -> None:
+        with self._lock:
+            self._reasons.add("unsupported_event")
+            self._unsupported_kinds.add(kind)
+
+    def _mark_private(self, kind: str) -> None:
+        with self._lock:
+            self._reasons.add("private_event")
+            self._private_kinds.add(kind)
+
+    def _mark_overflow(self, kind: str) -> None:
+        with self._lock:
+            self._reasons.add("overflow")
+            self._unsupported_kinds.add(f"overflow:{kind}")
+
+    def _mark_internal_failure(self, kind: str) -> None:
+        with self._lock:
+            self._reasons.add("instrumentation_failure")
+            self._internal_failure_kinds.add(kind)
+
+    def _category_limit(self, category: str) -> int:
+        return getattr(self.limits, f"max_{category}")
+
+    def _accept_fact(self, category: str, fact: dict[str, Any]) -> bool:
+        try:
+            encoded = canonical_json_bytes(fact)
+            if len(encoded) > self.limits.max_text_chars * 8:
+                self._mark_overflow("fact_bytes")
+                self._increment("_dropped_event_count")
+                return False
+            with self._lock:
+                self._increment("_observed_event_count")
+                if self._observed_event_count > self.limits.max_events:
+                    self._mark_overflow("events")
+                    self._increment("_dropped_event_count")
+                    return False
+                bucket = self._facts[category]
+                if encoded in bucket:
+                    return True
+                if len(bucket) >= self._category_limit(category):
+                    self._mark_overflow(category)
+                    self._increment("_dropped_event_count")
+                    return False
+                bucket[encoded] = fact
+            return True
+        except BaseException:
+            self._mark_internal_failure("record_fact")
+            return False
+
+    def _root_relative_path(
+        self, raw_path: Any, *, mark_private: bool = True
+    ) -> tuple[str, Path, str] | None:
+        if not isinstance(raw_path, (str, bytes, os.PathLike)):
+            if mark_private:
+                self._mark_private("file_path")
+            return None
+        try:
+            path = Path(os.fsdecode(os.fspath(raw_path)))
+            lexical = Path(os.path.abspath(path))
+        except (OSError, TypeError, ValueError):
+            if mark_private:
+                self._mark_private("file_path")
+            return None
+        for root_id, root in self._allowed_roots:
+            try:
+                relative = lexical.relative_to(root)
+            except ValueError:
+                continue
+            if not relative.parts:
+                self._mark_unsupported("directory_read")
+                return None
+            probe = root
+            try:
+                for part in relative.parts:
+                    probe = probe / part
+                    if probe.is_symlink():
+                        self._mark_private("symlink")
+                        return None
+                resolved = lexical.resolve(strict=True)
+                resolved.relative_to(root)
+            except (OSError, RuntimeError, ValueError):
+                self._mark_private("path_escape")
+                return None
+            relative_text = relative.as_posix()
+            if len(relative_text) > self.limits.max_text_chars or any(
+                ord(char) < 32 for char in relative_text
+            ):
+                self._mark_private("file_path")
+                return None
+            return root_id, resolved, relative_text
+        if mark_private:
+            self._mark_private("file_path")
+        return None
+
+    def _file_fact(self, raw_path: Any) -> dict[str, Any] | None:
+        located = self._root_relative_path(raw_path)
+        if located is None:
+            return None
+        root_id, resolved, relative = located
+        try:
+            stat_before = resolved.stat()
+            if not resolved.is_file():
+                self._mark_unsupported("non_regular_file")
+                return None
+            if stat_before.st_size > self.limits.max_file_bytes:
+                self._mark_overflow("file_bytes")
+                return None
+            hasher = hashlib.sha256()
+            count = 0
+            previous_guard = getattr(self._inside_callback, "active", False)
+            self._inside_callback.active = True
+            try:
+                with open(resolved, "rb") as stream:
+                    while True:
+                        chunk = stream.read(128 * 1_024)
+                        if not chunk:
+                            break
+                        count += len(chunk)
+                        if count > self.limits.max_file_bytes:
+                            self._mark_overflow("file_bytes")
+                            return None
+                        hasher.update(chunk)
+            finally:
+                self._inside_callback.active = previous_guard
+            stat_after = resolved.stat()
+            if (
+                count != stat_before.st_size
+                or stat_before.st_size != stat_after.st_size
+                or stat_before.st_mtime_ns != stat_after.st_mtime_ns
+            ):
+                self._mark_unsupported("file_changed_during_trace")
+                return None
+            return {
+                "root_id": root_id,
+                "path": relative,
+                "size_bytes": count,
+                "content_sha256": hasher.hexdigest(),
+            }
+        except (OSError, ValueError):
+            self._mark_unsupported("file_unavailable")
+            return None
+        except BaseException:
+            self._mark_internal_failure("file_identity")
+            return None
+
+    def record_file_read(self, path: os.PathLike[str] | str) -> bool:
+        """Record an admitted file read without retaining an absolute path."""
+
+        try:
+            fact = self._file_fact(path)
+            return fact is not None and self._accept_fact("files", fact)
+        except BaseException:
+            self._mark_internal_failure("record_file")
+            return False
+
+    def _record_code_object(self, code: CodeType, module: Any = "") -> bool:
+        located = self._root_relative_path(code.co_filename, mark_private=False)
+        if located is None:
+            # Profiles see framework/stdlib code too.  Those paths are already
+            # bound by interpreter/dependency identities and are ignored here;
+            # only code claimed to be in-scope is recorded as a code object.
+            return False
+        root_id, _resolved, relative = located
+        try:
+            module_name = module if type(module) is str else ""
+            if module_name and not _SAFE_NAME_RE.fullmatch(module_name):
+                module_name = ""
+            qualname = getattr(code, "co_qualname", code.co_name)
+            if type(qualname) is not str or not _SAFE_NAME_RE.fullmatch(qualname):
+                self._mark_private("code_name")
+                return False
+            # ``co_filename`` is often absolute.  Replace it before hashing so
+            # the code identity is stable across checkout locations and cannot
+            # act as a digest oracle for a private host path.  CPython audits
+            # both code replacement and marshaling; suppress those events from
+            # our own hook so instrumentation cannot observe itself.
+            previous_guard = getattr(self._inside_callback, "active", False)
+            self._inside_callback.active = True
+            try:
+                normalized_code = code.replace(co_filename=relative)
+                digest = hashlib.sha256(marshal.dumps(normalized_code)).hexdigest()
+            finally:
+                self._inside_callback.active = previous_guard
+            return self._accept_fact(
+                "code_objects",
+                {
+                    "root_id": root_id,
+                    "path": relative,
+                    "module": module_name,
+                    "qualname": qualname,
+                    "first_line": max(0, int(code.co_firstlineno)),
+                    "code_sha256": digest,
+                },
+            )
+        except BaseException:
+            self._mark_internal_failure("code_identity")
+            return False
+
+    def record_code_object(self, code: CodeType, module: str = "") -> bool:
+        try:
+            if not isinstance(code, CodeType):
+                self._mark_unsupported("invalid_code_object")
+                return False
+            return self._record_code_object(code, module)
+        except BaseException:
+            self._mark_internal_failure("record_code")
+            return False
+
+    def record_module(
+        self,
+        name: str,
+        *,
+        source_path: os.PathLike[str] | str | None = None,
+        native: bool = False,
+    ) -> bool:
+        try:
+            safe_name = self._checked_name(name, field="module name")
+            fact: dict[str, Any] = {"name": safe_name, "kind": "python"}
+            if native:
+                fact["kind"] = "native"
+                self._mark_unsupported("native_module")
+            if source_path is not None:
+                source = self._file_fact(source_path)
+                if source is None:
+                    return False
+                fact.update(
+                    {
+                        "root_id": source["root_id"],
+                        "path": source["path"],
+                        "source_sha256": source["content_sha256"],
+                    }
+                )
+            return self._accept_fact("modules", fact)
+        except RuntimeTraceError:
+            self._mark_private("module_name")
+            return False
+        except BaseException:
+            self._mark_internal_failure("record_module")
+            return False
+
+    def record_environment_read(self, name: str, value: Any = _MISSING) -> bool:
+        """Bind a reviewed environment read while retaining no raw value."""
+
+        try:
+            if type(name) is not str or name not in self.environment_allowlist:
+                self._mark_private("environment")
+                return False
+            raw = os.environ.get(name) if value is _MISSING else value
+            if raw is not None and type(raw) is not str:
+                self._mark_private("environment")
+                return False
+            value_identity = self._mint_internal_identity(
+                {
+                    "schema": "ipfs_accelerate_py/agent-supervisor/runtime-environment-value@1",
+                    "name": name,
+                    "present": raw is not None,
+                    "value": raw if raw is not None else "",
+                }
+            ).cid
+            return self._accept_fact("environment", {"name": name, "value_cid": value_identity})
+        except BaseException:
+            self._mark_internal_failure("record_environment")
+            return False
+
+    def getenv(self, name: str, default: Any = None) -> Any:
+        """Outcome-transparent ``os.getenv`` adapter with observation."""
+
+        value = os.getenv(name, default)
+        try:
+            self.record_environment_read(name, value)
+        except BaseException:
+            pass
+        return value
+
+    @staticmethod
+    def _argument_digest(arguments: Any) -> tuple[int, str] | None:
+        if isinstance(arguments, (str, bytes, os.PathLike)):
+            items: Sequence[Any] = (arguments,)
+        elif isinstance(arguments, (tuple, list)):
+            items = arguments
+        else:
+            return None
+        if len(items) > 4_096:
+            return None
+        hasher = hashlib.sha256()
+        for item in items:
+            try:
+                raw = os.fspath(item) if isinstance(item, os.PathLike) else item
+            except (TypeError, ValueError, OSError):
+                return None
+            if isinstance(raw, str):
+                encoded = raw.encode("utf-8", "surrogatepass")
+                tag = b"s"
+            elif isinstance(raw, bytes):
+                encoded = raw
+                tag = b"b"
+            else:
+                return None
+            hasher.update(tag)
+            hasher.update(len(encoded).to_bytes(8, "big"))
+            hasher.update(encoded)
+        return len(items), hasher.hexdigest()
+
+    def record_subprocess(
+        self,
+        executable: str,
+        arguments: Any = (),
+        *,
+        tool_identity: str | None = None,
+    ) -> bool:
+        """Record a tool invocation, never raw arguments, cwd, env, or output."""
+
+        try:
+            name = self._executable_name(executable)
+            argument_identity = self._argument_digest(arguments)
+            if argument_identity is None:
+                self._mark_private("subprocess_arguments")
+                return False
+            count, digest = argument_identity
+            expected_identity = self._subprocess_allowlist.get(name)
+            identity = (
+                expected_identity
+                if tool_identity is None
+                else self._checked_identity(tool_identity, field="tool identity")
+            )
+            if expected_identity is None or identity != expected_identity:
+                self._mark_unsupported("subprocess_tool")
+            return self._accept_fact(
+                "subprocesses",
+                {
+                    "executable": name,
+                    "argument_count": count,
+                    "arguments_sha256": digest,
+                    "tool_identity": identity or "unadmitted",
+                },
+            )
+        except RuntimeTraceError:
+            self._mark_private("subprocess")
+            return False
+        except BaseException:
+            self._mark_internal_failure("record_subprocess")
+            return False
+
+    def record_service(
+        self, service: str, *, adapter_identity: str, snapshot_identity: str
+    ) -> bool:
+        try:
+            return self._accept_fact(
+                "services",
+                {
+                    "service": self._checked_name(service, field="service name"),
+                    "adapter_identity": self._checked_identity(
+                        adapter_identity, field="adapter identity"
+                    ),
+                    "snapshot_identity": self._checked_identity(
+                        snapshot_identity, field="snapshot identity"
+                    ),
+                },
+            )
+        except RuntimeTraceError:
+            self._mark_unsupported("service_adapter")
+            return False
+        except BaseException:
+            self._mark_internal_failure("record_service")
+            return False
+
+    def record_policy(self, kind: str, policy_identity: str) -> bool:
+        try:
+            safe_kind = self._checked_name(kind, field="policy kind")
+            if safe_kind not in {"clock", "randomness"}:
+                self._mark_unsupported("policy_kind")
+                return False
+            return self._accept_fact(
+                "policies",
+                {
+                    "kind": safe_kind,
+                    "policy_identity": self._checked_identity(
+                        policy_identity, field="policy identity"
+                    ),
+                },
+            )
+        except RuntimeTraceError:
+            self._mark_unsupported("policy_identity")
+            return False
+        except BaseException:
+            self._mark_internal_failure("record_policy")
+            return False
+
+    def record_randomness_policy(self, policy_identity: str) -> bool:
+        return self.record_policy("randomness", policy_identity)
+
+    def record_clock_policy(self, policy_identity: str) -> bool:
+        return self.record_policy("clock", policy_identity)
+
+    def record_capability(
+        self, capability: str, *, adapter_identity: str, state_identity: str
+    ) -> bool:
+        try:
+            return self._accept_fact(
+                "capabilities",
+                {
+                    "capability": self._checked_name(capability, field="capability name"),
+                    "adapter_identity": self._checked_identity(
+                        adapter_identity, field="adapter identity"
+                    ),
+                    "state_identity": self._checked_identity(
+                        state_identity, field="state identity"
+                    ),
+                },
+            )
+        except RuntimeTraceError:
+            self._mark_unsupported("capability_adapter")
+            return False
+        except BaseException:
+            self._mark_internal_failure("record_capability")
+            return False
+
+    record_hardware_capability = record_capability
+
+    def record_unsupported_event(self, kind: str = "explicit") -> bool:
+        del kind  # Attacker-controlled event labels are never retained.
+        self._mark_unsupported("explicit")
+        return False
+
+    def record_private_event(self, kind: str = "explicit") -> bool:
+        del kind
+        self._mark_private("explicit")
+        return False
+
+    def observe_audit_event(self, event: str, arguments: tuple[Any, ...] = ()) -> None:
+        """Test/adapter entry point with unsupported-event fail-closed behavior."""
+
+        try:
+            self._observe_audit_event(event, arguments, synthetic=True)
+        except BaseException:
+            self._mark_internal_failure("observe_audit")
+
+    def _observe_audit_event(self, event: Any, arguments: Any, *, synthetic: bool) -> None:
+        del synthetic
+        if not self._active or getattr(self._inside_callback, "active", False):
             return
-        if isinstance(event, Mapping) and len(self._events) < 256:
-            self._events.append(dict(event))
+        self._inside_callback.active = True
+        try:
+            if type(event) is not str or type(arguments) is not tuple:
+                self._mark_unsupported("malformed_audit_event")
+                return
+            if event == "open":
+                path = arguments[0] if arguments else None
+                mode = arguments[1] if len(arguments) > 1 else "r"
+                flags = arguments[2] if len(arguments) > 2 else 0
+                writes = False
+                if isinstance(mode, str):
+                    writes = any(marker in mode for marker in ("w", "a", "+", "x"))
+                elif isinstance(flags, int):
+                    writes = (flags & os.O_ACCMODE) != os.O_RDONLY
+                if writes:
+                    self._mark_unsupported("file_write")
+                else:
+                    self.record_file_read(path)
+                return
+            if event == "import":
+                name = arguments[0] if arguments else ""
+                filename = arguments[1] if len(arguments) > 1 else None
+                native = isinstance(filename, str) and filename.lower().endswith(
+                    (".so", ".pyd", ".dll", ".dylib")
+                )
+                if isinstance(filename, str) and filename:
+                    self.record_module(name, source_path=filename, native=native)
+                elif type(name) is str:
+                    # The initial import-search audit event has no origin yet.
+                    self.record_module(name)
+                else:
+                    self._mark_unsupported("malformed_import")
+                return
+            if event == "subprocess.Popen":
+                executable = arguments[0] if arguments else ""
+                argv = arguments[1] if len(arguments) > 1 else ()
+                self.record_subprocess(executable, argv)
+                return
+            if event == "exec" and arguments and isinstance(arguments[0], CodeType):
+                self._record_code_object(arguments[0])
+                return
+
+            if event.startswith("socket."):
+                self._mark_unsupported("network")
+                return
+            if event.startswith("ctypes."):
+                self._mark_unsupported("native_code")
+                return
+            if event in {"os.system", "os.posix_spawn", "os.posix_spawnp"} or event.startswith(
+                "os.exec"
+            ):
+                self._mark_unsupported("process")
+                return
+            if event in {
+                "os.listdir",
+                "os.scandir",
+                "os.remove",
+                "os.rename",
+                "os.rmdir",
+                "os.mkdir",
+                "os.chdir",
+                "builtins.input",
+            }:
+                self._mark_unsupported("filesystem_effect")
+                return
+            if event in _IGNORED_NO_EFFECT_AUDIT_EVENTS:
+                return
+            # Completeness is closed: an audit event outside the explicitly
+            # supported vocabulary cannot be silently treated as irrelevant.
+            self._mark_unsupported("unknown_audit_event")
+        finally:
+            self._inside_callback.active = False
+
+    def _dependencies_dict(self) -> dict[str, list[dict[str, Any]]]:
+        with self._lock:
+            return {
+                kind: [self._facts[kind][key] for key in sorted(self._facts[kind])]
+                for kind in _DEPENDENCY_KINDS
+            }
+
+    def _payload(self) -> dict[str, Any]:
+        reasons = set(self._reasons)
+        if not self._audit_hook_healthy:
+            reasons.add("instrumentation_failure")
+        if self.capture_code_objects and not self._profile_healthy:
+            reasons.add("instrumentation_failure")
+        if not self._instrumentation_cid:
+            reasons.add("instrumentation_failure")
+        dependencies = self._dependencies_dict()
+        recorded = sum(len(items) for items in dependencies.values())
+        completeness = (
+            RuntimeTraceCompleteness.COMPLETE
+            if not reasons
+            else RuntimeTraceCompleteness.INCOMPLETE
+        )
+        return {
+            "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
+            "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
+            "eligibility_profile": self.eligibility_profile,
+            "completeness": {
+                "status": completeness.value,
+                "complete": completeness.complete,
+                "reasons": sorted(reasons),
+            },
+            "instrumentation": self._instrumentation,
+            "instrumentation_cid": self._instrumentation_cid,
+            "limits": self.limits.to_dict(),
+            "dependencies": dependencies,
+            "health": {
+                "audit_hook_healthy": self._audit_hook_healthy,
+                "profile_healthy": self._profile_healthy,
+                "started": self._started,
+                "stopped": self._stopped,
+                "observed_event_count": self._observed_event_count,
+                "recorded_fact_count": recorded,
+                "dropped_event_count": self._dropped_event_count,
+                "unsupported_event_kinds": sorted(self._unsupported_kinds),
+                "private_event_kinds": sorted(self._private_kinds),
+                "internal_failure_kinds": sorted(self._internal_failure_kinds),
+            },
+        }
+
+    def _build_result(self) -> RuntimeTestDependencyTrace:
+        payload = self._payload()
+        identity = self._mint_internal_identity(payload)
+        canonical = identity.canonical_bytes
+        status = RuntimeTraceCompleteness(payload["completeness"]["status"])
+        return RuntimeTestDependencyTrace(
+            content_identity=identity,
+            retained_canonical_bytes=canonical,
+            completeness=status,
+            completeness_reasons=tuple(payload["completeness"]["reasons"]),
+            observed_event_count=payload["health"]["observed_event_count"],
+            recorded_fact_count=payload["health"]["recorded_fact_count"],
+            dropped_event_count=payload["health"]["dropped_event_count"],
+        )
+
+    def _build_fallback_result(self) -> RuntimeTestDependencyTrace:
+        try:
+            payload = self._payload()
+            payload["completeness"] = {
+                "status": RuntimeTraceCompleteness.INCOMPLETE.value,
+                "complete": False,
+                "reasons": sorted(
+                    set(payload["completeness"]["reasons"]) | {"instrumentation_failure"}
+                ),
+            }
+            canonical = canonical_json_bytes(payload)
+        except BaseException:
+            payload = {
+                "schema": RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
+                "interface": RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
+                "completeness": {
+                    "status": "incomplete",
+                    "complete": False,
+                    "reasons": ["instrumentation_failure"],
+                },
+            }
+            canonical = canonical_json_bytes(payload)
+        return RuntimeTestDependencyTrace(
+            content_identity=None,
+            retained_canonical_bytes=canonical,
+            completeness=RuntimeTraceCompleteness.INCOMPLETE,
+            completeness_reasons=tuple(payload["completeness"]["reasons"]),
+            observed_event_count=min(_MAX_COUNTER, self._observed_event_count),
+            recorded_fact_count=0,
+            dropped_event_count=min(_MAX_COUNTER, self._dropped_event_count),
+        )
 
 
-__all__ = (
+def trace_runtime_dependencies(
+    operation: Callable[..., Any],
+    *args: Any,
+    tracer: RuntimeTestDependencyTracer | None = None,
+    **kwargs: Any,
+) -> tuple[Any, RuntimeTestDependencyTrace]:
+    """Run ``operation`` and return its value plus trace.
+
+    Exceptions from ``operation`` propagate unchanged after tracing is stopped;
+    callers creating pass receipts use this helper only for successful runs.
+    """
+
+    active = tracer or RuntimeTestDependencyTracer()
+    active.start()
+    try:
+        value = operation(*args, **kwargs)
+    finally:
+        result = active.stop()
+    return value, result
+
+
+__all__ = [
     "RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE",
     "RUNTIME_TEST_DEPENDENCY_TRACER_INTERFACE",
+    "RUNTIME_TRACE_INSTRUMENTATION_INTERFACE",
+    "RUNTIME_TRACE_LIMITS_INTERFACE",
+    "RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA",
+    "RUNTIME_TRACE_INSTRUMENTATION_SCHEMA",
+    "RUNTIME_TRACE_LIMITS_SCHEMA",
+    "RuntimeTraceCompleteness",
+    "RuntimeTraceError",
+    "RuntimeTraceLimits",
     "RuntimeTestDependencyTrace",
     "RuntimeTestDependencyTracer",
-)
+    "trace_runtime_dependencies",
+]

--- a/ipfs_accelerate_py/agent_supervisor/analysis/test_static_dependency_trace.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/test_static_dependency_trace.py
@@ -1,284 +1,1387 @@
-"""Static dependency tracing over analysis AST indexes (PTR-020 surface)."""
+"""Deterministic, bounded static dependency tracing for pytest (PTR-020).
+
+``StaticTestDependencyTrace@1`` is compact evidence derived from an
+``AnalysisASTIndex`` and the exact source files represented by that index.  It
+is deliberately fail-closed: a construct which cannot be resolved without
+executing user code is retained as an :class:`UnknownDependencyFrontier`.
+
+Source is read only while parsing.  Trace rows contain repository-relative
+paths, content hashes, AST record identities, symbols, and source spans; they
+never contain a source body or an absolute path.
+"""
 
 from __future__ import annotations
 
 import ast
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
-from pathlib import Path
-from types import MappingProxyType
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Final
 
+from ipfs_accelerate_py.agent_supervisor.analysis.analysis_ast_index import (
+    AnalysisASTIndex,
+    IndexedASTPath,
+)
 from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    ContentIdentity,
     mint_content_identity,
+)
+from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+    canonical_json_bytes,
 )
 
 STATIC_TEST_DEPENDENCY_TRACE_INTERFACE: Final = "StaticTestDependencyTrace@1"
 STATIC_TEST_DEPENDENCY_TRACER_INTERFACE: Final = "StaticTestDependencyTracer@1"
+STATIC_TRACE_LIMITS_INTERFACE: Final = "StaticTraceLimits@1"
+STATIC_TRACE_ANALYZER_INTERFACE: Final = "StaticTraceAnalyzer@1"
+
 STATIC_TEST_DEPENDENCY_TRACE_SCHEMA: Final = (
     "ipfs_accelerate_py/agent-supervisor/static-test-dependency-trace@1"
 )
+STATIC_TRACE_LIMITS_SCHEMA: Final = "ipfs_accelerate_py/agent-supervisor/static-trace-limits@1"
+STATIC_TRACE_ANALYZER_SCHEMA: Final = "ipfs_accelerate_py/agent-supervisor/static-trace-analyzer@1"
+
+_SAFE_TEXT_RE: Final = re.compile(r"^[A-Za-z0-9_.:@/+ <>*=-]{1,512}$")
+_CONFIG_FILES: Final = ("pyproject.toml", "pytest.ini", "setup.cfg", "tox.ini")
+_REFLECTION_CALLS: Final = frozenset(
+    {
+        "compile",
+        "delattr",
+        "eval",
+        "exec",
+        "getattr",
+        "globals",
+        "hasattr",
+        "locals",
+        "setattr",
+        "vars",
+    }
+)
+_DYNAMIC_IMPORT_CALLS: Final = frozenset({"__import__", "import_module", "importlib.import_module"})
+_EFFECT_CALLS: Final[Mapping[str, frozenset[str]]] = {
+    "subprocess": frozenset(
+        {
+            "Popen",
+            "call",
+            "check_call",
+            "check_output",
+            "os.popen",
+            "os.spawnl",
+            "os.spawnv",
+            "os.system",
+            "subprocess.Popen",
+            "subprocess.call",
+            "subprocess.check_call",
+            "subprocess.check_output",
+            "subprocess.run",
+        }
+    ),
+    "network": frozenset(
+        {
+            "aiohttp.ClientSession",
+            "httpx.get",
+            "httpx.post",
+            "requests.get",
+            "requests.post",
+            "socket.create_connection",
+            "socket.socket",
+            "urllib.request.urlopen",
+            "urlopen",
+        }
+    ),
+    "clock": frozenset({"datetime.now", "datetime.utcnow", "time.monotonic", "time.time"}),
+    "randomness": frozenset(
+        {
+            "random.choice",
+            "random.random",
+            "random.randrange",
+            "secrets.token_bytes",
+            "secrets.token_hex",
+            "uuid.uuid4",
+        }
+    ),
+    "environment": frozenset({"os.environ.get", "os.getenv", "os.putenv", "os.unsetenv"}),
+    "hardware": frozenset(
+        {
+            "cuda.is_available",
+            "jax.devices",
+            "torch.cuda.is_available",
+            "torch.cuda.get_device_name",
+        }
+    ),
+}
+_SAFE_DECORATORS: Final = frozenset(
+    {
+        "abstractmethod",
+        "abc.abstractmethod",
+        "classmethod",
+        "dataclass",
+        "functools.cache",
+        "functools.lru_cache",
+        "property",
+        "pytest.fixture",
+        "fixture",
+        "pytest.mark.asyncio",
+        "pytest.mark.filterwarnings",
+        "pytest.mark.parametrize",
+        "pytest.mark.skip",
+        "pytest.mark.skipif",
+        "pytest.mark.usefixtures",
+        "pytest.mark.xfail",
+        "staticmethod",
+    }
+)
 
 
-@dataclass(frozen=True, slots=True)
-class StaticUnknownFrontierEntry:
-    """One residual unknown or effect frontier observed during static analysis."""
+class StaticTraceError(ValueError):
+    """Invalid static trace input or identity material."""
 
-    kind: str
-    frontier_id: str = ""
-    detail: str = ""
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "kind", str(self.kind or "").strip() or "unknown")
-        object.__setattr__(
-            self,
-            "frontier_id",
-            str(self.frontier_id or self.kind).strip()[:128],
-        )
-        object.__setattr__(self, "detail", str(self.detail or "")[:256])
+    __test__ = False
 
 
-@dataclass(frozen=True, slots=True)
-class StaticTestDependencyTrace:
-    """Content-addressed static dependency closure for one test symbol."""
+@dataclass(frozen=True)
+class StaticTraceLimits:
+    """Hard analysis limits which participate in the trace identity."""
 
     __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = STATIC_TEST_DEPENDENCY_TRACE_INTERFACE
 
-    complete: bool
-    trace_cid: str
-    node_id: str = ""
-    relative_path: str = ""
-    test_symbol: str = ""
-    unknown_frontier: tuple[StaticUnknownFrontierEntry, ...] = ()
-    retained_canonical_bytes: bytes = b""
-    dependencies: Mapping[str, Any] = field(default_factory=dict)
+    max_files: int = 256
+    max_edges: int = 2_048
+    max_frontier: int = 512
+    max_depth: int = 32
+    max_source_bytes: int = 2 * 1_048_576
+    max_ast_nodes: int = 100_000
+    max_data_bytes: int = 8 * 1_048_576
+    max_symbols_per_file: int = 2_048
+    max_text_chars: int = 512
 
-    def verify(self) -> None:
-        if not self.trace_cid:
-            raise ValueError("static trace is missing trace_cid")
-        if self.retained_canonical_bytes:
-            expected = mint_content_identity_from_bytes(self.retained_canonical_bytes)
-            if expected != self.trace_cid:
-                raise ValueError("static trace CID does not match retained bytes")
+    _BOUNDS: ClassVar[Mapping[str, tuple[int, int]]] = {
+        "max_files": (1, 8_192),
+        "max_edges": (1, 65_536),
+        "max_frontier": (1, 16_384),
+        "max_depth": (1, 256),
+        "max_source_bytes": (1, 32 * 1_048_576),
+        "max_ast_nodes": (1, 1_000_000),
+        "max_data_bytes": (1, 128 * 1_048_576),
+        "max_symbols_per_file": (1, 16_384),
+        "max_text_chars": (32, 4_096),
+    }
+
+    def __post_init__(self) -> None:
+        for name, (minimum, maximum) in self._BOUNDS.items():
+            value = getattr(self, name)
+            if type(value) is not int or not minimum <= value <= maximum:
+                raise StaticTraceError(f"{name} must be an integer in [{minimum}, {maximum}]")
+
+    @property
+    def interface(self) -> str:
+        return STATIC_TRACE_LIMITS_INTERFACE
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA,
-            "interface": STATIC_TEST_DEPENDENCY_TRACE_INTERFACE,
-            "complete": self.complete,
-            "trace_cid": self.trace_cid,
-            "node_id": self.node_id,
-            "relative_path": self.relative_path,
-            "test_symbol": self.test_symbol,
-            "unknown_frontier": [
-                {
-                    "kind": entry.kind,
-                    "frontier_id": entry.frontier_id,
-                    "detail": entry.detail,
-                }
-                for entry in self.unknown_frontier
-            ],
-            "dependencies": dict(self.dependencies),
+            "schema": STATIC_TRACE_LIMITS_SCHEMA,
+            "interface": STATIC_TRACE_LIMITS_INTERFACE,
+            **{name: getattr(self, name) for name in sorted(self._BOUNDS)},
         }
 
 
-def mint_content_identity_from_bytes(data: bytes) -> str:
-    from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
-        mint_content_identity_bytes,
-    )
+@dataclass(frozen=True)
+class UnknownDependencyFrontier:
+    """One typed, compact edge the static analyzer could not close."""
 
-    return mint_content_identity_bytes(data).cid
+    __test__: ClassVar[bool] = False
+
+    kind: str
+    source_path: str
+    source_symbol: str = ""
+    target: str = ""
+    line_start: int = 0
+    line_end: int = 0
+
+    def __post_init__(self) -> None:
+        kind = _safe_public_text(self.kind, "frontier kind")
+        path = _repo_path(self.source_path, allow_empty=True)
+        symbol = _safe_public_text(self.source_symbol, "source symbol", allow_empty=True)
+        target = _safe_public_text(self.target, "frontier target", allow_empty=True)
+        start = _line_number(self.line_start)
+        end = _line_number(self.line_end)
+        if end and start and end < start:
+            raise StaticTraceError("frontier line_end precedes line_start")
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "source_path", path)
+        object.__setattr__(self, "source_symbol", symbol)
+        object.__setattr__(self, "target", target)
+        object.__setattr__(self, "line_start", start)
+        object.__setattr__(self, "line_end", end)
+
+    @property
+    def frontier_id(self) -> str:
+        return (
+            "static-frontier:sha256:"
+            + hashlib.sha256(canonical_json_bytes(self._content_dict())).hexdigest()
+        )
+
+    def _content_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "source_path": self.source_path,
+            "source_symbol": self.source_symbol,
+            "target": self.target,
+            "line_start": self.line_start,
+            "line_end": self.line_end,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"frontier_id": self.frontier_id, **self._content_dict()}
+
+
+@dataclass(frozen=True)
+class StaticTestDependencyTrace:
+    """Immutable canonical result of one static closure computation."""
+
+    __test__: ClassVar[bool] = False
+
+    content_identity: ContentIdentity
+    retained_canonical_bytes: bytes
+    unknown_frontier: tuple[UnknownDependencyFrontier, ...]
+    analyzed_file_count: int
+    dependency_edge_count: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.content_identity, ContentIdentity):
+            raise StaticTraceError("static trace requires a ContentIdentity")
+        if type(self.retained_canonical_bytes) is not bytes:
+            raise StaticTraceError("retained_canonical_bytes must be exact bytes")
+        if self.retained_canonical_bytes != self.content_identity.canonical_bytes:
+            raise StaticTraceError("trace bytes do not match ContentIdentity")
+        frontiers = tuple(sorted(self.unknown_frontier, key=lambda item: item.frontier_id))
+        if len({item.frontier_id for item in frontiers}) != len(frontiers):
+            raise StaticTraceError("unknown frontier rows must be unique")
+        object.__setattr__(self, "unknown_frontier", frontiers)
+        for value in (self.analyzed_file_count, self.dependency_edge_count):
+            if type(value) is not int or value < 0:
+                raise StaticTraceError("trace counters must be non-negative integers")
+
+    @property
+    def interface(self) -> str:
+        return STATIC_TEST_DEPENDENCY_TRACE_INTERFACE
+
+    @property
+    def schema(self) -> str:
+        return STATIC_TEST_DEPENDENCY_TRACE_SCHEMA
+
+    @property
+    def complete(self) -> bool:
+        return not self.unknown_frontier
+
+    @property
+    def completeness(self) -> str:
+        return "complete" if self.complete else "incomplete"
+
+    @property
+    def cid(self) -> str:
+        return self.content_identity.cid
+
+    @property
+    def trace_cid(self) -> str:
+        return self.cid
+
+    @property
+    def root_cid(self) -> str:
+        return self.cid
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return self.retained_canonical_bytes
+
+    @property
+    def unknown_dependency_frontier(self) -> tuple[UnknownDependencyFrontier, ...]:
+        return self.unknown_frontier
+
+    def to_dict(self) -> dict[str, Any]:
+        value = json.loads(self.retained_canonical_bytes.decode("utf-8"))
+        if not isinstance(value, dict):  # pragma: no cover - construction invariant
+            raise StaticTraceError("static trace canonical bytes are not an object")
+        return value
+
+    def verify(self) -> StaticTestDependencyTrace:
+        self.content_identity.verify()
+        if canonical_json_bytes(self.to_dict()) != self.retained_canonical_bytes:
+            raise StaticTraceError("static trace bytes are not canonical")
+        payload_frontier = tuple(
+            item["frontier_id"] for item in self.to_dict().get("unknown_frontier", ())
+        )
+        if payload_frontier != tuple(item.frontier_id for item in self.unknown_frontier):
+            raise StaticTraceError("frontier projection does not match canonical trace")
+        return self
+
+
+@dataclass
+class _ParsedFile:
+    indexed: IndexedASTPath
+    tree: ast.Module
+    roles: set[str]
+    depth: int
+
+
+@dataclass(frozen=True)
+class _FixtureDefinition:
+    name: str
+    path: str
+    symbol: str
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _safe_public_text(value: Any, field: str, *, allow_empty: bool = False) -> str:
+    text = " ".join(str(value or "").split())
+    if not text and allow_empty:
+        return ""
+    if not _SAFE_TEXT_RE.fullmatch(text):
+        raise StaticTraceError(f"{field} is not bounded public text")
+    return text
+
+
+def _repo_path(value: Any, *, allow_empty: bool = False) -> str:
+    raw = str(value or "").strip().replace("\\", "/")
+    while raw.startswith("./"):
+        raw = raw[2:]
+    if not raw and allow_empty:
+        return ""
+    path = PurePosixPath(raw)
+    if not raw or path.is_absolute() or ".." in path.parts:
+        raise StaticTraceError("path must be repository-relative and contained")
+    return path.as_posix()
+
+
+def _line_number(value: Any) -> int:
+    if type(value) is not int or value < 0 or value > (1 << 31) - 1:
+        raise StaticTraceError("source lines must be non-negative bounded integers")
+    return value
+
+
+def _expression_name(node: ast.AST | None) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _expression_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return ""
+
+
+def _span(node: ast.AST) -> tuple[int, int]:
+    start = int(getattr(node, "lineno", 0) or 0)
+    return start, int(getattr(node, "end_lineno", start) or start)
+
+
+def _literal_strings(node: ast.AST) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return (node.value,)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        result: list[str] = []
+        for item in node.elts:
+            values = _literal_strings(item)
+            if values is None:
+                return None
+            result.extend(values)
+        return tuple(result)
+    return None
 
 
 class StaticTestDependencyTracer:
-    """Build a bounded static dependency trace from an analysis AST index."""
+    """Compute a conservative repository-local dependency closure."""
 
-    __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = STATIC_TEST_DEPENDENCY_TRACER_INTERFACE
+    __test__ = False
 
-    def __init__(self, index: Any, root_path: str | Path) -> None:
-        self.index = index
-        self.root_path = Path(root_path)
+    def __init__(
+        self,
+        analysis_index: AnalysisASTIndex | None = None,
+        repository_root: str | os.PathLike[str] | None = None,
+        *,
+        ast_index: AnalysisASTIndex | None = None,
+        limits: StaticTraceLimits | None = None,
+        identity_minter: Callable[[Any], ContentIdentity] = mint_content_identity,
+    ) -> None:
+        if analysis_index is not None and ast_index is not None:
+            raise StaticTraceError("provide only one of analysis_index or ast_index")
+        index = analysis_index if analysis_index is not None else ast_index
+        if not isinstance(index, AnalysisASTIndex):
+            raise StaticTraceError("analysis_index must be an AnalysisASTIndex")
+        if repository_root is None:
+            raise StaticTraceError("repository_root is required")
+        try:
+            root = Path(os.fspath(repository_root)).resolve(strict=True)
+        except (OSError, TypeError, ValueError) as exc:
+            raise StaticTraceError("repository_root is unavailable") from exc
+        if not root.is_dir():
+            raise StaticTraceError("repository_root must be a directory")
+        if not callable(identity_minter):
+            raise StaticTraceError("identity_minter must be callable")
+
+        self.analysis_index = index
+        self.repository_root = root
+        self.limits = limits or StaticTraceLimits()
+        self._identity_minter = identity_minter
+        self._records = {item.path: item for item in index.path_records}
+        self._modules: dict[str, list[str]] = {}
+        for item in index.path_records:
+            for alias in self._module_aliases(item):
+                self._modules.setdefault(alias, []).append(item.path)
+        for paths in self._modules.values():
+            paths.sort()
+        self._reset()
+
+    @staticmethod
+    def _module_aliases(indexed: IndexedASTPath) -> tuple[str, ...]:
+        module = indexed.module
+        parts = module.split(".") if module else []
+        aliases = {module} if module else set()
+        # Source-layout repositories commonly index ``src/pkg/x.py`` while
+        # Python imports it as ``pkg.x``.  Only this explicit layout alias is
+        # added; arbitrary suffix matching would make resolution ambiguous.
+        if parts and parts[0] in {"src", "lib", "python"} and len(parts) > 1:
+            aliases.add(".".join(parts[1:]))
+        return tuple(sorted(aliases))
+
+    def _reset(self) -> None:
+        self._parsed: dict[str, _ParsedFile] = {}
+        self._nodes: dict[bytes, dict[str, Any]] = {}
+        self._edges: dict[bytes, dict[str, Any]] = {}
+        self._frontiers: dict[str, UnknownDependencyFrontier] = {}
+        self._fixtures: dict[str, list[_FixtureDefinition]] = {}
+        self._root_path = ""
+        self._root_symbol = ""
+        self._bound_kinds: set[str] = set()
+        self._source_hashes_verified = True
+        self._parser_healthy = True
+        self._result: StaticTestDependencyTrace | None = None
+
+    @property
+    def result(self) -> StaticTestDependencyTrace | None:
+        return self._result
+
+    @property
+    def trace_result(self) -> StaticTestDependencyTrace | None:
+        return self._result
 
     def trace(
         self,
-        relative_path: str,
+        test_path: str,
+        test_symbol: str = "",
         *,
-        test_symbol: str,
         node_id: str = "",
     ) -> StaticTestDependencyTrace:
-        rel = str(relative_path or "").replace("\\", "/").lstrip("./")
-        symbol = str(test_symbol or "").strip()
-        node = str(node_id or f"{rel}::{symbol}")
-        frontiers: list[StaticUnknownFrontierEntry] = []
-        edges: list[dict[str, Any]] = []
-        imports: list[str] = []
-        source = ""
-        path = self.root_path / rel
-        if not path.is_file():
-            frontiers.append(
-                StaticUnknownFrontierEntry(
-                    kind="missing_file",
-                    frontier_id=f"missing:{rel}",
-                    detail=rel,
-                )
-            )
-        else:
-            try:
-                source = path.read_text(encoding="utf-8")
-            except OSError as exc:
-                frontiers.append(
-                    StaticUnknownFrontierEntry(
-                        kind="missing_file",
-                        frontier_id=f"unreadable:{rel}",
-                        detail=type(exc).__name__,
-                    )
-                )
-                source = ""
-        module_ast = None
-        if source:
-            try:
-                module_ast = ast.parse(source, filename=rel)
-            except SyntaxError as exc:
-                frontiers.append(
-                    StaticUnknownFrontierEntry(
-                        kind="parse_error",
-                        frontier_id=f"parse:{rel}",
-                        detail=str(exc.msg)[:128],
-                    )
-                )
-        found_symbol = False
-        if module_ast is not None:
-            for node_ast in module_ast.body:
-                if isinstance(node_ast, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    if node_ast.name == symbol:
-                        found_symbol = True
-                elif isinstance(node_ast, ast.ClassDef):
-                    for child in node_ast.body:
-                        if (
-                            isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
-                            and child.name == symbol
-                        ):
-                            found_symbol = True
-                if isinstance(node_ast, (ast.Import, ast.ImportFrom)):
-                    for alias in node_ast.names:
-                        name = alias.name if isinstance(node_ast, ast.Import) else (
-                            f"{node_ast.module or ''}.{alias.name}".strip(".")
-                        )
-                        if name:
-                            imports.append(name)
-                            edges.append(
-                                {
-                                    "kind": "import",
-                                    "target": name,
-                                    "source": rel,
-                                }
-                            )
-            # Conservative effect heuristics for common impure builtins.
-            effect_names = {
-                "open": "filesystem",
-                "print": "filesystem",
-                "input": "environment",
-                "system": "subprocess",
-                "Popen": "subprocess",
-                "run": "subprocess",
-                "urlopen": "network",
-                "request": "network",
-                "sleep": "clock",
-                "time": "clock",
-                "random": "randomness",
-                "getenv": "environment",
-                "environ": "environment",
-            }
-            for ast_node in ast.walk(module_ast):
-                name = ""
-                if isinstance(ast_node, ast.Name):
-                    name = ast_node.id
-                elif isinstance(ast_node, ast.Attribute):
-                    name = ast_node.attr
-                if name in effect_names:
-                    effect = effect_names[name]
-                    edges.append(
-                        {
-                            "kind": "effect",
-                            "target": effect,
-                            "target_symbol": effect,
-                            "source": rel,
-                            "symbol": name,
-                        }
-                    )
-            if symbol and not found_symbol:
-                frontiers.append(
-                    StaticUnknownFrontierEntry(
-                        kind="missing_test_symbol",
-                        frontier_id=f"symbol:{symbol}",
-                        detail=symbol,
-                    )
-                )
+        """Trace one indexed test module/symbol and return canonical evidence."""
 
-        # Prefer index metadata when available (stale detection hook).
-        try:
-            records = getattr(self.index, "records", None) or getattr(
-                self.index, "modules", None
-            )
-            if records is not None and rel not in records and not source:
-                frontiers.append(
-                    StaticUnknownFrontierEntry(
-                        kind="stale_ast_index",
-                        frontier_id=f"index:{rel}",
-                        detail="relative path not present in analysis index",
-                    )
-                )
-        except Exception:
-            pass
+        self._reset()
+        self._root_path = _repo_path(test_path)
+        selected = (test_symbol or (node_id.rsplit("::", 1)[-1] if node_id else "")).split("[", 1)[
+            0
+        ]
+        self._root_symbol = _safe_public_text(selected, "test symbol", allow_empty=True)
 
+        # Pytest configuration and ancestor conftests affect collection and
+        # fixture/hook semantics even when the test imports none of them.
+        self._record_configuration_files()
+        conftests = self._ancestor_conftests(self._root_path)
+        for path in conftests:
+            self._analyze_file(path, role="conftest", depth=0)
+        self._analyze_file(self._root_path, role="test", depth=0)
+        self._resolve_root_fixtures()
+        self._record_conftest_hooks(conftests)
+
+        analyzer, analyzer_cid = self._analyzer_identity()
+        frontiers = tuple(sorted(self._frontiers.values(), key=lambda item: item.frontier_id))
         payload = {
             "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA,
             "interface": STATIC_TEST_DEPENDENCY_TRACE_INTERFACE,
-            "node_id": node,
-            "relative_path": rel,
-            "test_symbol": symbol,
-            "imports": sorted(set(imports)),
-            "unknown_frontier": [
-                {
-                    "kind": entry.kind,
-                    "frontier_id": entry.frontier_id,
-                    "detail": entry.detail,
-                }
-                for entry in frontiers
-            ],
-            "dependencies": {"edges": edges},
-            "source_sha256": (
-                mint_content_identity(
-                    {
-                        "schema": STATIC_TEST_DEPENDENCY_TRACE_SCHEMA + "/source",
-                        "relative_path": rel,
-                        "source": source,
-                    }
-                ).digest
-                if source
-                else ""
-            ),
+            "root": {"path": self._root_path, "symbol": self._root_symbol},
+            "analysis_ast_index_id": self.analysis_index.index_id,
+            "limits": self.limits.to_dict(),
+            "analyzer": analyzer,
+            "analyzer_cid": analyzer_cid,
+            "dependencies": {
+                "nodes": [self._nodes[key] for key in sorted(self._nodes)],
+                "edges": [self._edges[key] for key in sorted(self._edges)],
+            },
+            "unknown_frontier": [item.to_dict() for item in frontiers],
+            "health": {
+                "complete": not frontiers,
+                "source_hashes_verified": self._source_hashes_verified,
+                "parser_healthy": self._parser_healthy,
+                "analysis_bounds_reached": sorted(self._bound_kinds),
+                "analyzed_file_count": len(self._parsed),
+                "dependency_edge_count": len(self._edges),
+                "unknown_frontier_count": len(frontiers),
+            },
         }
-        identity = mint_content_identity(payload)
-        complete = not frontiers
-        return StaticTestDependencyTrace(
-            complete=complete,
-            trace_cid=identity.cid,
-            node_id=node,
-            relative_path=rel,
-            test_symbol=symbol,
-            unknown_frontier=tuple(frontiers),
-            retained_canonical_bytes=identity.canonical_bytes,
-            dependencies=MappingProxyType({"edges": edges}),
+        expected = canonical_json_bytes(payload)
+        identity = self._identity_minter(payload)
+        if not isinstance(identity, ContentIdentity):
+            raise StaticTraceError("identity provider did not return ContentIdentity")
+        identity.verify()
+        if identity.canonical_bytes != expected:
+            raise StaticTraceError("identity provider canonical bytes do not match trace")
+        result = StaticTestDependencyTrace(
+            content_identity=identity,
+            retained_canonical_bytes=expected,
+            unknown_frontier=frontiers,
+            analyzed_file_count=len(self._parsed),
+            dependency_edge_count=len(self._edges),
+        )
+        self._result = result
+        return result
+
+    analyze = trace
+    build = trace
+
+    def _analyzer_identity(self) -> tuple[dict[str, Any], str]:
+        try:
+            source_digest = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+        except OSError as exc:  # pragma: no cover - installed source is expected
+            raise StaticTraceError("static analyzer source is unavailable") from exc
+        analyzer = {
+            "schema": STATIC_TRACE_ANALYZER_SCHEMA,
+            "interface": STATIC_TRACE_ANALYZER_INTERFACE,
+            "tracer_interface": STATIC_TEST_DEPENDENCY_TRACER_INTERFACE,
+            "implementation": "python-ast-index-closure",
+            "implementation_source_sha256": source_digest,
+            "python_implementation": sys.implementation.name,
+            "python_version": ".".join(str(value) for value in sys.version_info[:3]),
+            "ast_schema": "python-ast@1",
+            "resolution_schema": "repository-local-import-fixture-effect@1",
+        }
+        identity = self._identity_minter(analyzer)
+        if not isinstance(identity, ContentIdentity):
+            raise StaticTraceError("identity provider did not return ContentIdentity")
+        identity.verify()
+        if identity.canonical_bytes != canonical_json_bytes(analyzer):
+            raise StaticTraceError("analyzer identity bytes do not match input")
+        return analyzer, identity.cid
+
+    def _ancestor_conftests(self, path: str) -> tuple[str, ...]:
+        parent = PurePosixPath(path).parent
+        candidates: list[str] = []
+        current = PurePosixPath()
+        for part in parent.parts:
+            current /= part
+            candidate = (current / "conftest.py").as_posix()
+            if candidate in self._records:
+                candidates.append(candidate)
+        if "conftest.py" in self._records:
+            candidates.insert(0, "conftest.py")
+        return tuple(dict.fromkeys(candidates))
+
+    def _record_configuration_files(self) -> None:
+        for name in _CONFIG_FILES:
+            candidate = self.repository_root / name
+            if not candidate.exists():
+                continue
+            if candidate.is_symlink() or not candidate.is_file():
+                self._frontier("missing_file", "", target=name)
+                continue
+            self._record_data_node(candidate, name, role="config")
+            self._edge("config", self._root_path, "", name, "", 0, 0)
+
+    def _analyze_file(self, path: str, *, role: str, depth: int) -> None:
+        path = _repo_path(path)
+        if len(path) > self.limits.max_text_chars:
+            self._bound("text", "", target="path")
+            return
+        prior = self._parsed.get(path)
+        if prior is not None:
+            prior.roles.add(role)
+            self._refresh_code_node(prior)
+            return
+        if depth > self.limits.max_depth:
+            self._bound("depth", path)
+            return
+        if len(self._parsed) >= self.limits.max_files:
+            self._bound("files", path)
+            return
+        indexed = self._records.get(path)
+        if indexed is None:
+            self._frontier("missing_file", path, target=path)
+            return
+        absolute = self.repository_root / Path(path)
+        try:
+            resolved = absolute.resolve(strict=True)
+            resolved.relative_to(self.repository_root)
+        except (OSError, ValueError):
+            self._frontier("missing_file", path, target=path)
+            return
+        if absolute.is_symlink() or not resolved.is_file():
+            self._frontier("missing_file", path, target=path)
+            return
+        try:
+            data = resolved.read_bytes()
+        except OSError:
+            self._frontier("missing_file", path, target=path)
+            return
+        if len(data) > self.limits.max_source_bytes:
+            self._bound("source_bytes", path)
+            return
+        actual_hash = hashlib.sha256(data).hexdigest()
+        claimed = indexed.source_sha256.removeprefix("sha256:")
+        if not claimed or claimed != actual_hash:
+            self._source_hashes_verified = False
+            self._frontier("stale_ast_index", path, target=indexed.record_id)
+            return
+        try:
+            source = data.decode("utf-8")
+            tree = ast.parse(source, filename=path)
+        except (UnicodeDecodeError, SyntaxError, ValueError):
+            self._parser_healthy = False
+            self._frontier("parse_error", path)
+            return
+        node_count = sum(1 for _ in ast.walk(tree))
+        if node_count > self.limits.max_ast_nodes:
+            self._bound("ast_nodes", path)
+            return
+        if indexed.ast_record.parse_error:
+            self._parser_healthy = False
+            self._frontier("indexed_parse_error", path, target=indexed.record_id)
+
+        parsed = _ParsedFile(indexed=indexed, tree=tree, roles={role}, depth=depth)
+        self._parsed[path] = parsed
+        self._refresh_code_node(parsed)
+        self._collect_fixtures(parsed)
+        self._inspect_decorators(parsed)
+        self._inspect_plugin_registration(parsed)
+        self._inspect_imports(parsed)
+        self._inspect_calls(parsed)
+
+    def _refresh_code_node(self, parsed: _ParsedFile) -> None:
+        record = parsed.indexed.ast_record
+        symbols = []
+        for symbol in sorted(record.qualified_symbols):
+            if len(symbols) >= self.limits.max_symbols_per_file:
+                self._bound("symbols", parsed.indexed.path)
+                break
+            if len(symbol) > self.limits.max_text_chars:
+                self._bound("text", parsed.indexed.path, target="symbol")
+                continue
+            start, end = record.symbol_lines.get(symbol, (0, 0))
+            symbols.append(
+                {
+                    "name": symbol,
+                    "line_start": start,
+                    "line_end": end,
+                    "symbol_hash": record.symbol_hashes.get(symbol, ""),
+                }
+            )
+        node = {
+            "kind": "source",
+            "path": parsed.indexed.path,
+            "module": parsed.indexed.module,
+            "roles": sorted(parsed.roles),
+            "blob_identity": parsed.indexed.blob_identity,
+            "source_sha256": parsed.indexed.source_sha256,
+            "record_id": parsed.indexed.record_id,
+            "symbols": symbols,
+        }
+        # Replace the older role projection for this path.
+        for key, value in tuple(self._nodes.items()):
+            if value.get("kind") == "source" and value.get("path") == parsed.indexed.path:
+                del self._nodes[key]
+        self._put_node(node)
+
+    def _put_node(self, node: dict[str, Any]) -> None:
+        encoded = canonical_json_bytes(node)
+        self._nodes[encoded] = node
+
+    def _record_data_node(self, absolute: Path, relative: str, *, role: str) -> bool:
+        relative = _repo_path(relative)
+        if len(relative) > self.limits.max_text_chars:
+            self._bound("text", self._root_path, target="data_path")
+            return False
+        try:
+            resolved = absolute.resolve(strict=True)
+            resolved.relative_to(self.repository_root)
+            if absolute.is_symlink() or not resolved.is_file():
+                raise OSError
+            size = resolved.stat().st_size
+            if size > self.limits.max_data_bytes:
+                self._bound("data_bytes", self._root_path, target=relative)
+                return False
+            digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+        except (OSError, ValueError):
+            self._frontier("missing_file", self._root_path, target=relative)
+            return False
+        self._put_node(
+            {
+                "kind": "data",
+                "path": relative,
+                "roles": [role],
+                "content_sha256": f"sha256:{digest}",
+                "size_bytes": size,
+            }
+        )
+        return True
+
+    def _inspect_imports(self, parsed: _ParsedFile) -> None:
+        for node in ast.walk(parsed.tree):
+            imports: list[tuple[str, int, str]] = []
+            if isinstance(node, ast.Import):
+                imports = [(alias.name, 0, alias.name) for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                for alias in node.names:
+                    if alias.name == "*":
+                        self._frontier_node(
+                            "reflection", parsed.indexed.path, node, target="star_import"
+                        )
+                        continue
+                    candidate = f"{module}.{alias.name}" if module else alias.name
+                    imports.append((candidate, int(node.level or 0), module))
+            for requested, level, fallback in imports:
+                resolved_name = self._absolute_import_name(parsed.indexed, requested, level)
+                target = self._resolve_internal_module(resolved_name)
+                if target is None and fallback and fallback != requested:
+                    base = self._absolute_import_name(parsed.indexed, fallback, level)
+                    target = self._resolve_internal_module(base)
+                    if target is not None:
+                        resolved_name = base
+                start, end = _span(node)
+                if target is not None:
+                    self._edge("import", parsed.indexed.path, "", target, resolved_name, start, end)
+                    self._analyze_file(target, role="import", depth=parsed.depth + 1)
+                else:
+                    kind = (
+                        "native_code" if self._is_native_module(resolved_name) else "missing_file"
+                    )
+                    self._frontier_node(kind, parsed.indexed.path, node, target=resolved_name)
+
+    @staticmethod
+    def _absolute_import_name(indexed: IndexedASTPath, requested: str, level: int) -> str:
+        if not level:
+            return requested.strip(".")
+        module_parts = indexed.module.split(".") if indexed.module else []
+        if indexed.path.endswith("/__init__.py") or indexed.path == "__init__.py":
+            package = module_parts
+        else:
+            package = module_parts[:-1]
+        remove = max(0, level - 1)
+        if remove > len(package):
+            return requested.strip(".")
+        prefix = package[: len(package) - remove] if remove else package
+        suffix = requested.strip(".").split(".") if requested.strip(".") else []
+        return ".".join([*prefix, *suffix])
+
+    def _resolve_internal_module(self, module: str) -> str | None:
+        paths = self._modules.get(module, ())
+        if len(paths) == 1:
+            return paths[0]
+        if len(paths) > 1:
+            self._frontier("ambiguous_import", self._root_path, target=module)
+        return None
+
+    def _is_native_module(self, module: str) -> bool:
+        top = module.split(".", 1)[0]
+        candidates = [
+            self.repository_root / Path(*module.split(".")),
+            self.repository_root / Path(*top.split(".")),
+        ]
+        suffixes = tuple(importlib.machinery.EXTENSION_SUFFIXES)
+        for base in candidates:
+            if any(Path(str(base) + suffix).exists() for suffix in suffixes):
+                return True
+        try:
+            spec = importlib.util.find_spec(top)
+        except (ImportError, AttributeError, ValueError):
+            return False
+        if spec is None:
+            return False
+        if spec.origin in {"built-in", "frozen"}:
+            return spec.origin == "built-in"
+        return bool(spec.origin and str(spec.origin).endswith(suffixes))
+
+    def _collect_fixtures(self, parsed: _ParsedFile) -> None:
+        for node in ast.walk(parsed.tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            fixture_name = ""
+            for decorator in node.decorator_list:
+                expression = decorator.func if isinstance(decorator, ast.Call) else decorator
+                if _expression_name(expression) not in {"fixture", "pytest.fixture"}:
+                    continue
+                fixture_name = node.name
+                if isinstance(decorator, ast.Call):
+                    for keyword in decorator.keywords:
+                        if keyword.arg == "name":
+                            values = _literal_strings(keyword.value)
+                            if values and len(values) == 1:
+                                fixture_name = values[0]
+                            else:
+                                self._frontier_node(
+                                    "opaque_decorator",
+                                    parsed.indexed.path,
+                                    decorator,
+                                    source_symbol=node.name,
+                                    target="fixture:name",
+                                )
+                break
+            if fixture_name:
+                try:
+                    fixture_name = _safe_public_text(fixture_name, "fixture name")
+                except StaticTraceError:
+                    self._frontier_node(
+                        "opaque_decorator",
+                        parsed.indexed.path,
+                        node,
+                        source_symbol=node.name,
+                        target="fixture:name",
+                    )
+                    continue
+                definition = _FixtureDefinition(fixture_name, parsed.indexed.path, node.name, node)
+                self._fixtures.setdefault(fixture_name, []).append(definition)
+
+    def _inspect_decorators(self, parsed: _ParsedFile) -> None:
+        for node in ast.walk(parsed.tree):
+            if not isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                expression = decorator.func if isinstance(decorator, ast.Call) else decorator
+                name = _expression_name(expression)
+                if name in _SAFE_DECORATORS or name.startswith("pytest.mark."):
+                    start, end = _span(decorator)
+                    self._edge(
+                        "decorator",
+                        parsed.indexed.path,
+                        node.name,
+                        parsed.indexed.path,
+                        name,
+                        start,
+                        end,
+                    )
+                    continue
+                target = name if name and _SAFE_TEXT_RE.fullmatch(name) else "dynamic_decorator"
+                self._frontier_node(
+                    "opaque_decorator",
+                    parsed.indexed.path,
+                    decorator,
+                    source_symbol=node.name,
+                    target=target,
+                )
+
+    def _inspect_plugin_registration(self, parsed: _ParsedFile) -> None:
+        for node in parsed.tree.body:
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if not any(
+                isinstance(target, ast.Name) and target.id == "pytest_plugins" for target in targets
+            ):
+                continue
+            value = node.value
+            plugins = _literal_strings(value) if value is not None else None
+            if plugins is None:
+                self._frontier_node(
+                    "reflection", parsed.indexed.path, node, target="pytest_plugins"
+                )
+                continue
+            for plugin in plugins:
+                try:
+                    safe_plugin = _safe_public_text(plugin, "plugin module")
+                except StaticTraceError:
+                    self._frontier_node(
+                        "reflection", parsed.indexed.path, node, target="pytest_plugins"
+                    )
+                    continue
+                target = self._resolve_internal_module(safe_plugin)
+                if target is None:
+                    self._frontier_node(
+                        "missing_file", parsed.indexed.path, node, target=safe_plugin
+                    )
+                    continue
+                start, end = _span(node)
+                self._edge("plugin", parsed.indexed.path, "", target, safe_plugin, start, end)
+                self._analyze_file(target, role="plugin", depth=parsed.depth + 1)
+
+    def _inspect_calls(self, parsed: _ParsedFile) -> None:
+        aliases = self._import_aliases(parsed.tree)
+        parents = {
+            child: parent
+            for parent in ast.walk(parsed.tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+        owners: list[tuple[ast.AST, str]] = []
+        for node in ast.walk(parsed.tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                owners.append((node, node.name))
+        for node in ast.walk(parsed.tree):
+            if not isinstance(node, ast.Call):
+                continue
+            raw_name = _expression_name(node.func)
+            name = self._expand_alias(raw_name, aliases)
+            owner = ""
+            containing = [
+                (candidate, symbol)
+                for candidate, symbol in owners
+                if _span(candidate)[0] <= _span(node)[0] <= _span(candidate)[1]
+            ]
+            if containing:
+                owner = min(containing, key=lambda item: _span(item[0])[1] - _span(item[0])[0])[1]
+            if name in _DYNAMIC_IMPORT_CALLS:
+                target = "dynamic_import"
+                if node.args:
+                    values = _literal_strings(node.args[0])
+                    if values and len(values) == 1 and _SAFE_TEXT_RE.fullmatch(values[0]):
+                        target = values[0]
+                self._frontier_node(
+                    "dynamic_import",
+                    parsed.indexed.path,
+                    node,
+                    source_symbol=owner,
+                    target=target,
+                )
+            if name in _REFLECTION_CALLS or name.rsplit(".", 1)[-1] in _REFLECTION_CALLS:
+                self._frontier_node(
+                    "reflection",
+                    parsed.indexed.path,
+                    node,
+                    source_symbol=owner,
+                    target=name.rsplit(".", 1)[-1],
+                )
+            effect = next((kind for kind, names in _EFFECT_CALLS.items() if name in names), None)
+            if effect is not None:
+                start, end = _span(node)
+                self._edge("effect", parsed.indexed.path, owner, "", effect, start, end)
+                self._frontier_node(
+                    "uncontrolled_effect",
+                    parsed.indexed.path,
+                    node,
+                    source_symbol=owner,
+                    target=effect,
+                )
+            if name in {"open", "builtins.open"} and not (
+                isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Call)
+            ):
+                self._inspect_path_call(parsed, node, owner, name)
+            if name in {"Path", "pathlib.Path"}:
+                self._inspect_path_constructor(parsed, node, owner, parents, aliases)
+
+    @staticmethod
+    def _import_aliases(tree: ast.Module) -> dict[str, str]:
+        aliases: dict[str, str] = {}
+        for node in tree.body:
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    local = alias.asname or alias.name.split(".", 1)[0]
+                    aliases[local] = alias.name if alias.asname else local
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    if alias.name != "*":
+                        aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+        return aliases
+
+    @staticmethod
+    def _expand_alias(name: str, aliases: Mapping[str, str]) -> str:
+        head, separator, tail = name.partition(".")
+        expanded = aliases.get(head, head)
+        return f"{expanded}.{tail}" if separator else expanded
+
+    def _inspect_path_constructor(
+        self,
+        parsed: _ParsedFile,
+        node: ast.Call,
+        owner: str,
+        parents: Mapping[ast.AST, ast.AST],
+        aliases: Mapping[str, str],
+    ) -> None:
+        attribute = parents.get(node)
+        invocation = parents.get(attribute) if attribute is not None else None
+        if not (
+            isinstance(attribute, ast.Attribute)
+            and attribute.value is node
+            and isinstance(invocation, ast.Call)
+            and invocation.func is attribute
+        ):
+            self._frontier_node(
+                "reflection",
+                parsed.indexed.path,
+                node,
+                source_symbol=owner,
+                target="dynamic_path",
+            )
+            return
+        method = attribute.attr
+        if method in {
+            "read_bytes",
+            "read_text",
+            "stat",
+            "lstat",
+            "exists",
+            "is_dir",
+            "is_file",
+            "is_symlink",
+        }:
+            self._inspect_path_call(parsed, node, owner, "pathlib.Path")
+            return
+        if method == "open":
+            self._inspect_path_call(parsed, node, owner, "open", mode_call=invocation)
+            return
+        if method in {
+            "chmod",
+            "mkdir",
+            "rename",
+            "replace",
+            "rmdir",
+            "symlink_to",
+            "touch",
+            "unlink",
+            "write_bytes",
+            "write_text",
+        }:
+            start, end = _span(invocation)
+            self._edge(
+                "effect",
+                parsed.indexed.path,
+                owner,
+                "",
+                "filesystem_write",
+                start,
+                end,
+            )
+            self._frontier_node(
+                "uncontrolled_effect",
+                parsed.indexed.path,
+                invocation,
+                source_symbol=owner,
+                target="filesystem_write",
+            )
+            return
+        # Unknown Path methods can perform I/O through subclasses or future
+        # APIs and therefore cannot close the dependency statically.
+        expanded = self._expand_alias(method, aliases)
+        self._frontier_node(
+            "reflection",
+            parsed.indexed.path,
+            invocation,
+            source_symbol=owner,
+            target=expanded if _SAFE_TEXT_RE.fullmatch(expanded) else "dynamic_path",
         )
 
+    def _inspect_path_call(
+        self,
+        parsed: _ParsedFile,
+        node: ast.Call,
+        owner: str,
+        name: str,
+        *,
+        mode_call: ast.Call | None = None,
+    ) -> None:
+        if not node.args:
+            self._frontier_node(
+                "reflection",
+                parsed.indexed.path,
+                node,
+                source_symbol=owner,
+                target="dynamic_path",
+            )
+            return
+        values = _literal_strings(node.args[0])
+        if not values or len(values) != 1:
+            self._frontier_node(
+                "reflection",
+                parsed.indexed.path,
+                node,
+                source_symbol=owner,
+                target="dynamic_path",
+            )
+            return
+        raw = values[0]
+        mode = "r"
+        mode_source = mode_call or node
+        mode_arg_index = 0 if mode_call is not None else 1
+        if name in {"open", "builtins.open"} and len(mode_source.args) > mode_arg_index:
+            modes = _literal_strings(mode_source.args[mode_arg_index])
+            mode = modes[0] if modes and len(modes) == 1 else "dynamic"
+        for keyword in mode_source.keywords:
+            if keyword.arg == "mode":
+                modes = _literal_strings(keyword.value)
+                mode = modes[0] if modes and len(modes) == 1 else "dynamic"
+        if mode == "dynamic" or any(flag in mode for flag in "wax+"):
+            start, end = _span(mode_source)
+            self._edge(
+                "effect",
+                parsed.indexed.path,
+                owner,
+                "",
+                "filesystem_write",
+                start,
+                end,
+            )
+            self._frontier_node(
+                "uncontrolled_effect",
+                parsed.indexed.path,
+                mode_source,
+                source_symbol=owner,
+                target="filesystem_write",
+            )
+            return
+        if Path(raw).is_absolute() or ".." in PurePosixPath(raw.replace("\\", "/")).parts:
+            self._frontier_node(
+                "missing_file",
+                parsed.indexed.path,
+                node,
+                source_symbol=owner,
+                target="outside_repository",
+            )
+            return
+        relative = (PurePosixPath(parsed.indexed.path).parent / raw).as_posix()
+        candidate = self.repository_root / Path(relative)
+        if not candidate.exists():
+            root_relative = _repo_path(raw)
+            root_candidate = self.repository_root / Path(root_relative)
+            if root_candidate.exists():
+                relative, candidate = root_relative, root_candidate
+        start, end = _span(node)
+        if relative in self._records:
+            self._edge("data", parsed.indexed.path, owner, relative, "", start, end)
+            self._analyze_file(relative, role="data", depth=parsed.depth + 1)
+        elif self._record_data_node(candidate, relative, role="data"):
+            self._edge("data", parsed.indexed.path, owner, relative, "", start, end)
 
-__all__ = (
+    def _resolve_root_fixtures(self) -> None:
+        parsed = self._parsed.get(self._root_path)
+        if parsed is None:
+            return
+        functions = [
+            node
+            for node in ast.walk(parsed.tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        selected: list[ast.FunctionDef | ast.AsyncFunctionDef]
+        if self._root_symbol:
+            leaf = self._root_symbol.split("[", 1)[0]
+            selected = [node for node in functions if node.name == leaf]
+            if not selected:
+                self._frontier("missing_test_symbol", self._root_path, target=leaf)
+                return
+        else:
+            selected = [node for node in functions if node.name.startswith("test")]
+        fixture_names: set[str] = set()
+        for node in selected:
+            fixture_names.update(argument.arg for argument in node.args.args)
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call):
+                    continue
+                if _expression_name(decorator.func) == "pytest.mark.usefixtures":
+                    for argument in decorator.args:
+                        values = _literal_strings(argument)
+                        if values is None:
+                            self._frontier_node(
+                                "opaque_decorator",
+                                self._root_path,
+                                decorator,
+                                source_symbol=node.name,
+                                target="usefixtures",
+                            )
+                        else:
+                            fixture_names.update(values)
+        seen: set[str] = set()
+        for fixture in sorted(fixture_names):
+            self._resolve_fixture(
+                fixture, source_path=self._root_path, source_symbol=self._root_symbol, seen=seen
+            )
+
+    def _resolve_fixture(
+        self, name: str, *, source_path: str, source_symbol: str, seen: set[str]
+    ) -> None:
+        if name in seen:
+            return
+        seen.add(name)
+        definitions = self._fixtures.get(name, ())
+        if not definitions:
+            self._frontier("unresolved_fixture", source_path, source_symbol, name)
+            return
+        # Local definition wins; otherwise nearest ancestor conftest wins.
+        local = [item for item in definitions if item.path == self._root_path]
+        candidates = local or sorted(
+            definitions,
+            key=lambda item: (-len(PurePosixPath(item.path).parts), item.path, item.symbol),
+        )
+        selected = candidates[0]
+        if len(candidates) > 1 and len(PurePosixPath(candidates[0].path).parts) == len(
+            PurePosixPath(candidates[1].path).parts
+        ):
+            self._frontier("ambiguous_fixture", source_path, source_symbol, name)
+            return
+        start, end = _span(selected.node)
+        self._edge(
+            "fixture",
+            source_path,
+            source_symbol,
+            selected.path,
+            selected.symbol,
+            start,
+            end,
+        )
+        parsed = self._parsed.get(selected.path)
+        if parsed is not None:
+            parsed.roles.add("fixture")
+            self._refresh_code_node(parsed)
+        for argument in selected.node.args.args:
+            self._resolve_fixture(
+                argument.arg,
+                source_path=selected.path,
+                source_symbol=selected.symbol,
+                seen=seen,
+            )
+
+    def _record_conftest_hooks(self, conftests: Sequence[str]) -> None:
+        for path in conftests:
+            parsed = self._parsed.get(path)
+            if parsed is None:
+                continue
+            for node in parsed.tree.body:
+                if isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and node.name.startswith("pytest_"):
+                    start, end = _span(node)
+                    self._edge("hook", self._root_path, "", path, node.name, start, end)
+
+    def _edge(
+        self,
+        kind: str,
+        source_path: str,
+        source_symbol: str,
+        target_path: str,
+        target_symbol: str,
+        line_start: int,
+        line_end: int,
+    ) -> None:
+        if any(
+            len(value) > self.limits.max_text_chars
+            for value in (kind, source_path, source_symbol, target_path, target_symbol)
+        ):
+            self._bound("text", source_path, target="edge")
+            return
+        try:
+            edge = {
+                "kind": _safe_public_text(kind, "edge kind"),
+                "source_path": _repo_path(source_path, allow_empty=True),
+                "source_symbol": _safe_public_text(
+                    source_symbol, "edge source symbol", allow_empty=True
+                ),
+                "target_path": _repo_path(target_path, allow_empty=True),
+                "target_symbol": _safe_public_text(
+                    target_symbol, "edge target symbol", allow_empty=True
+                ),
+                "line_start": _line_number(line_start),
+                "line_end": _line_number(line_end),
+            }
+        except StaticTraceError:
+            self._bound("text", source_path, target="edge")
+            return
+        encoded = canonical_json_bytes(edge)
+        if encoded in self._edges:
+            return
+        if len(self._edges) >= self.limits.max_edges:
+            self._bound("edges", source_path)
+            return
+        self._edges[encoded] = edge
+
+    def _frontier_node(
+        self,
+        kind: str,
+        source_path: str,
+        node: ast.AST,
+        *,
+        source_symbol: str = "",
+        target: str = "",
+    ) -> None:
+        start, end = _span(node)
+        self._frontier(kind, source_path, source_symbol, target, start, end)
+
+    def _frontier(
+        self,
+        kind: str,
+        source_path: str,
+        source_symbol: str = "",
+        target: str = "",
+        line_start: int = 0,
+        line_end: int = 0,
+    ) -> None:
+        if any(
+            len(str(value or "")) > self.limits.max_text_chars
+            for value in (kind, source_path, source_symbol, target)
+        ):
+            self._bound_kinds.add("text")
+            kind = "analysis_bound"
+            source_path = source_path if len(source_path) <= self.limits.max_text_chars else ""
+            source_symbol = ""
+            target = "text"
+            line_start = 0
+            line_end = 0
+        try:
+            item = UnknownDependencyFrontier(
+                kind=kind,
+                source_path=source_path,
+                source_symbol=source_symbol,
+                target=target,
+                line_start=line_start,
+                line_end=line_end,
+            )
+        except StaticTraceError:
+            self._bound_kinds.add("text")
+            item = UnknownDependencyFrontier("analysis_bound", source_path, target="text")
+        if item.frontier_id in self._frontiers:
+            return
+        if len(self._frontiers) >= self.limits.max_frontier:
+            self._bound_kinds.add("frontier")
+            marker = UnknownDependencyFrontier("analysis_bound", self._root_path, target="frontier")
+            if marker.frontier_id not in self._frontiers:
+                # The bound marker is authority-relevant and may not itself be
+                # discarded by the bound.  Evict a deterministic detail row.
+                evicted = max(self._frontiers)
+                del self._frontiers[evicted]
+                self._frontiers[marker.frontier_id] = marker
+            return
+        self._frontiers[item.frontier_id] = item
+
+    def _bound(self, kind: str, source_path: str, *, target: str = "") -> None:
+        self._bound_kinds.add(kind)
+        self._frontier("analysis_bound", source_path or self._root_path, target=target or kind)
+
+
+def trace_static_dependencies(
+    analysis_index: AnalysisASTIndex,
+    test_path: str,
+    *,
+    repository_root: str | os.PathLike[str],
+    test_symbol: str = "",
+    node_id: str = "",
+    limits: StaticTraceLimits | None = None,
+    identity_minter: Callable[[Any], ContentIdentity] = mint_content_identity,
+) -> StaticTestDependencyTrace:
+    """Convenience wrapper for a single static dependency trace."""
+
+    return StaticTestDependencyTracer(
+        analysis_index,
+        repository_root,
+        limits=limits,
+        identity_minter=identity_minter,
+    ).trace(test_path, test_symbol, node_id=node_id)
+
+
+__all__ = [
     "STATIC_TEST_DEPENDENCY_TRACE_INTERFACE",
+    "STATIC_TEST_DEPENDENCY_TRACE_SCHEMA",
     "STATIC_TEST_DEPENDENCY_TRACER_INTERFACE",
+    "STATIC_TRACE_ANALYZER_INTERFACE",
+    "STATIC_TRACE_LIMITS_INTERFACE",
     "StaticTestDependencyTrace",
     "StaticTestDependencyTracer",
-    "StaticUnknownFrontierEntry",
-)
+    "StaticTraceError",
+    "StaticTraceLimits",
+    "UnknownDependencyFrontier",
+    "trace_static_dependencies",
+]

--- a/ipfs_accelerate_py/agent_supervisor/proof/test_candidate_context_store.py
+++ b/ipfs_accelerate_py/agent_supervisor/proof/test_candidate_context_store.py
@@ -1,29 +1,99 @@
-"""Dedicated candidate-context CAS for two-stage warm lookup (PTR-145).
+"""Immutable candidate execution context CAS, fenced index, and atomic publication.
 
-Retains exact canonical component bytes keyed by locator CID.  Index hits are
-hints only — callers must rehash retained bytes before trusting content.
-This store never authorizes SKIP.
+``TestCandidateContextStore@1`` retains exact pass-time canonical bytes so a
+later warm run can reconstruct what a certificate attests.  Authority still
+lives in the proof cache / certificate path: this module never treats index
+metadata, cache presence, historical execution keys, or the candidate
+descriptor itself as skip authority.
+
+Write protocol (fail-closed):
+
+1. Bound and rehash every retained component; confirm internal field CIDs and
+   external claimed CIDs agree.
+2. Write each component and the envelope to the immutable CAS via temporary
+   file, fsync, and ``os.replace``.
+3. Read published paths back and rehash; only then may the locator index be
+   updated under a single-flight write fence.
+4. Index publication is controller-fenced so parallel writers cannot mix
+   components from different generations.
+
+Reads reject symlinks, path escapes, oversized or partial files, poisoned
+indexes, stale generations, remote failures, and transport absence.  Corrupt
+artifacts are quarantined where safe and surface as typed misses.
+``may_authorize_skip`` is always false for every store surface.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import re
+import tempfile
 import threading
 import time
-from collections.abc import Callable, Mapping
+import uuid
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, ClassVar, Final
+from typing import Any, ClassVar, Final, Protocol, runtime_checkable
 
 from .formal_verification_contracts import canonical_json_bytes, content_identity
+from .test_certificate_store import (
+    CertificateStoreFenceError,
+    CertificateStoreIntegrityError,
+    CertificateStoreReason as _CasReason,
+    CertificateStoreStatus as _CasStatus,
+    CertificateWriteFence,
+    ImmutableCertificateCAS,
+    _cid_for_canonical_bytes,
+    _exclusive_lock,
+    _now_ms,
+    _object_without_duplicate_keys,
+    _validate_cid_token,
+)
+
+try:
+    from ...testing.proof_reuse.activation_contracts import (
+        ArtifactRole,
+        CandidateExecutionContext,
+        admit_content_addressed_boundary,
+    )
+except ImportError:  # pragma: no cover - package layout fallback
+    from ipfs_accelerate_py.testing.proof_reuse.activation_contracts import (
+        ArtifactRole,
+        CandidateExecutionContext,
+        admit_content_addressed_boundary,
+    )
 
 TEST_CANDIDATE_CONTEXT_STORE_INTERFACE: Final = "TestCandidateContextStore@1"
 TEST_CANDIDATE_CONTEXT_STORE_SCHEMA: Final = (
     "ipfs_accelerate_py/agent-supervisor/test-candidate-context-store@1"
 )
+TEST_CANDIDATE_CONTEXT_INDEX_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/test-candidate-context-index@1"
+)
+CANDIDATE_CONTEXT_ENVELOPE_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/candidate-context-envelope@1"
+)
+CANDIDATE_CONTEXT_ENVELOPE_INTERFACE: Final = "CandidateContextEnvelope@1"
+CANONICAL_ARTIFACT_STORE_TRANSPORT_INTERFACE: Final = (
+    "CanonicalArtifactStoreTransport@1"
+)
+CANDIDATE_EXECUTION_CONTEXT_INTERFACE: Final = "CandidateExecutionContext@1"
 
+DEFAULT_MAX_BLOB_BYTES: Final = 1_048_576
+DEFAULT_MAX_COMPONENT_BYTES: Final = 1_048_576
+DEFAULT_MAX_CANDIDATES: Final = 32
+DEFAULT_MAX_INDEX_BYTES: Final = 256 * 1024
+DEFAULT_INDEX_TTL_MS: Final = 7 * 24 * 60 * 60 * 1000
+DEFAULT_FENCE_TTL_MS: Final = 30_000
+DEFAULT_LOCK_TIMEOUT_SECONDS: Final = 30.0
+ENVELOPE_VERSION: Final = 1
+
+_INDEX_SUFFIX: Final = ".json"
+_TMP_PREFIX: Final = ".tmp."
+
+# Retained pass-time components that must rehash on every admission.
 REQUIRED_COMPONENT_KEYS: Final[tuple[str, ...]] = (
     "execution_key",
     "static_trace",
@@ -32,246 +102,2231 @@ REQUIRED_COMPONENT_KEYS: Final[tuple[str, ...]] = (
     "environment",
     "policy",
     "pass_receipt",
-    "test_ast",
 )
 
-_CID_SAFE_RE: Final = re.compile(r"^[a-z0-9]+$")
-_DEFAULT_MAX_BLOB_BYTES: Final = 2 * 1_048_576
+# Map store component keys → CandidateExecutionContext field names.
+COMPONENT_FIELD_MAP: Final[Mapping[str, str]] = {
+    "execution_key": "execution_key_cid",
+    "static_trace": "static_trace_root_cid",
+    "runtime_trace": "runtime_trace_root_cid",
+    "repository_forest": "repository_forest_cid",
+    "environment": "environment_cid",
+    "policy": "policy_cid",
+    "pass_receipt": "pass_receipt_cid",
+    "test_ast": "test_ast_cid",
+    "dependency_lock": "dependency_lock_cid",
+    "installed_distributions": "installed_distributions_cid",
+    "platform": "platform_cid",
+    "capability_root": "capability_root_cid",
+}
 
 
 class CandidateContextStoreError(RuntimeError):
-    """Operational failure for the candidate-context store."""
+    """Base class for candidate-context store operational failures."""
+
+    __test__ = False
 
 
-@dataclass(frozen=True, slots=True)
-class CandidateContextPublishResult:
-    """Result of :meth:`TestCandidateContextStore.publish`."""
+class CandidateContextStoreIntegrityError(CandidateContextStoreError, ValueError):
+    """Blob, envelope, or index failed integrity / path safety checks."""
 
-    stored: bool
-    may_authorize_skip: bool = False
-    reason_code: str = ""
-    locator_cid: str = ""
-    candidate_context_cid: str = ""
+    __test__ = False
 
 
-@dataclass(frozen=True, slots=True)
-class CandidateContextLookupResult:
-    """Result of :meth:`TestCandidateContextStore.lookup`."""
+class CandidateContextStoreStatus(StrEnum):
+    """Closed store / lookup result states."""
 
-    hit: bool
-    may_authorize_skip: bool = False
-    reason_code: str = ""
-    locator_cid: str = ""
-    descriptor_bytes: bytes = b""
-    component_bytes: Mapping[str, bytes] = field(default_factory=dict)
-    candidate_context_cid: str = ""
+    STORED = "stored"
+    HIT = "hit"
+    MISS = "miss"
+    REJECTED = "rejected"
+    ERROR = "error"
+
+    __test__ = False
 
 
-class TestCandidateContextStore:
-    """Filesystem-backed candidate context store with rehash-on-read semantics."""
+class CandidateContextStoreReason(StrEnum):
+    """Typed reasons for store admissions and safe misses."""
+
+    OK = "ok"
+    OVER_BUDGET = "over_budget"
+    MALFORMED = "malformed"
+    INTEGRITY_FAILED = "integrity_failed"
+    PATH_ESCAPE = "path_escape"
+    SYMLINK_REJECTED = "symlink_rejected"
+    CORRUPT = "corrupt"
+    PARTIAL = "partial"
+    QUARANTINED = "quarantined"
+    FENCED = "fenced"
+    FENCE_MISMATCH = "fence_mismatch"
+    FENCE_EXPIRED = "fence_expired"
+    REVOKED = "revoked"
+    EXPIRED = "expired"
+    UNAVAILABLE = "unavailable"
+    CANDIDATE_MISSING = "candidate_missing"
+    CID_MISMATCH = "cid_mismatch"
+    ALREADY_EXISTS = "already_exists"
+    INDEX_POISONED = "index_poisoned"
+    STALE_GENERATION = "stale_generation"
+    TRANSPORT_ABSENT = "transport_absent"
+    REMOTE_FAILURE = "remote_failure"
+    VERSION_MISMATCH = "version_mismatch"
+    SIZE_EXCEEDED = "size_exceeded"
+    COMPONENT_MISSING = "component_missing"
+    INTERNAL_EXTERNAL_CID_MISMATCH = "internal_external_cid_mismatch"
+
+    __test__ = False
+
+
+def _map_cas_reason(reason: _CasReason | str) -> CandidateContextStoreReason:
+    value = reason.value if isinstance(reason, _CasReason) else str(reason)
+    try:
+        return CandidateContextStoreReason(value)
+    except ValueError:
+        return CandidateContextStoreReason.UNAVAILABLE
+
+
+@runtime_checkable
+class CanonicalArtifactStoreTransport(Protocol):
+    """Optional remote/local byte transport; never skip authority.
+
+    Implementations must rehash retained bytes before returning a hit.
+    Absence or failure of this transport is a typed miss, never an exception
+    that suppresses test execution.
+    """
+
+    @property
+    def interface(self) -> str:  # pragma: no cover - protocol
+        ...
+
+    def get_bytes(self, cid: str) -> Any:  # pragma: no cover - protocol
+        ...
+
+    def put_bytes(self, data: bytes, **kwargs: Any) -> Any:  # pragma: no cover
+        ...
+
+
+@dataclass(frozen=True)
+class CandidateContextEnvelope:
+    """Immutable publication unit binding a descriptor to retained components.
+
+    The envelope is content-addressed.  Index entries that point at an envelope
+    are retrieval hints only and never authorize ``SKIP``.
+    """
 
     __test__: ClassVar[bool] = False
-    interface: ClassVar[str] = TEST_CANDIDATE_CONTEXT_STORE_INTERFACE
+    SCHEMA: ClassVar[str] = CANDIDATE_CONTEXT_ENVELOPE_SCHEMA
+
+    candidate_context_cid: str
+    locator_cid: str
+    execution_key_cid: str
+    pass_receipt_cid: str
+    component_cids: Mapping[str, str]
+    version: int = ENVELOPE_VERSION
+    generation: int = 1
+    created_at_ms: int = 0
+    expires_at_ms: int | None = None
+    fencing_token: int | None = None
+    byte_length: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_context_cid",
+            _validate_cid_token(
+                self.candidate_context_cid, field_name="candidate_context_cid"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "locator_cid",
+            _validate_cid_token(self.locator_cid, field_name="locator_cid"),
+        )
+        object.__setattr__(
+            self,
+            "execution_key_cid",
+            _validate_cid_token(
+                self.execution_key_cid, field_name="execution_key_cid"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "pass_receipt_cid",
+            _validate_cid_token(
+                self.pass_receipt_cid, field_name="pass_receipt_cid"
+            ),
+        )
+        if (
+            isinstance(self.version, bool)
+            or not isinstance(self.version, int)
+            or self.version < 1
+        ):
+            raise CandidateContextStoreIntegrityError("version must be a positive int")
+        if (
+            isinstance(self.generation, bool)
+            or not isinstance(self.generation, int)
+            or self.generation < 1
+        ):
+            raise CandidateContextStoreIntegrityError(
+                "generation must be a positive int"
+            )
+        if (
+            isinstance(self.created_at_ms, bool)
+            or not isinstance(self.created_at_ms, int)
+            or self.created_at_ms < 0
+        ):
+            raise CandidateContextStoreIntegrityError("created_at_ms is invalid")
+        if self.expires_at_ms is not None and (
+            isinstance(self.expires_at_ms, bool)
+            or not isinstance(self.expires_at_ms, int)
+            or self.expires_at_ms < 0
+        ):
+            raise CandidateContextStoreIntegrityError("expires_at_ms is invalid")
+        if self.fencing_token is not None and (
+            isinstance(self.fencing_token, bool)
+            or not isinstance(self.fencing_token, int)
+            or self.fencing_token < 0
+        ):
+            raise CandidateContextStoreIntegrityError("fencing_token is invalid")
+        if (
+            isinstance(self.byte_length, bool)
+            or not isinstance(self.byte_length, int)
+            or self.byte_length < 0
+        ):
+            raise CandidateContextStoreIntegrityError("byte_length is invalid")
+        if not isinstance(self.component_cids, Mapping) or not self.component_cids:
+            raise CandidateContextStoreIntegrityError(
+                "component_cids must be a nonempty mapping"
+            )
+        normalized: dict[str, str] = {}
+        for key, value in self.component_cids.items():
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise CandidateContextStoreIntegrityError(
+                    "component_cids keys are invalid"
+                )
+            normalized[key] = _validate_cid_token(
+                str(value), field_name=f"component_cids.{key}"
+            )
+        for required in REQUIRED_COMPONENT_KEYS:
+            if required not in normalized:
+                raise CandidateContextStoreIntegrityError(
+                    f"missing required component {required}"
+                )
+        object.__setattr__(self, "component_cids", dict(normalized))
+        metadata = self.metadata or {}
+        if not isinstance(metadata, Mapping):
+            raise CandidateContextStoreIntegrityError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", dict(metadata))
+
+    @property
+    def interface(self) -> str:
+        return CANDIDATE_CONTEXT_ENVELOPE_INTERFACE
+
+    @property
+    def may_authorize_skip(self) -> bool:
+        return False
+
+    @property
+    def envelope_id(self) -> str:
+        return content_identity(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema": self.SCHEMA,
+            "interface": CANDIDATE_CONTEXT_ENVELOPE_INTERFACE,
+            "version": self.version,
+            "generation": self.generation,
+            "candidate_context_cid": self.candidate_context_cid,
+            "locator_cid": self.locator_cid,
+            "execution_key_cid": self.execution_key_cid,
+            "pass_receipt_cid": self.pass_receipt_cid,
+            "component_cids": dict(self.component_cids),
+            "created_at_ms": self.created_at_ms,
+            "byte_length": self.byte_length,
+            "may_authorize_skip": False,
+        }
+        if self.expires_at_ms is not None:
+            payload["expires_at_ms"] = self.expires_at_ms
+        if self.fencing_token is not None:
+            payload["fencing_token"] = self.fencing_token
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CandidateContextEnvelope":
+        if not isinstance(payload, Mapping):
+            raise CandidateContextStoreIntegrityError("envelope must be an object")
+        if payload.get("schema") != cls.SCHEMA:
+            raise CandidateContextStoreIntegrityError("envelope schema mismatch")
+        if payload.get("interface") not in (
+            None,
+            "",
+            CANDIDATE_CONTEXT_ENVELOPE_INTERFACE,
+        ):
+            raise CandidateContextStoreIntegrityError("envelope interface mismatch")
+        if payload.get("may_authorize_skip") is True:
+            raise CandidateContextStoreIntegrityError(
+                "envelope must not claim skip authority"
+            )
+        return cls(
+            candidate_context_cid=str(payload.get("candidate_context_cid", "")),
+            locator_cid=str(payload.get("locator_cid", "")),
+            execution_key_cid=str(payload.get("execution_key_cid", "")),
+            pass_receipt_cid=str(payload.get("pass_receipt_cid", "")),
+            component_cids=dict(payload.get("component_cids") or {}),
+            version=int(payload.get("version", ENVELOPE_VERSION)),
+            generation=int(payload.get("generation", 1)),
+            created_at_ms=int(payload.get("created_at_ms", 0)),
+            expires_at_ms=(
+                None
+                if payload.get("expires_at_ms") is None
+                else int(payload["expires_at_ms"])
+            ),
+            fencing_token=(
+                None
+                if payload.get("fencing_token") is None
+                else int(payload["fencing_token"])
+            ),
+            byte_length=int(payload.get("byte_length", 0)),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "CandidateContextEnvelope":
+        if type(data) is not bytes or not data:
+            raise CandidateContextStoreIntegrityError("envelope bytes are required")
+        try:
+            payload = json.loads(
+                data.decode("utf-8"),
+                object_pairs_hook=_object_without_duplicate_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.CORRUPT.value
+            ) from exc
+        envelope = cls.from_dict(payload)
+        recomputed = envelope.canonical_bytes()
+        if recomputed != data:
+            raise CandidateContextStoreIntegrityError(
+                "envelope bytes are not canonical DAG-JSON form"
+            )
+        return envelope
+
+
+@dataclass(frozen=True)
+class CandidateContextIndexHint:
+    """One locator-index hint; never pass authority by itself."""
+
+    __test__: ClassVar[bool] = False
+
+    envelope_cid: str
+    candidate_context_cid: str
+    execution_key_cid: str
+    generation: int
+    created_at_ms: int
+    expires_at_ms: int | None = None
+    revoked: bool = False
+    quarantined: bool = False
+    fencing_token: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "envelope_cid": self.envelope_cid,
+            "candidate_context_cid": self.candidate_context_cid,
+            "execution_key_cid": self.execution_key_cid,
+            "generation": self.generation,
+            "created_at_ms": self.created_at_ms,
+            "revoked": bool(self.revoked),
+            "quarantined": bool(self.quarantined),
+            "may_authorize_skip": False,
+        }
+        if self.expires_at_ms is not None:
+            payload["expires_at_ms"] = self.expires_at_ms
+        if self.fencing_token is not None:
+            payload["fencing_token"] = self.fencing_token
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CandidateContextIndexHint":
+        if not isinstance(payload, Mapping):
+            raise CandidateContextStoreIntegrityError("index hint must be an object")
+        if payload.get("may_authorize_skip") is True:
+            raise CandidateContextStoreIntegrityError(
+                "index hint must not claim skip authority"
+            )
+        generation = payload.get("generation", 1)
+        if (
+            isinstance(generation, bool)
+            or not isinstance(generation, int)
+            or generation < 1
+        ):
+            raise CandidateContextStoreIntegrityError("generation is invalid")
+        created = payload.get("created_at_ms")
+        if isinstance(created, bool) or not isinstance(created, int) or created < 0:
+            raise CandidateContextStoreIntegrityError("created_at_ms is invalid")
+        expires = payload.get("expires_at_ms")
+        if expires is not None and (
+            isinstance(expires, bool) or not isinstance(expires, int) or expires < 0
+        ):
+            raise CandidateContextStoreIntegrityError("expires_at_ms is invalid")
+        fencing = payload.get("fencing_token")
+        if fencing is not None and (
+            isinstance(fencing, bool) or not isinstance(fencing, int) or fencing < 0
+        ):
+            raise CandidateContextStoreIntegrityError("fencing_token is invalid")
+        metadata = payload.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            raise CandidateContextStoreIntegrityError("hint metadata must be a mapping")
+        return cls(
+            envelope_cid=_validate_cid_token(
+                str(payload.get("envelope_cid", "")), field_name="envelope_cid"
+            ),
+            candidate_context_cid=_validate_cid_token(
+                str(payload.get("candidate_context_cid", "")),
+                field_name="candidate_context_cid",
+            ),
+            execution_key_cid=_validate_cid_token(
+                str(payload.get("execution_key_cid", "")),
+                field_name="execution_key_cid",
+            ),
+            generation=generation,
+            created_at_ms=created,
+            expires_at_ms=expires,
+            revoked=bool(payload.get("revoked", False)),
+            quarantined=bool(payload.get("quarantined", False)),
+            fencing_token=fencing,
+            metadata=dict(metadata),
+        )
+
+
+@dataclass(frozen=True)
+class CandidateContextPutResult:
+    """Outcome of an atomic candidate-context publication."""
+
+    __test__: ClassVar[bool] = False
+
+    stored: bool
+    reason_code: CandidateContextStoreReason
+    envelope_cid: str = ""
+    candidate_context_cid: str = ""
+    locator_cid: str = ""
+    generation: int = 0
+    indexed: bool = False
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.stored
+
+    @property
+    def may_authorize_skip(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class CandidateContextAdmission:
+    """Result of rehashing every retained component for one candidate.
+
+    Admission never elevates cache presence or historical keys into ``SKIP``.
+    """
+
+    __test__: ClassVar[bool] = False
+
+    admitted: bool
+    reason_code: CandidateContextStoreReason
+    envelope_cid: str = ""
+    candidate_context_cid: str = ""
+    component_cids: Mapping[str, str] = field(default_factory=dict)
+    byte_length: int = 0
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.admitted
+
+    @property
+    def may_authorize_skip(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class CandidateContextLookupResult:
+    """Lookup outcome: exact bytes plus a non-authoritative descriptor.
+
+    ``descriptor`` is the decoded :class:`CandidateExecutionContext` and is
+    never skip authority.  ``envelope_bytes`` / ``descriptor_bytes`` are the
+    retained canonical forms after rehash admission.
+    """
+
+    __test__: ClassVar[bool] = False
+
+    status: CandidateContextStoreStatus
+    reason_code: CandidateContextStoreReason
+    envelope_cid: str = ""
+    candidate_context_cid: str = ""
+    envelope_bytes: bytes | None = None
+    descriptor_bytes: bytes | None = None
+    descriptor: CandidateExecutionContext | None = None
+    component_bytes: Mapping[str, bytes] = field(default_factory=dict)
+    admission: CandidateContextAdmission | None = None
+    generation: int = 0
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return (
+            self.status is CandidateContextStoreStatus.HIT
+            and self.descriptor is not None
+            and (
+                self.envelope_bytes is not None or self.descriptor_bytes is not None
+            )
+        )
+
+    @property
+    def hit(self) -> bool:
+        return bool(self)
+
+    @property
+    def may_authorize_skip(self) -> bool:
+        return False
+
+    @property
+    def bytes(self) -> bytes | None:
+        """Primary retained bytes returned by lookup (envelope, else descriptor)."""
+
+        if self.envelope_bytes is not None:
+            return self.envelope_bytes
+        return self.descriptor_bytes
+
+
+@dataclass(frozen=True)
+class IndexPublishResult:
+    __test__: ClassVar[bool] = False
+
+    published: bool
+    locator_cid: str
+    reason_code: CandidateContextStoreReason
+    candidate_count: int = 0
+    generation: int = 0
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.published
+
+
+@dataclass(frozen=True)
+class IndexLookupResult:
+    __test__: ClassVar[bool] = False
+
+    status: CandidateContextStoreStatus
+    locator_cid: str
+    reason_code: CandidateContextStoreReason
+    candidates: tuple[CandidateContextIndexHint, ...] = ()
+    generation: int = 0
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return self.status is CandidateContextStoreStatus.HIT and bool(self.candidates)
+
+
+class CandidateContextIndex:
+    """Mutable locator → bounded candidate-context envelope hints.
+
+    Index entries are never authority.  TTL, revocation, quarantine, and
+    generation fencing only affect whether a CID is *suggested* for re-admission.
+    """
+
+    __test__ = False
 
     def __init__(
         self,
-        root: str | Path,
+        root: str | os.PathLike[str],
         *,
-        clock: Callable[[], float] | None = None,
-        max_blob_bytes: int = _DEFAULT_MAX_BLOB_BYTES,
+        max_candidates: int = DEFAULT_MAX_CANDIDATES,
+        max_index_bytes: int = DEFAULT_MAX_INDEX_BYTES,
+        default_ttl_ms: int = DEFAULT_INDEX_TTL_MS,
+        lock_timeout_seconds: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+        clock: Callable[[], float] | Callable[[], int] | None = None,
     ) -> None:
-        self.root = Path(root)
-        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._clock = clock or time.time
-        self._max_blob_bytes = int(max_blob_bytes)
-        self._lock = threading.RLock()
-        (self.root / "blobs").mkdir(exist_ok=True, mode=0o700)
-        (self.root / "index").mkdir(exist_ok=True, mode=0o700)
+        if (
+            isinstance(max_candidates, bool)
+            or not isinstance(max_candidates, int)
+            or max_candidates <= 0
+        ):
+            raise ValueError("max_candidates must be a positive integer")
+        if (
+            isinstance(max_index_bytes, bool)
+            or not isinstance(max_index_bytes, int)
+            or max_index_bytes <= 0
+        ):
+            raise ValueError("max_index_bytes must be a positive integer")
+        self.root = Path(root).resolve()
+        self.index_root = self.root / "candidate_index"
+        self.lock_root = self.root / "locks" / "candidate_index"
+        self.max_candidates = int(max_candidates)
+        self.max_index_bytes = int(max_index_bytes)
+        self.default_ttl_ms = int(default_ttl_ms)
+        self.lock_timeout_seconds = float(lock_timeout_seconds)
+        self._clock = clock
+        self.index_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.lock_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    def _index_path(self, locator_cid: str) -> Path:
+        token = _validate_cid_token(locator_cid, field_name="locator_cid")
+        return self.index_root / f"{token}{_INDEX_SUFFIX}"
+
+    def _lock_path(self, locator_cid: str) -> Path:
+        token = _validate_cid_token(locator_cid, field_name="locator_cid")
+        return self.lock_root / f"{token}.lock"
+
+    def _ensure_index_path(self, locator_cid: str) -> Path:
+        path = self._index_path(locator_cid)
+        base = self.index_root.resolve()
+        if path.is_symlink():
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.SYMLINK_REJECTED.value
+            )
+        try:
+            if path.exists():
+                path.resolve(strict=True).relative_to(base)
+            else:
+                path.parent.resolve().relative_to(base)
+        except ValueError as exc:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.PATH_ESCAPE.value
+            ) from exc
+        return path
+
+    def _read_document(
+        self, path: Path, *, locator_cid: str
+    ) -> dict[str, Any] | None:
+        if not path.exists():
+            return None
+        if path.is_symlink():
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.SYMLINK_REJECTED.value
+            )
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise CandidateContextStoreError("index unavailable") from exc
+        if not raw:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.PARTIAL.value
+            )
+        if len(raw) > self.max_index_bytes:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.OVER_BUDGET.value
+            )
+        try:
+            payload = json.loads(
+                raw.decode("utf-8"),
+                object_pairs_hook=_object_without_duplicate_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            ) from exc
+        if not isinstance(payload, Mapping):
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            )
+        if payload.get("schema") != TEST_CANDIDATE_CONTEXT_INDEX_SCHEMA:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            )
+        if payload.get("locator_cid") != locator_cid:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            )
+        if payload.get("may_authorize_skip") is True:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            )
+        generation = payload.get("generation", 1)
+        if (
+            isinstance(generation, bool)
+            or not isinstance(generation, int)
+            or generation < 1
+        ):
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.INDEX_POISONED.value
+            )
+        return dict(payload)
+
+    def _write_document(self, path: Path, document: Mapping[str, Any]) -> None:
+        encoded = canonical_json_bytes(document)
+        if len(encoded) > self.max_index_bytes:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.OVER_BUDGET.value
+            )
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f"{_TMP_PREFIX}{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        temporary = Path(temporary_name)
+        try:
+            if temporary.is_symlink():
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.SYMLINK_REJECTED.value
+                )
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(encoded)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.chmod(temporary, 0o600)
+            except OSError:
+                pass
+            os.replace(temporary, path)
+            try:
+                directory_fd = os.open(path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError:
+                pass
+        finally:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
 
     def publish(
         self,
-        candidate: Any,
+        locator_cid: str,
+        *,
+        envelope_cid: str,
+        candidate_context_cid: str,
+        execution_key_cid: str,
+        generation: int | None = None,
+        created_at_ms: int | None = None,
+        expires_at_ms: int | None = None,
+        fencing_token: int | None = None,
+        expected_fencing_token: int | None = None,
+        expected_generation: int | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> IndexPublishResult:
+        """Atomically append/replace one envelope hint for ``locator_cid``."""
+
+        try:
+            locator = _validate_cid_token(locator_cid, field_name="locator_cid")
+            envelope = _validate_cid_token(envelope_cid, field_name="envelope_cid")
+            context = _validate_cid_token(
+                candidate_context_cid, field_name="candidate_context_cid"
+            )
+            execution = _validate_cid_token(
+                execution_key_cid, field_name="execution_key_cid"
+            )
+            path = self._ensure_index_path(locator)
+        except (CertificateStoreIntegrityError, CandidateContextStoreIntegrityError) as exc:
+            reason = CandidateContextStoreReason.PATH_ESCAPE
+            if str(exc) == CandidateContextStoreReason.SYMLINK_REJECTED.value:
+                reason = CandidateContextStoreReason.SYMLINK_REJECTED
+            return IndexPublishResult(False, str(locator_cid), reason)
+
+        now = _now_ms(self._clock)
+        created = now if created_at_ms is None else created_at_ms
+        if isinstance(created, bool) or not isinstance(created, int) or created < 0:
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.MALFORMED
+            )
+        expires = expires_at_ms
+        if expires is None and self.default_ttl_ms > 0:
+            expires = created + self.default_ttl_ms
+        if expires is not None and (
+            isinstance(expires, bool) or not isinstance(expires, int) or expires < 0
+        ):
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.MALFORMED
+            )
+        if expires is not None and expires <= created:
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.MALFORMED
+            )
+
+        lock_path = self._lock_path(locator)
+        try:
+            with _exclusive_lock(
+                lock_path, timeout_seconds=self.lock_timeout_seconds
+            ):
+                if (
+                    expected_fencing_token is not None
+                    and fencing_token is not None
+                    and fencing_token != expected_fencing_token
+                ):
+                    return IndexPublishResult(
+                        False, locator, CandidateContextStoreReason.FENCE_MISMATCH
+                    )
+                try:
+                    document = self._read_document(path, locator_cid=locator)
+                except CandidateContextStoreIntegrityError as exc:
+                    reason_value = str(exc)
+                    try:
+                        reason = CandidateContextStoreReason(reason_value)
+                    except ValueError:
+                        reason = CandidateContextStoreReason.INDEX_POISONED
+                    if reason is CandidateContextStoreReason.SYMLINK_REJECTED:
+                        return IndexPublishResult(False, locator, reason)
+                    # Poisoned index: start a fresh document rather than mix.
+                    document = None
+                existing: list[CandidateContextIndexHint] = []
+                current_generation = 0
+                if document is not None:
+                    current_generation = int(document.get("generation", 0) or 0)
+                    raw_candidates = document.get("candidates", [])
+                    if not isinstance(raw_candidates, list):
+                        existing = []
+                    else:
+                        for item in raw_candidates:
+                            try:
+                                existing.append(
+                                    CandidateContextIndexHint.from_dict(item)
+                                )
+                            except (
+                                CandidateContextStoreIntegrityError,
+                                CertificateStoreIntegrityError,
+                            ):
+                                continue
+                if expected_generation is not None:
+                    if current_generation != expected_generation:
+                        return IndexPublishResult(
+                            False,
+                            locator,
+                            CandidateContextStoreReason.STALE_GENERATION,
+                            generation=current_generation,
+                            diagnostics={
+                                "expected_generation": expected_generation,
+                                "current_generation": current_generation,
+                            },
+                        )
+                next_generation = (
+                    int(generation)
+                    if generation is not None
+                    else current_generation + 1
+                )
+                if next_generation <= current_generation:
+                    return IndexPublishResult(
+                        False,
+                        locator,
+                        CandidateContextStoreReason.STALE_GENERATION,
+                        generation=current_generation,
+                    )
+                hint = CandidateContextIndexHint(
+                    envelope_cid=envelope,
+                    candidate_context_cid=context,
+                    execution_key_cid=execution,
+                    generation=next_generation,
+                    created_at_ms=created,
+                    expires_at_ms=expires,
+                    fencing_token=fencing_token,
+                    metadata=dict(metadata or {}),
+                )
+                merged = [
+                    item
+                    for item in existing
+                    if item.envelope_cid != hint.envelope_cid
+                    and item.candidate_context_cid != hint.candidate_context_cid
+                ]
+                merged.insert(0, hint)
+                merged = merged[: self.max_candidates]
+                payload = {
+                    "schema": TEST_CANDIDATE_CONTEXT_INDEX_SCHEMA,
+                    "interface": TEST_CANDIDATE_CONTEXT_STORE_INTERFACE,
+                    "locator_cid": locator,
+                    "generation": next_generation,
+                    "updated_at_ms": now,
+                    "may_authorize_skip": False,
+                    "candidates": [item.to_dict() for item in merged],
+                }
+                if fencing_token is not None:
+                    payload["fencing_token"] = int(fencing_token)
+                self._write_document(path, payload)
+                return IndexPublishResult(
+                    True,
+                    locator,
+                    CandidateContextStoreReason.OK,
+                    candidate_count=len(merged),
+                    generation=next_generation,
+                )
+        except TimeoutError:
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.UNAVAILABLE
+            )
+        except CandidateContextStoreIntegrityError as exc:
+            reason_value = str(exc)
+            try:
+                reason = CandidateContextStoreReason(reason_value)
+            except ValueError:
+                reason = CandidateContextStoreReason.CORRUPT
+            return IndexPublishResult(False, locator, reason)
+        except OSError:
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.UNAVAILABLE
+            )
+
+    def candidates(
+        self,
+        locator_cid: str,
+        *,
+        max_candidates: int | None = None,
+        now_ms: int | None = None,
+        include_revoked: bool = False,
+        include_quarantined: bool = False,
+        min_generation: int | None = None,
+    ) -> IndexLookupResult:
+        try:
+            locator = _validate_cid_token(locator_cid, field_name="locator_cid")
+            path = self._ensure_index_path(locator)
+        except (CertificateStoreIntegrityError, CandidateContextStoreIntegrityError) as exc:
+            reason = CandidateContextStoreReason.PATH_ESCAPE
+            if str(exc) == CandidateContextStoreReason.SYMLINK_REJECTED.value:
+                reason = CandidateContextStoreReason.SYMLINK_REJECTED
+            return IndexLookupResult(
+                CandidateContextStoreStatus.MISS, str(locator_cid), reason
+            )
+
+        limit = self.max_candidates if max_candidates is None else max_candidates
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            return IndexLookupResult(
+                CandidateContextStoreStatus.MISS,
+                locator,
+                CandidateContextStoreReason.MALFORMED,
+            )
+        current = _now_ms(self._clock) if now_ms is None else now_ms
+        if isinstance(current, bool) or not isinstance(current, int) or current < 0:
+            return IndexLookupResult(
+                CandidateContextStoreStatus.MISS,
+                locator,
+                CandidateContextStoreReason.MALFORMED,
+            )
+
+        lock_path = self._lock_path(locator)
+        try:
+            with _exclusive_lock(
+                lock_path, timeout_seconds=self.lock_timeout_seconds
+            ):
+                try:
+                    document = self._read_document(path, locator_cid=locator)
+                except CandidateContextStoreIntegrityError as exc:
+                    reason_value = str(exc)
+                    try:
+                        reason = CandidateContextStoreReason(reason_value)
+                    except ValueError:
+                        reason = CandidateContextStoreReason.INDEX_POISONED
+                    return IndexLookupResult(
+                        CandidateContextStoreStatus.MISS, locator, reason
+                    )
+                if document is None:
+                    return IndexLookupResult(
+                        CandidateContextStoreStatus.MISS,
+                        locator,
+                        CandidateContextStoreReason.CANDIDATE_MISSING,
+                    )
+                generation = int(document.get("generation", 0) or 0)
+                raw_candidates = document.get("candidates", [])
+                if not isinstance(raw_candidates, list):
+                    return IndexLookupResult(
+                        CandidateContextStoreStatus.MISS,
+                        locator,
+                        CandidateContextStoreReason.INDEX_POISONED,
+                        generation=generation,
+                    )
+                admitted: list[CandidateContextIndexHint] = []
+                for item in raw_candidates:
+                    if len(admitted) >= limit:
+                        break
+                    try:
+                        candidate = CandidateContextIndexHint.from_dict(item)
+                    except (
+                        CandidateContextStoreIntegrityError,
+                        CertificateStoreIntegrityError,
+                    ):
+                        continue
+                    if candidate.revoked and not include_revoked:
+                        continue
+                    if candidate.quarantined and not include_quarantined:
+                        continue
+                    if (
+                        candidate.expires_at_ms is not None
+                        and candidate.expires_at_ms <= current
+                    ):
+                        continue
+                    if (
+                        min_generation is not None
+                        and candidate.generation < min_generation
+                    ):
+                        continue
+                    admitted.append(candidate)
+                if not admitted:
+                    return IndexLookupResult(
+                        CandidateContextStoreStatus.MISS,
+                        locator,
+                        CandidateContextStoreReason.CANDIDATE_MISSING,
+                        generation=generation,
+                    )
+                return IndexLookupResult(
+                    CandidateContextStoreStatus.HIT,
+                    locator,
+                    CandidateContextStoreReason.OK,
+                    candidates=tuple(admitted),
+                    generation=generation,
+                )
+        except TimeoutError:
+            return IndexLookupResult(
+                CandidateContextStoreStatus.MISS,
+                locator,
+                CandidateContextStoreReason.UNAVAILABLE,
+            )
+        except OSError:
+            return IndexLookupResult(
+                CandidateContextStoreStatus.MISS,
+                locator,
+                CandidateContextStoreReason.UNAVAILABLE,
+            )
+
+    def revoke(
+        self, locator_cid: str, candidate_context_cid: str
+    ) -> IndexPublishResult:
+        return self._flag(
+            locator_cid,
+            candidate_context_cid,
+            field_name="revoked",
+            reason=CandidateContextStoreReason.REVOKED,
+        )
+
+    def quarantine(
+        self, locator_cid: str, candidate_context_cid: str
+    ) -> IndexPublishResult:
+        return self._flag(
+            locator_cid,
+            candidate_context_cid,
+            field_name="quarantined",
+            reason=CandidateContextStoreReason.QUARANTINED,
+        )
+
+    def _flag(
+        self,
+        locator_cid: str,
+        candidate_context_cid: str,
+        *,
+        field_name: str,
+        reason: CandidateContextStoreReason,
+    ) -> IndexPublishResult:
+        try:
+            locator = _validate_cid_token(locator_cid, field_name="locator_cid")
+            context = _validate_cid_token(
+                candidate_context_cid, field_name="candidate_context_cid"
+            )
+            path = self._ensure_index_path(locator)
+        except (CertificateStoreIntegrityError, CandidateContextStoreIntegrityError) as exc:
+            mapped = CandidateContextStoreReason.PATH_ESCAPE
+            if str(exc) == CandidateContextStoreReason.SYMLINK_REJECTED.value:
+                mapped = CandidateContextStoreReason.SYMLINK_REJECTED
+            return IndexPublishResult(False, str(locator_cid), mapped)
+
+        lock_path = self._lock_path(locator)
+        try:
+            with _exclusive_lock(
+                lock_path, timeout_seconds=self.lock_timeout_seconds
+            ):
+                document = self._read_document(path, locator_cid=locator)
+                if document is None:
+                    return IndexPublishResult(
+                        False, locator, CandidateContextStoreReason.CANDIDATE_MISSING
+                    )
+                changed = False
+                candidates: list[dict[str, Any]] = []
+                for item in document.get("candidates", []):
+                    if not isinstance(item, Mapping):
+                        continue
+                    entry = dict(item)
+                    if entry.get("candidate_context_cid") == context:
+                        entry[field_name] = True
+                        changed = True
+                    candidates.append(entry)
+                if not changed:
+                    return IndexPublishResult(
+                        False, locator, CandidateContextStoreReason.CANDIDATE_MISSING
+                    )
+                document = dict(document)
+                document["candidates"] = candidates
+                document["updated_at_ms"] = _now_ms(self._clock)
+                document["may_authorize_skip"] = False
+                self._write_document(path, document)
+                return IndexPublishResult(
+                    True,
+                    locator,
+                    reason,
+                    candidate_count=len(candidates),
+                    generation=int(document.get("generation", 0) or 0),
+                )
+        except CandidateContextStoreIntegrityError as exc:
+            reason_value = str(exc)
+            try:
+                mapped = CandidateContextStoreReason(reason_value)
+            except ValueError:
+                mapped = CandidateContextStoreReason.CORRUPT
+            return IndexPublishResult(False, locator, mapped)
+        except (TimeoutError, OSError):
+            return IndexPublishResult(
+                False, locator, CandidateContextStoreReason.UNAVAILABLE
+            )
+
+
+class TestCandidateContextStore:
+    """Facade combining immutable CAS, locator index, and write fencing.
+
+    ``publish`` is the single publication entrypoint that enforces temporary
+    file write → atomic replace → readback rehash of every retained component →
+    fenced index publication.  Parallel putters for the same locator cannot
+    publish a mixed multi-component unit: each publication is one fenced
+    generation.
+
+    Lookup returns retained envelope bytes plus a non-authoritative
+    :class:`CandidateExecutionContext` descriptor after admission rehash.
+    Nothing exposed by this store may authorize ``SKIP``.
+    """
+
+    __test__ = False
+    interface = TEST_CANDIDATE_CONTEXT_STORE_INTERFACE
+
+    def __init__(
+        self,
+        root: str | os.PathLike[str] | None = None,
+        *,
+        max_blob_bytes: int = DEFAULT_MAX_BLOB_BYTES,
+        max_component_bytes: int = DEFAULT_MAX_COMPONENT_BYTES,
+        max_candidates: int = DEFAULT_MAX_CANDIDATES,
+        max_index_bytes: int = DEFAULT_MAX_INDEX_BYTES,
+        index_ttl_ms: int = DEFAULT_INDEX_TTL_MS,
+        fence_ttl_ms: int = DEFAULT_FENCE_TTL_MS,
+        lock_timeout_seconds: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+        clock: Callable[[], float] | Callable[[], int] | None = None,
+        owner_id: str | None = None,
+        remote_transport: CanonicalArtifactStoreTransport | None = None,
+    ) -> None:
+        if root is None:
+            self.root = Path(
+                tempfile.mkdtemp(prefix="test-candidate-context-store-")
+            ).resolve()
+            self._ephemeral = True
+        else:
+            self.root = Path(root).resolve()
+            self._ephemeral = False
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.max_blob_bytes = int(max_blob_bytes)
+        self.max_component_bytes = int(max_component_bytes)
+        self.max_candidates = int(max_candidates)
+        self._clock = clock
+        self.owner_id = owner_id or f"candidate-store:{uuid.uuid4().hex}"
+        self.remote_transport = remote_transport
+        self.cas = ImmutableCertificateCAS(
+            self.root / "cas",
+            max_blob_bytes=max_blob_bytes,
+            lock_timeout_seconds=lock_timeout_seconds,
+            clock=clock,
+        )
+        self.index = CandidateContextIndex(
+            self.root,
+            max_candidates=max_candidates,
+            max_index_bytes=max_index_bytes,
+            default_ttl_ms=index_ttl_ms,
+            lock_timeout_seconds=lock_timeout_seconds,
+            clock=clock,
+        )
+        self.fence = CertificateWriteFence(
+            self.root,
+            default_ttl_ms=fence_ttl_ms,
+            lock_timeout_seconds=lock_timeout_seconds,
+            clock=clock,
+        )
+        self._publish_lock = threading.RLock()
+
+    @property
+    def schema(self) -> str:
+        return TEST_CANDIDATE_CONTEXT_STORE_SCHEMA
+
+    @property
+    def may_authorize_skip(self) -> bool:
+        return False
+
+    def put_canonical_bytes(
+        self, data: bytes, *, claimed_cid: str | None = None
+    ) -> Any:
+        return self.cas.put_bytes(data, claimed_cid=claimed_cid)
+
+    def get_bytes(self, cid: str) -> Any:
+        local = self.cas.get_bytes(cid)
+        if local.hit:
+            return local
+        if self.remote_transport is None:
+            if local.reason_code is _CasReason.CANDIDATE_MISSING:
+                # No remote backend configured: absence is a typed miss.
+                return local
+            return local
+        return self._remote_get(cid, local_miss=local)
+
+    def _remote_get(self, cid: str, *, local_miss: Any) -> Any:
+        transport = self.remote_transport
+        if transport is None:
+            # Surface transport absence explicitly when callers force remote.
+            class _Miss:
+                status = _CasStatus.MISS
+                reason_code = _CasReason.UNAVAILABLE
+                data = None
+                cid = cid
+                hit = False
+                diagnostics = {
+                    "reason": CandidateContextStoreReason.TRANSPORT_ABSENT.value
+                }
+
+            return _Miss()
+        try:
+            result = transport.get_bytes(cid)
+        except Exception as exc:  # noqa: BLE001 - typed miss boundary
+            class _RemoteFail:
+                status = _CasStatus.MISS
+                reason_code = _CasReason.UNAVAILABLE
+                data = None
+                hit = False
+                diagnostics = {
+                    "reason": CandidateContextStoreReason.REMOTE_FAILURE.value,
+                    "error": type(exc).__name__,
+                }
+
+            _RemoteFail.cid = cid  # type: ignore[attr-defined]
+            return _RemoteFail()
+        data = getattr(result, "data", None)
+        if data is None and isinstance(result, Mapping):
+            data = result.get("data")
+        if not isinstance(data, (bytes, bytearray)):
+            hit = bool(getattr(result, "hit", False) or getattr(result, "stored", False))
+            if not hit:
+                class _RemoteMiss:
+                    status = _CasStatus.MISS
+                    reason_code = _CasReason.CANDIDATE_MISSING
+                    data = None
+                    hit = False
+                    diagnostics = {
+                        "reason": CandidateContextStoreReason.REMOTE_FAILURE.value
+                    }
+
+                _RemoteMiss.cid = cid  # type: ignore[attr-defined]
+                return _RemoteMiss()
+            class _RemoteBad:
+                status = _CasStatus.MISS
+                reason_code = _CasReason.CORRUPT
+                data = None
+                hit = False
+                diagnostics = {
+                    "reason": CandidateContextStoreReason.REMOTE_FAILURE.value
+                }
+
+            _RemoteBad.cid = cid  # type: ignore[attr-defined]
+            return _RemoteBad()
+        data_bytes = bytes(data)
+        put = self.cas.put_bytes(data_bytes, claimed_cid=cid)
+        if not put.stored and put.reason_code not in {
+            _CasReason.OK,
+            _CasReason.ALREADY_EXISTS,
+        }:
+            class _RemoteReject:
+                status = _CasStatus.MISS
+                reason_code = put.reason_code
+                data = None
+                hit = False
+                diagnostics = {
+                    "reason": CandidateContextStoreReason.REMOTE_FAILURE.value,
+                    "stage": "remote_rehash",
+                }
+
+            _RemoteReject.cid = cid  # type: ignore[attr-defined]
+            return _RemoteReject()
+        return self.cas.get_bytes(cid)
+
+    def publish(
+        self,
+        descriptor: CandidateExecutionContext | Mapping[str, Any] | bytes,
         components: Mapping[str, bytes],
         *,
         locator_cid: str | None = None,
-    ) -> CandidateContextPublishResult:
-        """Persist descriptor + component bytes for one locator."""
-
-        loc = str(
-            locator_cid
-            or getattr(candidate, "locator_cid", "")
-            or ""
-        ).strip()
-        if not loc or not _CID_SAFE_RE.fullmatch(loc):
-            return CandidateContextPublishResult(
-                stored=False,
-                reason_code="invalid_locator_cid",
-            )
-        if not isinstance(components, Mapping) or not components:
-            return CandidateContextPublishResult(
-                stored=False,
-                reason_code="components_required",
-                locator_cid=loc,
-            )
-        retained: dict[str, bytes] = {}
-        for key, value in components.items():
-            name = str(key).strip()
-            if not name or not isinstance(value, (bytes, bytearray)):
-                return CandidateContextPublishResult(
-                    stored=False,
-                    reason_code="invalid_component",
-                    locator_cid=loc,
-                )
-            data = bytes(value)
-            if not data or len(data) > self._max_blob_bytes:
-                return CandidateContextPublishResult(
-                    stored=False,
-                    reason_code="component_size_out_of_bounds",
-                    locator_cid=loc,
-                )
-            retained[name] = data
+        created_at_ms: int | None = None,
+        expires_at_ms: int | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        publish_index: bool = True,
+        owner_id: str | None = None,
+        expected_generation: int | None = None,
+    ) -> CandidateContextPutResult:
+        """Persist descriptor + retained components as one fenced generation."""
 
         try:
-            if hasattr(candidate, "to_dict"):
-                descriptor = dict(candidate.to_dict())
-            elif isinstance(candidate, Mapping):
-                descriptor = dict(candidate)
-            else:
-                descriptor = {
-                    "locator_cid": loc,
-                    "type_name": type(candidate).__name__,
-                }
-            descriptor_bytes = canonical_json_bytes(descriptor)
-            context_cid = content_identity(descriptor)
-        except Exception as exc:
-            return CandidateContextPublishResult(
-                stored=False,
-                reason_code=f"descriptor_encode_failed:{type(exc).__name__}",
-                locator_cid=loc,
+            typed, descriptor_bytes = self._coerce_descriptor(descriptor)
+        except (
+            CandidateContextStoreIntegrityError,
+            CertificateStoreIntegrityError,
+            TypeError,
+            ValueError,
+        ):
+            return CandidateContextPutResult(
+                False, CandidateContextStoreReason.MALFORMED
             )
 
-        with self._lock:
+        if typed.may_authorize_skip:
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.MALFORMED,
+                diagnostics={"stage": "descriptor_claims_skip"},
+            )
+
+        try:
+            component_plan = self._plan_components(typed, components)
+        except CandidateContextStoreIntegrityError as exc:
+            reason_value = str(exc)
             try:
-                blob_dir = self.root / "blobs" / loc
-                blob_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-                self._atomic_write(blob_dir / "descriptor.blob", descriptor_bytes)
-                component_index: dict[str, str] = {}
-                for name, data in retained.items():
-                    cid = content_identity(
-                        {
-                            "schema": TEST_CANDIDATE_CONTEXT_STORE_SCHEMA + "/component",
-                            "name": name,
-                            "sha256": __import__("hashlib")
-                            .sha256(data)
-                            .hexdigest(),
-                        }
-                    )
-                    # Retain exact bytes under a content-safe filename.
-                    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", name)[:128]
-                    path = blob_dir / f"{safe}.blob"
-                    self._atomic_write(path, data)
-                    component_index[name] = path.name
-                index_payload = {
-                    "schema": TEST_CANDIDATE_CONTEXT_STORE_SCHEMA,
-                    "interface": TEST_CANDIDATE_CONTEXT_STORE_INTERFACE,
-                    "locator_cid": loc,
-                    "candidate_context_cid": context_cid,
-                    "component_files": component_index,
-                    "retained_at": float(self._clock()),
-                    "may_authorize_skip": False,
-                }
-                self._atomic_write(
-                    self.root / "index" / f"{loc}.json",
-                    json.dumps(index_payload, sort_keys=True, separators=(",", ":")).encode(
-                        "utf-8"
-                    ),
-                )
-            except Exception as exc:
-                return CandidateContextPublishResult(
-                    stored=False,
-                    reason_code=f"publish_failed:{type(exc).__name__}",
-                    locator_cid=loc,
-                )
-        return CandidateContextPublishResult(
-            stored=True,
-            may_authorize_skip=False,
-            locator_cid=loc,
-            candidate_context_cid=context_cid,
+                reason = CandidateContextStoreReason(reason_value)
+            except ValueError:
+                reason = CandidateContextStoreReason.MALFORMED
+            return CandidateContextPutResult(
+                False,
+                reason,
+                candidate_context_cid=typed.candidate_context_id,
+                diagnostics={"stage": "component_plan", "detail": reason_value},
+            )
+
+        resolved_locator = locator_cid or typed.locator_cid
+        try:
+            locator = _validate_cid_token(
+                resolved_locator, field_name="locator_cid"
+            )
+        except CertificateStoreIntegrityError:
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.PATH_ESCAPE,
+                candidate_context_cid=typed.candidate_context_id,
+                locator_cid=str(resolved_locator),
+            )
+
+        if typed.locator_cid != locator:
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.CID_MISMATCH,
+                candidate_context_cid=typed.candidate_context_id,
+                locator_cid=locator,
+                diagnostics={"stage": "locator_binding"},
+            )
+
+        total_bytes = len(descriptor_bytes) + sum(
+            len(item) for item in component_plan.values()
         )
+        if (
+            len(descriptor_bytes) > self.max_blob_bytes
+            or any(len(item) > self.max_component_bytes for item in component_plan.values())
+            or total_bytes > self.max_blob_bytes * max(4, len(component_plan) + 1)
+        ):
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.OVER_BUDGET
+                if total_bytes > self.max_blob_bytes
+                else CandidateContextStoreReason.SIZE_EXCEEDED,
+                candidate_context_cid=typed.candidate_context_id,
+                locator_cid=locator,
+            )
 
-    def lookup(self, locator_cid: str, *, max_candidates: int = 1) -> CandidateContextLookupResult:
-        """Load retained descriptor/components for a locator CID."""
+        fence_key = f"candidate-locator:{locator}"
+        owner = owner_id or self.owner_id
+        try:
+            lease = self.fence.acquire(fence_key, owner_id=owner)
+        except CertificateStoreFenceError:
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.FENCED,
+                candidate_context_cid=typed.candidate_context_id,
+                locator_cid=locator,
+            )
+        except (TimeoutError, OSError):
+            return CandidateContextPutResult(
+                False,
+                CandidateContextStoreReason.UNAVAILABLE,
+                candidate_context_cid=typed.candidate_context_id,
+                locator_cid=locator,
+            )
 
-        del max_candidates  # single-candidate v1 store
-        loc = str(locator_cid or "").strip()
-        if not loc or not _CID_SAFE_RE.fullmatch(loc):
+        with self._publish_lock:
+            try:
+                # 1. CAS-publish every retained component.
+                for name, data in component_plan.items():
+                    claimed = _cid_for_canonical_bytes(data)
+                    put = self.cas.put_bytes(data, claimed_cid=claimed)
+                    if not put.stored and put.reason_code not in {
+                        _CasReason.OK,
+                        _CasReason.ALREADY_EXISTS,
+                    }:
+                        return CandidateContextPutResult(
+                            False,
+                            _map_cas_reason(put.reason_code),
+                            candidate_context_cid=typed.candidate_context_id,
+                            locator_cid=locator,
+                            diagnostics={"stage": f"component_cas:{name}"},
+                        )
+                    readback = self.cas.get_bytes(claimed)
+                    if (
+                        not readback.hit
+                        or readback.data != data
+                        or readback.cid != claimed
+                    ):
+                        return CandidateContextPutResult(
+                            False,
+                            CandidateContextStoreReason.INTEGRITY_FAILED,
+                            candidate_context_cid=typed.candidate_context_id,
+                            locator_cid=locator,
+                            diagnostics={"stage": f"component_readback:{name}"},
+                        )
+
+                # 2. CAS-publish descriptor bytes under candidate_context_cid.
+                desc_put = self.cas.put_bytes(
+                    descriptor_bytes, claimed_cid=typed.candidate_context_id
+                )
+                if not desc_put.stored and desc_put.reason_code not in {
+                    _CasReason.OK,
+                    _CasReason.ALREADY_EXISTS,
+                }:
+                    return CandidateContextPutResult(
+                        False,
+                        _map_cas_reason(desc_put.reason_code),
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "descriptor_cas"},
+                    )
+                desc_get = self.cas.get_bytes(typed.candidate_context_id)
+                if (
+                    not desc_get.hit
+                    or desc_get.data != descriptor_bytes
+                    or desc_get.cid != typed.candidate_context_id
+                ):
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.INTEGRITY_FAILED,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "descriptor_readback"},
+                    )
+
+                now = _now_ms(self._clock)
+                created = now if created_at_ms is None else created_at_ms
+                component_cids = {
+                    name: _cid_for_canonical_bytes(data)
+                    for name, data in component_plan.items()
+                }
+                envelope = CandidateContextEnvelope(
+                    candidate_context_cid=typed.candidate_context_id,
+                    locator_cid=locator,
+                    execution_key_cid=typed.execution_key_cid,
+                    pass_receipt_cid=typed.pass_receipt_cid,
+                    component_cids=component_cids,
+                    version=ENVELOPE_VERSION,
+                    generation=1,  # concrete generation assigned at index publish
+                    created_at_ms=created,
+                    expires_at_ms=expires_at_ms,
+                    fencing_token=lease.fencing_token,
+                    byte_length=total_bytes,
+                    metadata=dict(metadata or {}),
+                )
+                # Generation is finalized after index publish; envelope generation
+                # field is rewritten once the index assigns the next generation.
+                # Provisional envelope is stored after generation is known.
+
+                try:
+                    self.fence.require_valid(lease)
+                except CertificateStoreFenceError:
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.FENCE_MISMATCH,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "pre_index_fence"},
+                    )
+
+                if not publish_index:
+                    # Store envelope with generation=1 as a pure CAS object.
+                    envelope_bytes = envelope.canonical_bytes()
+                    env_put = self.cas.put_bytes(envelope_bytes)
+                    if not env_put.stored and env_put.reason_code not in {
+                        _CasReason.OK,
+                        _CasReason.ALREADY_EXISTS,
+                    }:
+                        return CandidateContextPutResult(
+                            False,
+                            _map_cas_reason(env_put.reason_code),
+                            candidate_context_cid=typed.candidate_context_id,
+                            locator_cid=locator,
+                            diagnostics={"stage": "envelope_cas"},
+                        )
+                    return CandidateContextPutResult(
+                        True,
+                        CandidateContextStoreReason.OK,
+                        envelope_cid=env_put.cid,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        generation=1,
+                        indexed=False,
+                    )
+
+                # Reserve generation by publishing a provisional index entry after
+                # the final envelope is written.  First compute next generation
+                # from current index state under the fence.
+                current = self.index.candidates(locator, max_candidates=1)
+                next_generation = (current.generation or 0) + 1
+                if (
+                    expected_generation is not None
+                    and current.generation != expected_generation
+                ):
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.STALE_GENERATION,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        generation=current.generation,
+                        diagnostics={
+                            "expected_generation": expected_generation,
+                            "current_generation": current.generation,
+                        },
+                    )
+
+                final_envelope = CandidateContextEnvelope(
+                    candidate_context_cid=typed.candidate_context_id,
+                    locator_cid=locator,
+                    execution_key_cid=typed.execution_key_cid,
+                    pass_receipt_cid=typed.pass_receipt_cid,
+                    component_cids=component_cids,
+                    version=ENVELOPE_VERSION,
+                    generation=next_generation,
+                    created_at_ms=created,
+                    expires_at_ms=expires_at_ms,
+                    fencing_token=lease.fencing_token,
+                    byte_length=total_bytes,
+                    metadata=dict(metadata or {}),
+                )
+                envelope_bytes = final_envelope.canonical_bytes()
+                if len(envelope_bytes) > self.max_blob_bytes:
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.OVER_BUDGET,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                    )
+                env_put = self.cas.put_bytes(envelope_bytes)
+                if not env_put.stored and env_put.reason_code not in {
+                    _CasReason.OK,
+                    _CasReason.ALREADY_EXISTS,
+                }:
+                    return CandidateContextPutResult(
+                        False,
+                        _map_cas_reason(env_put.reason_code),
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "envelope_cas"},
+                    )
+                env_get = self.cas.get_bytes(env_put.cid)
+                if (
+                    not env_get.hit
+                    or env_get.data != envelope_bytes
+                    or env_get.cid != env_put.cid
+                ):
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.INTEGRITY_FAILED,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "envelope_readback"},
+                    )
+
+                # Optional remote mirror (best-effort; local remains authority for reads).
+                if self.remote_transport is not None:
+                    try:
+                        self.remote_transport.put_bytes(
+                            envelope_bytes, claimed_cid=env_put.cid
+                        )
+                    except Exception:
+                        # Remote failure never rolls back local success; later
+                        # remote-only reads surface REMOTE_FAILURE.
+                        pass
+
+                try:
+                    self.fence.require_valid(lease)
+                except CertificateStoreFenceError:
+                    return CandidateContextPutResult(
+                        False,
+                        CandidateContextStoreReason.FENCE_MISMATCH,
+                        envelope_cid=env_put.cid,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        diagnostics={"stage": "pre_index_fence_final"},
+                    )
+
+                publish = self.index.publish(
+                    locator,
+                    envelope_cid=env_put.cid,
+                    candidate_context_cid=typed.candidate_context_id,
+                    execution_key_cid=typed.execution_key_cid,
+                    generation=next_generation,
+                    created_at_ms=created,
+                    expires_at_ms=expires_at_ms,
+                    fencing_token=lease.fencing_token,
+                    expected_fencing_token=lease.fencing_token,
+                    expected_generation=expected_generation,
+                    metadata=metadata,
+                )
+                if not publish.published:
+                    return CandidateContextPutResult(
+                        False,
+                        publish.reason_code,
+                        envelope_cid=env_put.cid,
+                        candidate_context_cid=typed.candidate_context_id,
+                        locator_cid=locator,
+                        generation=publish.generation,
+                        diagnostics={"stage": "index_publish"},
+                    )
+                return CandidateContextPutResult(
+                    True,
+                    CandidateContextStoreReason.OK,
+                    envelope_cid=env_put.cid,
+                    candidate_context_cid=typed.candidate_context_id,
+                    locator_cid=locator,
+                    generation=publish.generation,
+                    indexed=True,
+                    diagnostics={"candidate_count": publish.candidate_count},
+                )
+            finally:
+                try:
+                    self.fence.release(lease)
+                except Exception:
+                    pass
+
+    def lookup(
+        self,
+        locator_cid: str,
+        *,
+        max_candidates: int | None = None,
+        now_ms: int | None = None,
+        min_generation: int | None = None,
+        candidate_context_cid: str | None = None,
+    ) -> CandidateContextLookupResult:
+        """Materialize one admitted candidate: bytes + non-authoritative descriptor."""
+
+        index_result = self.index.candidates(
+            locator_cid,
+            max_candidates=max_candidates or self.max_candidates,
+            now_ms=now_ms,
+            min_generation=min_generation,
+        )
+        if index_result.status is not CandidateContextStoreStatus.HIT:
             return CandidateContextLookupResult(
-                hit=False, reason_code="invalid_locator_cid"
+                CandidateContextStoreStatus.MISS,
+                index_result.reason_code,
+                generation=index_result.generation,
+                diagnostics=dict(index_result.diagnostics),
             )
-        index_path = self.root / "index" / f"{loc}.json"
-        blob_dir = self.root / "blobs" / loc
-        with self._lock:
-            if not index_path.is_file() or not blob_dir.is_dir():
-                return CandidateContextLookupResult(
-                    hit=False, reason_code="miss", locator_cid=loc
+
+        last_reason = CandidateContextStoreReason.CANDIDATE_MISSING
+        for hint in index_result.candidates:
+            if (
+                candidate_context_cid is not None
+                and hint.candidate_context_cid != candidate_context_cid
+            ):
+                continue
+            admitted = self.admit(
+                hint.envelope_cid,
+                expected_generation=hint.generation,
+                now_ms=now_ms,
+                index_generation=index_result.generation,
+            )
+            if not admitted.admitted:
+                last_reason = admitted.reason_code
+                if admitted.reason_code in {
+                    CandidateContextStoreReason.CORRUPT,
+                    CandidateContextStoreReason.INTEGRITY_FAILED,
+                    CandidateContextStoreReason.PARTIAL,
+                    CandidateContextStoreReason.SYMLINK_REJECTED,
+                    CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                    CandidateContextStoreReason.VERSION_MISMATCH,
+                }:
+                    self.index.quarantine(
+                        locator_cid, hint.candidate_context_cid
+                    )
+                continue
+
+            envelope_get = self.get_bytes(hint.envelope_cid)
+            if not getattr(envelope_get, "hit", False) or envelope_get.data is None:
+                last_reason = _map_cas_reason(
+                    getattr(
+                        envelope_get,
+                        "reason_code",
+                        CandidateContextStoreReason.CANDIDATE_MISSING,
+                    )
                 )
+                continue
             try:
-                index = json.loads(index_path.read_text(encoding="utf-8"))
-                if not isinstance(index, dict):
-                    return CandidateContextLookupResult(
-                        hit=False, reason_code="corrupt_index", locator_cid=loc
-                    )
-                descriptor_path = blob_dir / "descriptor.blob"
-                descriptor_bytes = descriptor_path.read_bytes()
-                # Rehash descriptor for integrity.
-                expected = str(index.get("candidate_context_cid") or "")
-                actual = content_identity(json.loads(descriptor_bytes.decode("utf-8")))
-                if expected and expected != actual:
-                    return CandidateContextLookupResult(
-                        hit=False,
-                        reason_code="descriptor_rehash_mismatch",
-                        locator_cid=loc,
-                    )
-                component_files = index.get("component_files") or {}
-                component_bytes: dict[str, bytes] = {}
-                if isinstance(component_files, Mapping):
-                    for name, filename in component_files.items():
-                        path = blob_dir / str(filename)
-                        if not path.is_file():
-                            continue
-                        data = path.read_bytes()
-                        if 0 < len(data) <= self._max_blob_bytes:
-                            component_bytes[str(name)] = data
-            except Exception as exc:
-                return CandidateContextLookupResult(
-                    hit=False,
-                    reason_code=f"lookup_failed:{type(exc).__name__}",
-                    locator_cid=loc,
+                envelope = CandidateContextEnvelope.from_bytes(envelope_get.data)
+            except CandidateContextStoreIntegrityError:
+                last_reason = CandidateContextStoreReason.CORRUPT
+                self.index.quarantine(locator_cid, hint.candidate_context_cid)
+                continue
+
+            desc_get = self.get_bytes(envelope.candidate_context_cid)
+            if not getattr(desc_get, "hit", False) or desc_get.data is None:
+                last_reason = CandidateContextStoreReason.COMPONENT_MISSING
+                continue
+            try:
+                descriptor = CandidateExecutionContext.from_dict(
+                    json.loads(desc_get.data.decode("utf-8"))
                 )
+            except Exception:
+                last_reason = CandidateContextStoreReason.CORRUPT
+                self.index.quarantine(locator_cid, hint.candidate_context_cid)
+                continue
+
+            if descriptor.may_authorize_skip:
+                last_reason = CandidateContextStoreReason.MALFORMED
+                continue
+
+            component_bytes: dict[str, bytes] = {}
+            for name, cid in envelope.component_cids.items():
+                blob = self.get_bytes(cid)
+                if not getattr(blob, "hit", False) or blob.data is None:
+                    last_reason = CandidateContextStoreReason.COMPONENT_MISSING
+                    component_bytes = {}
+                    break
+                component_bytes[name] = blob.data
+            if not component_bytes:
+                continue
+
+            return CandidateContextLookupResult(
+                CandidateContextStoreStatus.HIT,
+                CandidateContextStoreReason.OK,
+                envelope_cid=hint.envelope_cid,
+                candidate_context_cid=envelope.candidate_context_cid,
+                envelope_bytes=envelope_get.data,
+                descriptor_bytes=desc_get.data,
+                descriptor=descriptor,
+                component_bytes=component_bytes,
+                admission=admitted,
+                generation=envelope.generation,
+                diagnostics={
+                    "locator_cid": locator_cid,
+                    "index_generation": index_result.generation,
+                },
+            )
+
         return CandidateContextLookupResult(
-            hit=True,
-            may_authorize_skip=False,
-            locator_cid=loc,
-            descriptor_bytes=descriptor_bytes,
-            component_bytes=component_bytes,
-            candidate_context_cid=str(index.get("candidate_context_cid") or ""),
+            CandidateContextStoreStatus.MISS,
+            last_reason,
+            generation=index_result.generation,
         )
 
-    def _atomic_write(self, path: Path, data: bytes) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        tmp = path.with_name(f".tmp.{os.getpid()}.{threading.get_ident()}.{path.name}")
-        with open(tmp, "wb") as handle:
-            handle.write(data)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp, path)
+    def admit(
+        self,
+        envelope_cid: str,
+        *,
+        expected_generation: int | None = None,
+        index_generation: int | None = None,
+        now_ms: int | None = None,
+    ) -> CandidateContextAdmission:
+        """Rehash every retained component and confirm CID agreement."""
+
+        try:
+            token = _validate_cid_token(envelope_cid, field_name="envelope_cid")
+        except CertificateStoreIntegrityError:
+            return CandidateContextAdmission(
+                False, CandidateContextStoreReason.PATH_ESCAPE, envelope_cid=str(envelope_cid)
+            )
+
+        envelope_get = self.get_bytes(token)
+        if not getattr(envelope_get, "hit", False) or envelope_get.data is None:
+            remote_diag = getattr(envelope_get, "diagnostics", {}) or {}
+            if (
+                isinstance(remote_diag, Mapping)
+                and remote_diag.get("reason")
+                == CandidateContextStoreReason.TRANSPORT_ABSENT.value
+            ):
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.TRANSPORT_ABSENT,
+                    envelope_cid=token,
+                )
+            if (
+                isinstance(remote_diag, Mapping)
+                and remote_diag.get("reason")
+                == CandidateContextStoreReason.REMOTE_FAILURE.value
+            ):
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.REMOTE_FAILURE,
+                    envelope_cid=token,
+                )
+            return CandidateContextAdmission(
+                False,
+                _map_cas_reason(
+                    getattr(
+                        envelope_get,
+                        "reason_code",
+                        CandidateContextStoreReason.CANDIDATE_MISSING,
+                    )
+                ),
+                envelope_cid=token,
+            )
+
+        data = envelope_get.data
+        if len(data) > self.max_blob_bytes:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.SIZE_EXCEEDED,
+                envelope_cid=token,
+                byte_length=len(data),
+            )
+
+        try:
+            external_cid = _cid_for_canonical_bytes(data)
+        except CertificateStoreIntegrityError:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.CORRUPT,
+                envelope_cid=token,
+                byte_length=len(data),
+            )
+        if external_cid != token:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                envelope_cid=token,
+                diagnostics={"actual_cid": external_cid},
+                byte_length=len(data),
+            )
+
+        try:
+            envelope = CandidateContextEnvelope.from_bytes(data)
+        except CandidateContextStoreIntegrityError as exc:
+            reason_value = str(exc)
+            try:
+                reason = CandidateContextStoreReason(reason_value)
+            except ValueError:
+                reason = CandidateContextStoreReason.CORRUPT
+            return CandidateContextAdmission(
+                False, reason, envelope_cid=token, byte_length=len(data)
+            )
+
+        if envelope.version != ENVELOPE_VERSION:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.VERSION_MISMATCH,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"version": envelope.version},
+            )
+
+        current = _now_ms(self._clock) if now_ms is None else now_ms
+        if (
+            envelope.expires_at_ms is not None
+            and envelope.expires_at_ms <= current
+        ):
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.EXPIRED,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+            )
+
+        if expected_generation is not None and envelope.generation != expected_generation:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.STALE_GENERATION,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={
+                    "envelope_generation": envelope.generation,
+                    "expected_generation": expected_generation,
+                },
+            )
+        if (
+            index_generation is not None
+            and envelope.generation > index_generation
+        ):
+            # Envelope from a future generation relative to the index document
+            # is inconsistent (poison / partial write).
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.STALE_GENERATION,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={
+                    "envelope_generation": envelope.generation,
+                    "index_generation": index_generation,
+                },
+            )
+
+        # Descriptor internal identity.
+        desc_get = self.get_bytes(envelope.candidate_context_cid)
+        if not getattr(desc_get, "hit", False) or desc_get.data is None:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.COMPONENT_MISSING,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"stage": "descriptor_missing"},
+            )
+        boundary = admit_content_addressed_boundary(
+            role=ArtifactRole.IMMUTABLE_CANDIDATE_CONTEXT,
+            claimed_cid=envelope.candidate_context_cid,
+            canonical_bytes=desc_get.data,
+        )
+        if not boundary.admitted:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.INTEGRITY_FAILED,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"stage": "descriptor_rehash"},
+            )
+        try:
+            descriptor = CandidateExecutionContext.from_dict(
+                json.loads(desc_get.data.decode("utf-8"))
+            )
+        except Exception:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.CORRUPT,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+            )
+        if descriptor.candidate_context_id != envelope.candidate_context_cid:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"stage": "descriptor_identity"},
+            )
+        if descriptor.may_authorize_skip:
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.MALFORMED,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"stage": "descriptor_claims_skip"},
+            )
+
+        # Cross-check envelope binding fields against descriptor.
+        if (
+            descriptor.locator_cid != envelope.locator_cid
+            or descriptor.execution_key_cid != envelope.execution_key_cid
+            or descriptor.pass_receipt_cid != envelope.pass_receipt_cid
+        ):
+            return CandidateContextAdmission(
+                False,
+                CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                envelope_cid=token,
+                candidate_context_cid=envelope.candidate_context_cid,
+                diagnostics={"stage": "envelope_descriptor_binding"},
+            )
+
+        verified_components: dict[str, str] = {}
+        for name, claimed_cid in envelope.component_cids.items():
+            blob = self.get_bytes(claimed_cid)
+            if not getattr(blob, "hit", False) or blob.data is None:
+                remote_diag = getattr(blob, "diagnostics", {}) or {}
+                if (
+                    isinstance(remote_diag, Mapping)
+                    and remote_diag.get("reason")
+                    == CandidateContextStoreReason.TRANSPORT_ABSENT.value
+                ):
+                    return CandidateContextAdmission(
+                        False,
+                        CandidateContextStoreReason.TRANSPORT_ABSENT,
+                        envelope_cid=token,
+                        candidate_context_cid=envelope.candidate_context_cid,
+                        diagnostics={"component": name},
+                    )
+                if (
+                    isinstance(remote_diag, Mapping)
+                    and remote_diag.get("reason")
+                    == CandidateContextStoreReason.REMOTE_FAILURE.value
+                ):
+                    return CandidateContextAdmission(
+                        False,
+                        CandidateContextStoreReason.REMOTE_FAILURE,
+                        envelope_cid=token,
+                        candidate_context_cid=envelope.candidate_context_cid,
+                        diagnostics={"component": name},
+                    )
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.COMPONENT_MISSING
+                    if _map_cas_reason(
+                        getattr(
+                            blob,
+                            "reason_code",
+                            CandidateContextStoreReason.CANDIDATE_MISSING,
+                        )
+                    )
+                    is CandidateContextStoreReason.CANDIDATE_MISSING
+                    else _map_cas_reason(
+                        getattr(
+                            blob,
+                            "reason_code",
+                            CandidateContextStoreReason.CANDIDATE_MISSING,
+                        )
+                    ),
+                    envelope_cid=token,
+                    candidate_context_cid=envelope.candidate_context_cid,
+                    diagnostics={"component": name},
+                )
+            if len(blob.data) > self.max_component_bytes:
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.SIZE_EXCEEDED,
+                    envelope_cid=token,
+                    candidate_context_cid=envelope.candidate_context_cid,
+                    diagnostics={"component": name, "byte_length": len(blob.data)},
+                )
+            try:
+                actual = _cid_for_canonical_bytes(blob.data)
+            except CertificateStoreIntegrityError:
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.CORRUPT,
+                    envelope_cid=token,
+                    candidate_context_cid=envelope.candidate_context_cid,
+                    diagnostics={"component": name},
+                )
+            if actual != claimed_cid:
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                    envelope_cid=token,
+                    candidate_context_cid=envelope.candidate_context_cid,
+                    diagnostics={
+                        "component": name,
+                        "claimed_cid": claimed_cid,
+                        "actual_cid": actual,
+                    },
+                )
+            # Internal field agreement for known components.
+            field_name = COMPONENT_FIELD_MAP.get(name)
+            if field_name is not None:
+                expected_field = getattr(descriptor, field_name, "")
+                if expected_field and expected_field != claimed_cid:
+                    return CandidateContextAdmission(
+                        False,
+                        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                        envelope_cid=token,
+                        candidate_context_cid=envelope.candidate_context_cid,
+                        diagnostics={
+                            "component": name,
+                            "field": field_name,
+                            "field_cid": expected_field,
+                            "component_cid": claimed_cid,
+                        },
+                    )
+            verified_components[name] = claimed_cid
+
+        for required in REQUIRED_COMPONENT_KEYS:
+            if required not in verified_components:
+                return CandidateContextAdmission(
+                    False,
+                    CandidateContextStoreReason.COMPONENT_MISSING,
+                    envelope_cid=token,
+                    candidate_context_cid=envelope.candidate_context_cid,
+                    diagnostics={"missing": required},
+                )
+
+        return CandidateContextAdmission(
+            True,
+            CandidateContextStoreReason.OK,
+            envelope_cid=token,
+            candidate_context_cid=envelope.candidate_context_cid,
+            component_cids=verified_components,
+            byte_length=len(data),
+            diagnostics={"generation": envelope.generation},
+        )
+
+    def lookup_by_context_cid(
+        self, candidate_context_cid: str
+    ) -> CandidateContextLookupResult:
+        """Direct CAS lookup of a descriptor by its content CID (no index)."""
+
+        try:
+            token = _validate_cid_token(
+                candidate_context_cid, field_name="candidate_context_cid"
+            )
+        except CertificateStoreIntegrityError:
+            return CandidateContextLookupResult(
+                CandidateContextStoreStatus.MISS,
+                CandidateContextStoreReason.PATH_ESCAPE,
+            )
+        desc_get = self.get_bytes(token)
+        if not getattr(desc_get, "hit", False) or desc_get.data is None:
+            return CandidateContextLookupResult(
+                CandidateContextStoreStatus.MISS,
+                _map_cas_reason(
+                    getattr(
+                        desc_get,
+                        "reason_code",
+                        CandidateContextStoreReason.CANDIDATE_MISSING,
+                    )
+                ),
+            )
+        try:
+            descriptor = CandidateExecutionContext.from_dict(
+                json.loads(desc_get.data.decode("utf-8"))
+            )
+        except Exception:
+            return CandidateContextLookupResult(
+                CandidateContextStoreStatus.MISS,
+                CandidateContextStoreReason.CORRUPT,
+                candidate_context_cid=token,
+            )
+        if descriptor.candidate_context_id != token:
+            return CandidateContextLookupResult(
+                CandidateContextStoreStatus.MISS,
+                CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+                candidate_context_cid=token,
+            )
+        # Direct descriptor presence is never SKIP authority.
+        return CandidateContextLookupResult(
+            CandidateContextStoreStatus.HIT,
+            CandidateContextStoreReason.OK,
+            candidate_context_cid=token,
+            descriptor_bytes=desc_get.data,
+            descriptor=descriptor,
+            diagnostics={"path": "direct_descriptor", "may_authorize_skip": False},
+        )
+
+    @staticmethod
+    def _coerce_descriptor(
+        descriptor: CandidateExecutionContext | Mapping[str, Any] | bytes,
+    ) -> tuple[CandidateExecutionContext, bytes]:
+        if isinstance(descriptor, (bytes, bytearray)):
+            data = bytes(descriptor)
+            payload = json.loads(data.decode("utf-8"))
+            typed = CandidateExecutionContext.from_dict(payload)
+            recomputed = typed.canonical_bytes()
+            if recomputed != data:
+                raise CandidateContextStoreIntegrityError(
+                    "descriptor bytes are not canonical"
+                )
+            if typed.candidate_context_id != _cid_for_canonical_bytes(data):
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.CID_MISMATCH.value
+                )
+            return typed, data
+        if isinstance(descriptor, CandidateExecutionContext):
+            data = descriptor.canonical_bytes()
+            return descriptor, data
+        if isinstance(descriptor, Mapping):
+            typed = CandidateExecutionContext.from_dict(descriptor)
+            return typed, typed.canonical_bytes()
+        raise TypeError(
+            "descriptor must be CandidateExecutionContext, mapping, or bytes"
+        )
+
+    def _plan_components(
+        self,
+        descriptor: CandidateExecutionContext,
+        components: Mapping[str, bytes],
+    ) -> dict[str, bytes]:
+        if not isinstance(components, Mapping) or not components:
+            raise CandidateContextStoreIntegrityError(
+                CandidateContextStoreReason.COMPONENT_MISSING.value
+            )
+        plan: dict[str, bytes] = {}
+        for name, data in components.items():
+            if not isinstance(name, str) or not name:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.MALFORMED.value
+                )
+            if type(data) is not bytes:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.MALFORMED.value
+                )
+            if not data:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.PARTIAL.value
+                )
+            if len(data) > self.max_component_bytes:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.SIZE_EXCEEDED.value
+                )
+            try:
+                actual = _cid_for_canonical_bytes(data)
+            except CertificateStoreIntegrityError as exc:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.CORRUPT.value
+                ) from exc
+            field_name = COMPONENT_FIELD_MAP.get(name)
+            if field_name is not None:
+                expected = getattr(descriptor, field_name, "")
+                if expected and expected != actual:
+                    raise CandidateContextStoreIntegrityError(
+                        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH.value
+                    )
+            # Also accept components listed in descriptor.component_cids.
+            if name in descriptor.component_cids:
+                expected = descriptor.component_cids[name]
+                if expected and expected != actual:
+                    raise CandidateContextStoreIntegrityError(
+                        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH.value
+                    )
+            plan[name] = data
+        for required in REQUIRED_COMPONENT_KEYS:
+            if required not in plan:
+                raise CandidateContextStoreIntegrityError(
+                    CandidateContextStoreReason.COMPONENT_MISSING.value
+                )
+        # Optional test_ast agreement when provided.
+        if "test_ast" not in plan and descriptor.test_ast_cid:
+            # Not required as a retained blob when only the identity is pinned,
+            # but callers may still supply it.  Required set above is enough.
+            pass
+        return plan
 
 
-__all__ = (
-    "REQUIRED_COMPONENT_KEYS",
-    "TEST_CANDIDATE_CONTEXT_STORE_INTERFACE",
+__all__ = [
+    "CANONICAL_ARTIFACT_STORE_TRANSPORT_INTERFACE",
+    "CANDIDATE_CONTEXT_ENVELOPE_INTERFACE",
+    "CANDIDATE_CONTEXT_ENVELOPE_SCHEMA",
+    "CANDIDATE_EXECUTION_CONTEXT_INTERFACE",
+    "COMPONENT_FIELD_MAP",
+    "CandidateContextAdmission",
+    "CandidateContextEnvelope",
+    "CandidateContextIndex",
+    "CandidateContextIndexHint",
     "CandidateContextLookupResult",
-    "CandidateContextPublishResult",
+    "CandidateContextPutResult",
     "CandidateContextStoreError",
+    "CandidateContextStoreIntegrityError",
+    "CandidateContextStoreReason",
+    "CandidateContextStoreStatus",
+    "CanonicalArtifactStoreTransport",
+    "DEFAULT_FENCE_TTL_MS",
+    "DEFAULT_INDEX_TTL_MS",
+    "DEFAULT_MAX_BLOB_BYTES",
+    "DEFAULT_MAX_CANDIDATES",
+    "DEFAULT_MAX_COMPONENT_BYTES",
+    "DEFAULT_MAX_INDEX_BYTES",
+    "ENVELOPE_VERSION",
+    "IndexLookupResult",
+    "IndexPublishResult",
+    "REQUIRED_COMPONENT_KEYS",
+    "TEST_CANDIDATE_CONTEXT_INDEX_SCHEMA",
+    "TEST_CANDIDATE_CONTEXT_STORE_INTERFACE",
+    "TEST_CANDIDATE_CONTEXT_STORE_SCHEMA",
     "TestCandidateContextStore",
-)
+]

--- a/test/api/test_agent_supervisor_test_candidate_context_store.py
+++ b/test/api/test_agent_supervisor_test_candidate_context_store.py
@@ -1,0 +1,600 @@
+"""Tests for immutable candidate execution context store (PTR-135)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ipfs_accelerate_py.agent_supervisor.proof.formal_verification_contracts import (
+    canonical_json_bytes,
+    content_identity,
+)
+from ipfs_accelerate_py.agent_supervisor.proof.test_candidate_context_store import (
+    CANDIDATE_CONTEXT_ENVELOPE_INTERFACE,
+    CANONICAL_ARTIFACT_STORE_TRANSPORT_INTERFACE,
+    CANDIDATE_EXECUTION_CONTEXT_INTERFACE,
+    REQUIRED_COMPONENT_KEYS,
+    TEST_CANDIDATE_CONTEXT_STORE_INTERFACE,
+    CandidateContextEnvelope,
+    CandidateContextStoreReason,
+    CandidateContextStoreStatus,
+    TestCandidateContextStore,
+)
+from ipfs_accelerate_py.testing.proof_reuse.activation_contracts import (
+    CandidateExecutionContext,
+)
+
+NOW_S = 10.0
+NOW_MS = 10_000
+
+
+def _component_bytes(label: str) -> bytes:
+    return canonical_json_bytes(
+        {
+            "schema": "ipfs_accelerate_py/test/candidate-component@1",
+            "label": label,
+            "version": 1,
+        }
+    )
+
+
+def _component_cid(label: str) -> str:
+    return content_identity(
+        {
+            "schema": "ipfs_accelerate_py/test/candidate-component@1",
+            "label": label,
+            "version": 1,
+        }
+    )
+
+
+def _locator_cid(tag: str = "default") -> str:
+    return content_identity(
+        {
+            "schema": "ipfs_accelerate_py/test/locator@1",
+            "tag": tag,
+        }
+    )
+
+
+def _build_bundle(
+    *,
+    tag: str = "default",
+    retained_at_ms: int = NOW_MS,
+) -> tuple[CandidateExecutionContext, dict[str, bytes]]:
+    """Build a descriptor and matching retained component bytes."""
+
+    labels = {
+        "execution_key": f"ek-{tag}",
+        "static_trace": f"static-{tag}",
+        "runtime_trace": f"runtime-{tag}",
+        "repository_forest": f"forest-{tag}",
+        "environment": f"env-{tag}",
+        "policy": f"policy-{tag}",
+        "pass_receipt": f"receipt-{tag}",
+        "test_ast": f"ast-{tag}",
+    }
+    components = {name: _component_bytes(label) for name, label in labels.items()}
+    cids = {name: _component_cid(label) for name, label in labels.items()}
+    locator = _locator_cid(tag)
+    descriptor = CandidateExecutionContext(
+        locator_cid=locator,
+        execution_key_cid=cids["execution_key"],
+        pass_receipt_cid=cids["pass_receipt"],
+        repository_forest_cid=cids["repository_forest"],
+        test_ast_cid=cids["test_ast"],
+        static_trace_root_cid=cids["static_trace"],
+        runtime_trace_root_cid=cids["runtime_trace"],
+        environment_cid=cids["environment"],
+        policy_cid=cids["policy"],
+        retained_at_ms=retained_at_ms,
+        component_cids={
+            "execution_key": cids["execution_key"],
+            "static_trace": cids["static_trace"],
+            "runtime_trace": cids["runtime_trace"],
+            "repository_forest": cids["repository_forest"],
+            "environment": cids["environment"],
+            "policy": cids["policy"],
+            "pass_receipt": cids["pass_receipt"],
+        },
+    )
+    return descriptor, components
+
+
+def _store(tmp_path: Path, **kwargs: Any) -> TestCandidateContextStore:
+    return TestCandidateContextStore(
+        tmp_path / "candidate-context-store",
+        clock=lambda: NOW_S,
+        **kwargs,
+    )
+
+
+def test_publish_and_lookup_returns_bytes_and_non_authoritative_descriptor(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle()
+
+    put = store.publish(descriptor, components, locator_cid=descriptor.locator_cid)
+
+    assert put.stored
+    assert put.indexed
+    assert put.reason_code is CandidateContextStoreReason.OK
+    assert put.candidate_context_cid == descriptor.candidate_context_id
+    assert put.envelope_cid
+    assert put.may_authorize_skip is False
+
+    lookup = store.lookup(descriptor.locator_cid)
+    assert lookup.status is CandidateContextStoreStatus.HIT
+    assert lookup.hit
+    assert lookup.may_authorize_skip is False
+    assert lookup.envelope_bytes is not None
+    assert lookup.descriptor_bytes is not None
+    assert lookup.descriptor is not None
+    assert lookup.descriptor.candidate_context_id == descriptor.candidate_context_id
+    assert lookup.descriptor.may_authorize_skip is False
+    assert lookup.admission is not None
+    assert lookup.admission.admitted
+    assert lookup.admission.may_authorize_skip is False
+    # All required components rehashed and materialised.
+    for key in REQUIRED_COMPONENT_KEYS:
+        assert key in lookup.component_bytes
+        assert lookup.component_bytes[key] == components[key]
+    # Envelope re-parses and never claims skip authority.
+    envelope = CandidateContextEnvelope.from_bytes(lookup.envelope_bytes)
+    assert envelope.may_authorize_skip is False
+    assert envelope.candidate_context_cid == descriptor.candidate_context_id
+    assert envelope.interface == CANDIDATE_CONTEXT_ENVELOPE_INTERFACE
+
+    leftovers = list((tmp_path / "candidate-context-store").rglob(".tmp.*"))
+    assert leftovers == []
+
+
+def test_admission_rehashes_components_and_checks_cid_agreement(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="admit")
+    put = store.publish(descriptor, components)
+    assert put.stored
+
+    admitted = store.admit(put.envelope_cid)
+    assert admitted.admitted
+    assert admitted.reason_code is CandidateContextStoreReason.OK
+    assert set(REQUIRED_COMPONENT_KEYS) <= set(admitted.component_cids)
+    assert admitted.may_authorize_skip is False
+
+    # Poison one component blob → internal/external CID mismatch after rewrite.
+    component_cid = admitted.component_cids["policy"]
+    path = store.cas.blob_path(component_cid)
+    path.write_bytes(b'{"schema":"poisoned","v":1}')
+    failed = store.admit(put.envelope_cid)
+    assert not failed.admitted
+    assert failed.reason_code in {
+        CandidateContextStoreReason.CORRUPT,
+        CandidateContextStoreReason.INTEGRITY_FAILED,
+        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+        CandidateContextStoreReason.COMPONENT_MISSING,
+    }
+
+
+def test_component_field_mismatch_rejects_publish(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="mismatch")
+    # Replace policy bytes with unrelated content so rehash diverges.
+    components = dict(components)
+    components["policy"] = _component_bytes("policy-wrong")
+
+    put = store.publish(descriptor, components)
+    assert not put.stored
+    assert put.reason_code is (
+        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH
+    )
+
+
+def test_missing_required_component_rejects_publish(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="missing")
+    del components["pass_receipt"]
+
+    put = store.publish(descriptor, components)
+    assert not put.stored
+    assert put.reason_code is CandidateContextStoreReason.COMPONENT_MISSING
+
+
+def test_poisoned_index_is_typed_miss(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="poison")
+    assert store.publish(descriptor, components).stored
+
+    index_path = store.index._index_path(descriptor.locator_cid)
+    index_path.write_bytes(b"{not-json")
+    lookup = store.lookup(descriptor.locator_cid)
+    assert lookup.status is CandidateContextStoreStatus.MISS
+    assert lookup.reason_code is CandidateContextStoreReason.INDEX_POISONED
+
+
+def test_missing_blob_is_typed_miss(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="missing-blob")
+    put = store.publish(descriptor, components)
+    assert put.stored
+
+    store.cas.blob_path(put.envelope_cid).unlink()
+    lookup = store.lookup(descriptor.locator_cid)
+    assert lookup.status is CandidateContextStoreStatus.MISS
+    assert lookup.reason_code in {
+        CandidateContextStoreReason.CANDIDATE_MISSING,
+        CandidateContextStoreReason.COMPONENT_MISSING,
+    }
+
+
+def test_partial_write_is_typed_miss_and_quarantines(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="partial")
+    put = store.publish(descriptor, components)
+    assert put.stored
+
+    path = store.cas.blob_path(put.envelope_cid)
+    path.write_bytes(b"")
+    admitted = store.admit(put.envelope_cid)
+    assert not admitted.admitted
+    assert admitted.reason_code is CandidateContextStoreReason.PARTIAL
+    # Empty blob is quarantined by the underlying CAS.
+    assert store.cas.quarantine_path(put.envelope_cid).exists()
+
+
+def test_symlink_blob_is_typed_miss(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="symlink")
+    put = store.publish(descriptor, components)
+    assert put.stored
+
+    blob = store.cas.blob_path(put.envelope_cid)
+    outside = tmp_path / "outside-envelope.json"
+    outside.write_bytes(blob.read_bytes())
+    blob.unlink()
+    blob.symlink_to(outside)
+
+    admitted = store.admit(put.envelope_cid)
+    assert not admitted.admitted
+    assert admitted.reason_code is CandidateContextStoreReason.SYMLINK_REJECTED
+
+
+def test_index_symlink_is_typed_miss(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="index-symlink")
+    assert store.publish(descriptor, components).stored
+
+    index_path = store.index._index_path(descriptor.locator_cid)
+    payload = index_path.read_bytes()
+    index_path.unlink()
+    outside = tmp_path / "evil-index.json"
+    outside.write_bytes(payload)
+    index_path.symlink_to(outside)
+
+    lookup = store.index.candidates(descriptor.locator_cid)
+    assert lookup.status is CandidateContextStoreStatus.MISS
+    assert lookup.reason_code is CandidateContextStoreReason.SYMLINK_REJECTED
+
+
+def test_expiry_and_revocation_hide_candidates(tmp_path: Path) -> None:
+    store = _store(tmp_path, index_ttl_ms=1_000)
+    descriptor, components = _build_bundle(tag="ttl")
+    assert store.publish(
+        descriptor,
+        components,
+        created_at_ms=NOW_MS,
+        expires_at_ms=NOW_MS + 500,
+    ).stored
+
+    expired = store.lookup(descriptor.locator_cid, now_ms=NOW_MS + 501)
+    assert expired.status is CandidateContextStoreStatus.MISS
+
+    store2 = _store(tmp_path / "revocation")
+    descriptor2, components2 = _build_bundle(tag="revoke")
+    put = store2.publish(descriptor2, components2, created_at_ms=NOW_MS)
+    assert put.stored
+    revoked = store2.index.revoke(
+        descriptor2.locator_cid, descriptor2.candidate_context_id
+    )
+    assert revoked.published
+    assert store2.lookup(descriptor2.locator_cid).status is CandidateContextStoreStatus.MISS
+
+
+def test_stale_generation_is_typed_miss(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="gen1")
+    first = store.publish(descriptor, components, expected_generation=0)
+    assert first.stored
+    assert first.generation == 1
+
+    # Second publication advances generation.
+    descriptor2, components2 = _build_bundle(tag="gen2")
+    # Force same locator as first.
+    descriptor2 = CandidateExecutionContext(
+        locator_cid=descriptor.locator_cid,
+        execution_key_cid=descriptor2.execution_key_cid,
+        pass_receipt_cid=descriptor2.pass_receipt_cid,
+        repository_forest_cid=descriptor2.repository_forest_cid,
+        test_ast_cid=descriptor2.test_ast_cid,
+        static_trace_root_cid=descriptor2.static_trace_root_cid,
+        runtime_trace_root_cid=descriptor2.runtime_trace_root_cid,
+        environment_cid=descriptor2.environment_cid,
+        policy_cid=descriptor2.policy_cid,
+        retained_at_ms=NOW_MS + 1,
+        component_cids=dict(descriptor2.component_cids),
+    )
+    second = store.publish(
+        descriptor2, components2, expected_generation=1
+    )
+    assert second.stored
+    assert second.generation == 2
+
+    # Stale expected generation rejects concurrent publication.
+    descriptor3, components3 = _build_bundle(tag="gen-stale")
+    descriptor3 = CandidateExecutionContext(
+        locator_cid=descriptor.locator_cid,
+        execution_key_cid=descriptor3.execution_key_cid,
+        pass_receipt_cid=descriptor3.pass_receipt_cid,
+        repository_forest_cid=descriptor3.repository_forest_cid,
+        test_ast_cid=descriptor3.test_ast_cid,
+        static_trace_root_cid=descriptor3.static_trace_root_cid,
+        runtime_trace_root_cid=descriptor3.runtime_trace_root_cid,
+        environment_cid=descriptor3.environment_cid,
+        policy_cid=descriptor3.policy_cid,
+        retained_at_ms=NOW_MS + 2,
+        component_cids=dict(descriptor3.component_cids),
+    )
+    stale = store.publish(
+        descriptor3, components3, expected_generation=0
+    )
+    assert not stale.stored
+    assert stale.reason_code is CandidateContextStoreReason.STALE_GENERATION
+
+
+def test_fence_blocks_parallel_mixed_publication(tmp_path: Path) -> None:
+    store_root = tmp_path / "parallel"
+    locator = _locator_cid("parallel")
+    barrier = threading.Barrier(2)
+    outcomes: list[Any] = []
+    lock = threading.Lock()
+
+    def worker(tag: str) -> None:
+        store = TestCandidateContextStore(
+            store_root,
+            clock=lambda: NOW_S,
+            owner_id=f"owner-{tag}",
+        )
+        descriptor, components = _build_bundle(tag=tag)
+        descriptor = CandidateExecutionContext(
+            locator_cid=locator,
+            execution_key_cid=descriptor.execution_key_cid,
+            pass_receipt_cid=descriptor.pass_receipt_cid,
+            repository_forest_cid=descriptor.repository_forest_cid,
+            test_ast_cid=descriptor.test_ast_cid,
+            static_trace_root_cid=descriptor.static_trace_root_cid,
+            runtime_trace_root_cid=descriptor.runtime_trace_root_cid,
+            environment_cid=descriptor.environment_cid,
+            policy_cid=descriptor.policy_cid,
+            retained_at_ms=NOW_MS,
+            component_cids=dict(descriptor.component_cids),
+        )
+        barrier.wait(timeout=5)
+        result = store.publish(
+            descriptor,
+            components,
+            locator_cid=locator,
+            owner_id=f"owner-{tag}",
+        )
+        with lock:
+            outcomes.append((tag, result, descriptor.candidate_context_id))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(worker, "a"), pool.submit(worker, "b")]
+        for future in futures:
+            future.result(timeout=30)
+
+    assert len(outcomes) == 2
+    stored = [item for item in outcomes if item[1].stored and item[1].indexed]
+    assert stored
+    assert all(
+        item[1].reason_code
+        in {
+            CandidateContextStoreReason.FENCED,
+            CandidateContextStoreReason.FENCE_MISMATCH,
+            CandidateContextStoreReason.UNAVAILABLE,
+            CandidateContextStoreReason.OK,
+            CandidateContextStoreReason.STALE_GENERATION,
+        }
+        for item in outcomes
+    )
+
+    reader = TestCandidateContextStore(store_root, clock=lambda: NOW_S)
+    lookup = reader.lookup(locator)
+    assert lookup.status is CandidateContextStoreStatus.HIT
+    assert lookup.descriptor is not None
+    assert lookup.may_authorize_skip is False
+    # Components remain a consistent set for the admitted candidate.
+    for key in REQUIRED_COMPONENT_KEYS:
+        assert key in lookup.component_bytes
+
+
+def test_remote_failure_and_transport_absence_are_typed_misses(
+    tmp_path: Path,
+) -> None:
+    descriptor, components = _build_bundle(tag="remote")
+
+    class FailingTransport:
+        interface = CANONICAL_ARTIFACT_STORE_TRANSPORT_INTERFACE
+
+        def get_bytes(self, cid: str) -> Any:
+            raise RuntimeError("ipfs down")
+
+        def put_bytes(self, data: bytes, **kwargs: Any) -> Any:
+            raise RuntimeError("ipfs down")
+
+    store = _store(tmp_path, remote_transport=FailingTransport())
+    put = store.publish(descriptor, components)
+    assert put.stored
+
+    # Remove local envelope so read falls through to remote.
+    store.cas.blob_path(put.envelope_cid).unlink()
+    admitted = store.admit(put.envelope_cid)
+    assert not admitted.admitted
+    assert admitted.reason_code is CandidateContextStoreReason.REMOTE_FAILURE
+
+    # Explicit transport absence when local is also missing and no transport.
+    bare = _store(tmp_path / "bare")
+    missing = bare.admit(put.envelope_cid)
+    assert not missing.admitted
+    assert missing.reason_code in {
+        CandidateContextStoreReason.CANDIDATE_MISSING,
+        CandidateContextStoreReason.TRANSPORT_ABSENT,
+    }
+
+
+def test_size_and_version_checks(tmp_path: Path) -> None:
+    store = _store(tmp_path, max_component_bytes=64)
+    descriptor, components = _build_bundle(tag="size")
+    # Components exceed the tiny budget.
+    put = store.publish(descriptor, components)
+    assert not put.stored
+    assert put.reason_code in {
+        CandidateContextStoreReason.SIZE_EXCEEDED,
+        CandidateContextStoreReason.OVER_BUDGET,
+    }
+
+    store2 = _store(tmp_path / "version")
+    descriptor2, components2 = _build_bundle(tag="version")
+    put2 = store2.publish(descriptor2, components2)
+    assert put2.stored
+    # Manually write an envelope with a foreign version.
+    envelope = CandidateContextEnvelope.from_bytes(
+        store2.get_bytes(put2.envelope_cid).data
+    )
+    payload = envelope.to_dict()
+    payload["version"] = 99
+    # Bypass envelope constructor validation by writing raw non-version-1 JSON
+    # under a new CID and pointing admission at it via direct admit path would
+    # fail schema; instead mutate the stored blob in place after publication.
+    # Rewrite as non-canonical version field using the CAS path.
+    bad_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
+    # Force-write over the envelope path (simulates corrupted versioned artifact).
+    path = store2.cas.blob_path(put2.envelope_cid)
+    path.write_bytes(bad_bytes)
+    admitted = store2.admit(put2.envelope_cid)
+    assert not admitted.admitted
+    assert admitted.reason_code in {
+        CandidateContextStoreReason.VERSION_MISMATCH,
+        CandidateContextStoreReason.CORRUPT,
+        CandidateContextStoreReason.INTEGRITY_FAILED,
+        CandidateContextStoreReason.INTERNAL_EXTERNAL_CID_MISMATCH,
+    }
+
+
+def test_mutable_metadata_and_cache_presence_never_authorize_skip(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    descriptor, components = _build_bundle(tag="no-skip")
+    put = store.publish(
+        descriptor,
+        components,
+        metadata={"trusted": True, "skip": True, "historical_execution_key": "x"},
+    )
+    assert put.stored
+    assert put.may_authorize_skip is False
+
+    lookup = store.lookup(descriptor.locator_cid)
+    assert lookup.hit
+    assert lookup.may_authorize_skip is False
+    assert lookup.descriptor is not None
+    assert lookup.descriptor.may_authorize_skip is False
+    # Historical execution key identity is retained for comparison, not authority.
+    assert lookup.descriptor.execution_key_cid == descriptor.execution_key_cid
+    # Cache presence alone is not skip authority.
+    assert store.get_bytes(put.envelope_cid).hit
+    assert store.may_authorize_skip is False
+
+    direct = store.lookup_by_context_cid(descriptor.candidate_context_id)
+    assert direct.hit
+    assert direct.may_authorize_skip is False
+    assert direct.diagnostics.get("may_authorize_skip") is False
+
+
+def test_path_escape_cid_tokens_miss_safely(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    for bad in ("../escape", "a/b", "a\\b", "UPPER", "has space", ""):
+        result = store.admit(bad)
+        assert not result.admitted
+        assert result.reason_code is CandidateContextStoreReason.PATH_ESCAPE
+
+
+def test_interfaces_and_required_components_are_sealed() -> None:
+    assert TEST_CANDIDATE_CONTEXT_STORE_INTERFACE == "TestCandidateContextStore@1"
+    assert CANDIDATE_EXECUTION_CONTEXT_INTERFACE == "CandidateExecutionContext@1"
+    assert (
+        CANONICAL_ARTIFACT_STORE_TRANSPORT_INTERFACE
+        == "CanonicalArtifactStoreTransport@1"
+    )
+    assert "execution_key" in REQUIRED_COMPONENT_KEYS
+    assert "pass_receipt" in REQUIRED_COMPONENT_KEYS
+    assert "policy" in REQUIRED_COMPONENT_KEYS
+
+
+def test_idempotent_component_cas_and_restart_scrub(tmp_path: Path) -> None:
+    root = tmp_path / "restart"
+    store = TestCandidateContextStore(root, clock=lambda: NOW_S)
+    descriptor, components = _build_bundle(tag="idem")
+    first = store.publish(descriptor, components)
+    second = store.publish(descriptor, components)
+    assert first.stored
+    # Second publish is a new generation but components already exist.
+    assert second.stored or second.reason_code in {
+        CandidateContextStoreReason.OK,
+        CandidateContextStoreReason.FENCED,
+    }
+
+    cas_dir = store.cas.cas_root / "aa"
+    cas_dir.mkdir(parents=True, exist_ok=True)
+    orphan = cas_dir / ".tmp.orphan.blob.tmp"
+    orphan.write_bytes(b"partial")
+    assert orphan.exists()
+    reopened = TestCandidateContextStore(root, clock=lambda: NOW_S)
+    assert not orphan.exists()
+    assert reopened.root == root.resolve()
+
+
+def test_oversized_envelope_lookup_is_size_exceeded(tmp_path: Path) -> None:
+    store = _store(tmp_path, max_blob_bytes=256)
+    # Build tiny components so publish of components might work, but force a
+    # large metadata blob if possible.  Simpler: publish with default store then
+    # open a restricted reader against the same CAS is not supported; instead
+    # publish normally and poke admit with a store that has a tiny budget.
+    full = _store(tmp_path / "full")
+    descriptor, components = _build_bundle(tag="oversize")
+    put = full.publish(descriptor, components)
+    assert put.stored
+
+    tight = TestCandidateContextStore(
+        tmp_path / "full" / "candidate-context-store",
+        clock=lambda: NOW_S,
+        max_blob_bytes=32,
+        max_component_bytes=32,
+    )
+    admitted = tight.admit(put.envelope_cid)
+    assert not admitted.admitted
+    assert admitted.reason_code in {
+        CandidateContextStoreReason.SIZE_EXCEEDED,
+        CandidateContextStoreReason.OVER_BUDGET,
+        CandidateContextStoreReason.CANDIDATE_MISSING,
+        CandidateContextStoreReason.CORRUPT,
+        CandidateContextStoreReason.INTEGRITY_FAILED,
+    }

--- a/test/api/test_agent_supervisor_test_execution_identity.py
+++ b/test/api/test_agent_supervisor_test_execution_identity.py
@@ -1,0 +1,478 @@
+"""PTR-010: core locator and execution identity (ContentIdentity@1)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from multiformats import CID, multihash
+
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    CID_BASE,
+    CID_CODEC,
+    CID_VERSION,
+    CONTENT_IDENTITY_INTERFACE,
+    DIGEST_SIZE,
+    MH_TYPE,
+    REASON_CID_PROVIDER_UNAVAILABLE,
+    REASON_NON_REUSABLE,
+    TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE,
+    CidSupportStatus,
+    CompiledTestExecutionKey,
+    CompiledTestLocator,
+    ContentIdentity,
+    TestExecutionIdentityCompiler,
+    TestExecutionIdentityError,
+    cid_support_available,
+    compile_test_execution_key,
+    compile_test_locator,
+    content_identity_from_retained_bytes,
+    mint_content_identity,
+    normalize_pytest_node_id,
+    probe_cid_support,
+    reject_pseudo_cid,
+)
+from ipfs_accelerate_py.agent_supervisor.proof.test_execution_contracts import (
+    EligibilityClass,
+    TestExecutionKey,
+    TestLocatorKey,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _locator_fields(**changes: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "repository_id": "repository:sha256:demo",
+        "package_identity": "ipfs_accelerate_py",
+        "node_id": "test/api/test_demo.py::test_alpha",
+        "collection_schema_version": "1",
+        "root_identity": "root:repo",
+        "selection_semantics": "exact_node",
+    }
+    values.update(changes)
+    return values
+
+
+def _execution_fields(locator_cid: str, **changes: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "locator_cid": locator_cid,
+        "repository_forest_cid": "forest:baguqeeratestforestidentity0001",
+        "git_commit_id": "deadbeefcafebabe",
+        "git_tree_id": "tree:abc123",
+        "test_module_cid": "module:baguqeeramoduleidentity0001",
+        "test_function_cid": "function:baguqeerafnidentity0001",
+        "test_ast_cid": "ast:baguqeeraastidentity0001",
+        "static_trace_root_cid": "static:baguqeerastaticidentity0001",
+        "runtime_trace_root_cid": "runtime:baguqeeraruntimeidentity0001",
+        "pytest_version": "8.2.0",
+        "python_version": "3.11.9",
+        "policy_cid": "policy:baguqeerapolicyidentity0001",
+        "eligibility_class": EligibilityClass.REPOSITORY_FOREST_BOUND,
+        "markers": ("unit", "slow"),
+        "fixture_cids": ("fixture:b", "fixture:a"),
+    }
+    values.update(changes)
+    return values
+
+
+def _assert_profile_cid(cid: str, *, payload_bytes: bytes) -> None:
+    """Assert CIDv1/base32/dag-json/sha2-256 and multihash == sha256(bytes).
+
+    Uses the independent ``multiformats`` package only (no multiformats_identity
+    / ipfs_datasets_py import path, which can fail under shadowing PYTHONPATH
+    orderings during supervisor validation).
+    """
+
+    assert cid == cid.lower()
+    assert cid.startswith("b")
+    parsed = CID.decode(cid)
+    assert parsed.version == CID_VERSION
+    assert parsed.codec.name == CID_CODEC
+    assert parsed.hashfun.name == MH_TYPE
+    assert parsed.base.name == CID_BASE
+    assert len(parsed.raw_digest) == DIGEST_SIZE
+    assert bytes(parsed.raw_digest) == hashlib.sha256(payload_bytes).digest()
+    independent = str(
+        CID(CID_BASE, CID_VERSION, CID_CODEC, multihash.digest(payload_bytes, MH_TYPE))
+    )
+    assert independent == cid
+
+
+# ---------------------------------------------------------------------------
+# ContentIdentity mint / retain / rehash
+# ---------------------------------------------------------------------------
+
+
+def test_mint_content_identity_stable_cidv1_profile() -> None:
+    payload = {"alpha": 1, "beta": ["x", "y"], "schema": "probe"}
+    first = mint_content_identity(payload)
+    second = mint_content_identity({"beta": ["x", "y"], "alpha": 1, "schema": "probe"})
+
+    assert first.interface == CONTENT_IDENTITY_INTERFACE
+    assert first.cid == second.cid
+    assert first.digest_hex == second.digest_hex
+    assert first.canonical_bytes == second.canonical_bytes
+    _assert_profile_cid(first.cid, payload_bytes=first.canonical_bytes)
+    assert first.verify() is first
+    assert first.rehash_cid() == first.cid
+
+
+def test_retained_canonical_bytes_decode_and_rehash() -> None:
+    payload = {"interface": "TestLocatorKey@1", "node": "n1", "v": 1}
+    identity = mint_content_identity(payload)
+
+    # Decode retained bytes and re-encode must match.
+    parsed = json.loads(identity.canonical_bytes.decode("utf-8"))
+    rebuilt = content_identity_from_retained_bytes(
+        identity.canonical_bytes, claimed_cid=identity.cid
+    )
+    assert rebuilt.cid == identity.cid
+    assert rebuilt.digest_hex == identity.digest_hex
+    assert rebuilt.canonical_bytes == identity.canonical_bytes
+    assert (
+        bytes(CID.decode(rebuilt.cid).raw_digest).hex()
+        == hashlib.sha256(rebuilt.canonical_bytes).hexdigest()
+    )
+    assert parsed["node"] == "n1"
+
+
+def test_retained_bytes_claimed_cid_mismatch_fails() -> None:
+    identity = mint_content_identity({"k": "v"})
+    other = mint_content_identity({"k": "other"})
+    with pytest.raises(TestExecutionIdentityError, match="claimed CID"):
+        content_identity_from_retained_bytes(
+            identity.canonical_bytes, claimed_cid=other.cid
+        )
+
+
+def test_content_identity_rejects_digest_mismatch() -> None:
+    identity = mint_content_identity({"z": 1})
+    with pytest.raises(TestExecutionIdentityError, match="digest_hex"):
+        ContentIdentity(
+            cid=identity.cid,
+            digest_hex="0" * 64,
+            canonical_bytes=identity.canonical_bytes,
+        )
+
+
+def test_reject_pseudo_cid_forms() -> None:
+    with pytest.raises(TestExecutionIdentityError, match="pseudo-hash"):
+        reject_pseudo_cid("cid:forest:v1")
+    with pytest.raises(TestExecutionIdentityError, match="pseudo-hash"):
+        reject_pseudo_cid("sha256:" + "ab" * 32)
+    with pytest.raises(TestExecutionIdentityError, match="pseudo-hash"):
+        reject_pseudo_cid("runtime-artifact:sha256:" + "cd" * 32)
+    with pytest.raises(TestExecutionIdentityError, match="CIDv0"):
+        reject_pseudo_cid("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG")
+    with pytest.raises(TestExecutionIdentityError, match="truncated"):
+        reject_pseudo_cid("bafy")
+
+    real = mint_content_identity({"ok": True}).cid
+    assert reject_pseudo_cid(real) == real
+
+
+# ---------------------------------------------------------------------------
+# Locator compilation
+# ---------------------------------------------------------------------------
+
+
+def test_compile_test_locator_stable_and_profile() -> None:
+    a = compile_test_locator(**_locator_fields())
+    b = compile_test_locator(**_locator_fields())
+
+    assert a.reusable is True
+    assert b.reusable is True
+    assert a.locator_cid == b.locator_cid
+    assert a.content_identity is not None
+    _assert_profile_cid(
+        a.locator_cid, payload_bytes=a.content_identity.canonical_bytes
+    )
+    assert a.locator is not None
+    assert a.locator.content_id == a.locator_cid
+    assert a.content_identity.verify().cid == a.locator_cid
+    # Multiformats independent agreement on the retained canonical bytes.
+    independent = str(
+        CID(
+            CID_BASE,
+            CID_VERSION,
+            CID_CODEC,
+            multihash.digest(a.content_identity.canonical_bytes, MH_TYPE),
+        )
+    )
+    assert independent == a.locator_cid
+    assert a.locator.canonical_bytes() == a.content_identity.canonical_bytes
+
+
+def test_compile_test_locator_from_contract_instance() -> None:
+    key = TestLocatorKey(**_locator_fields())  # type: ignore[arg-type]
+    compiled = compile_test_locator(key)
+    assert compiled.reusable is True
+    assert compiled.locator_cid == key.content_id
+
+
+def test_compile_test_locator_normalizes_node_id() -> None:
+    compiled = compile_test_locator(
+        **_locator_fields(node_id=r"test\\api//test_demo.py::test_alpha")
+    )
+    assert compiled.reusable is True
+    assert compiled.locator is not None
+    assert compiled.locator.node_id == normalize_pytest_node_id(
+        r"test\\api//test_demo.py::test_alpha"
+    )
+    assert "\\" not in compiled.locator.node_id
+    assert "//" not in compiled.locator.node_id
+
+
+def test_compile_test_locator_parameter_non_reusable_retains_cid() -> None:
+    compiled = compile_test_locator(
+        **_locator_fields(
+            parameter_id="p0",
+            non_reusable_reason="unsupported_parameter_type",
+        )
+    )
+    assert compiled.reusable is False
+    assert compiled.reason_code == REASON_NON_REUSABLE
+    assert compiled.non_reusable_reason == "unsupported_parameter_type"
+    assert compiled.locator_cid
+    assert compiled.content_identity is not None
+    _assert_profile_cid(
+        compiled.locator_cid,
+        payload_bytes=compiled.content_identity.canonical_bytes,
+    )
+
+
+def test_compile_test_locator_malformed_is_non_reusable() -> None:
+    compiled = compile_test_locator(
+        repository_id="repo",
+        package_identity="pkg",
+        # missing node_id
+    )
+    assert compiled.reusable is False
+    assert compiled.locator_cid == ""
+    assert compiled.content_identity is None
+    assert "malformed" in compiled.non_reusable_reason or compiled.reason_code
+
+
+def test_compile_test_locator_missing_cid_support_non_reusable() -> None:
+    compiler = TestExecutionIdentityCompiler(
+        cid_probe=lambda: CidSupportStatus.MISSING,
+    )
+    compiled = compiler.compile_locator(**_locator_fields())
+    assert compiled.reusable is False
+    assert compiled.reason_code == REASON_CID_PROVIDER_UNAVAILABLE
+    assert compiled.locator_cid == ""
+    assert compiled.content_identity is None
+    assert compiled.cid_support is CidSupportStatus.MISSING
+    # Must not invent a pseudo-CID.
+    assert not compiled.locator_cid.startswith("sha256:")
+    assert not compiled.locator_cid.startswith("cid:")
+
+
+def test_compile_test_locator_incompatible_cid_support_non_reusable() -> None:
+    compiler = TestExecutionIdentityCompiler(
+        cid_probe=lambda: CidSupportStatus.INCOMPATIBLE,
+    )
+    compiled = compiler.compile_locator(**_locator_fields())
+    assert compiled.reusable is False
+    assert compiled.reason_code == REASON_CID_PROVIDER_UNAVAILABLE
+    assert compiled.locator_cid == ""
+
+
+# ---------------------------------------------------------------------------
+# Execution key compilation
+# ---------------------------------------------------------------------------
+
+
+def test_compile_test_execution_key_stable_and_profile() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    assert locator.reusable and locator.locator_cid
+
+    first = compile_test_execution_key(
+        **_execution_fields(locator.locator_cid)
+    )
+    second = compile_test_execution_key(
+        **_execution_fields(locator.locator_cid)
+    )
+
+    assert first.reusable is True
+    assert first.execution_cid == second.execution_cid
+    assert first.locator_cid == locator.locator_cid
+    assert first.content_identity is not None
+    _assert_profile_cid(
+        first.execution_cid,
+        payload_bytes=first.content_identity.canonical_bytes,
+    )
+    assert first.execution_key is not None
+    assert first.execution_key.content_id == first.execution_cid
+    first.content_identity.verify()
+    assert first.content_identity.rehash_cid() == first.execution_cid
+
+
+def test_any_bound_change_changes_execution_cid() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    base = compile_test_execution_key(**_execution_fields(locator.locator_cid))
+    assert base.reusable is True
+
+    mutations: list[dict[str, object]] = [
+        {"repository_forest_cid": "forest:changed"},
+        {"git_commit_id": "c0ffee"},
+        {"test_module_cid": "module:changed"},
+        {"test_ast_cid": "ast:changed"},
+        {"policy_cid": "policy:changed"},
+        {"pytest_version": "8.3.0"},
+        {"python_version": "3.12.0"},
+        {"markers": ("unit",)},
+        {"fixture_cids": ("fixture:z",)},
+        {"environment_cid": "env:changed"},
+        {"static_trace_root_cid": "static:changed"},
+        {"runtime_trace_root_cid": "runtime:changed"},
+        {"eligibility_class": EligibilityClass.PURE},
+    ]
+    # Locator change (different locator CID) also changes execution identity.
+    other_locator = compile_test_locator(
+        **_locator_fields(node_id="test/api/test_demo.py::test_beta")
+    )
+    mutations.append({"locator_cid": other_locator.locator_cid})
+
+    seen = {base.execution_cid}
+    for change in mutations:
+        fields = _execution_fields(locator.locator_cid)
+        fields.update(change)
+        compiled = compile_test_execution_key(**fields)
+        assert compiled.reusable is True, change
+        assert compiled.execution_cid not in seen, change
+        seen.add(compiled.execution_cid)
+
+
+def test_compile_execution_key_from_contract_instance() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    key = TestExecutionKey(
+        **_execution_fields(locator.locator_cid)  # type: ignore[arg-type]
+    )
+    compiled = compile_test_execution_key(key)
+    assert compiled.reusable is True
+    assert compiled.execution_cid == key.content_id
+
+
+def test_execution_key_eligibility_non_reusable_still_has_cid() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    compiled = compile_test_execution_key(
+        **_execution_fields(
+            locator.locator_cid,
+            eligibility_class=EligibilityClass.NON_REUSABLE,
+        )
+    )
+    assert compiled.reusable is False
+    assert compiled.reason_code == REASON_NON_REUSABLE
+    assert "non_reusable" in compiled.non_reusable_reason
+    assert compiled.execution_cid
+    assert compiled.content_identity is not None
+    _assert_profile_cid(
+        compiled.execution_cid,
+        payload_bytes=compiled.content_identity.canonical_bytes,
+    )
+
+
+def test_compile_execution_key_missing_cid_support_non_reusable() -> None:
+    compiler = TestExecutionIdentityCompiler(
+        cid_probe=lambda: CidSupportStatus.MISSING,
+    )
+    compiled = compiler.compile_execution_key(
+        **_execution_fields("baguqeeraplacesholdercidvalue01")
+    )
+    assert compiled.reusable is False
+    assert compiled.reason_code == REASON_CID_PROVIDER_UNAVAILABLE
+    assert compiled.execution_cid == ""
+    assert compiled.content_identity is None
+
+
+def test_compile_execution_key_malformed_non_reusable() -> None:
+    # Missing required locator_cid / forest.
+    compiled = compile_test_execution_key(git_commit_id="x")
+    assert compiled.reusable is False
+    assert compiled.execution_cid == ""
+    assert compiled.content_identity is None
+
+
+# ---------------------------------------------------------------------------
+# Compiler surface / probes
+# ---------------------------------------------------------------------------
+
+
+def test_compiler_interface_and_probe_available() -> None:
+    compiler = TestExecutionIdentityCompiler()
+    assert compiler.interface == TEST_EXECUTION_IDENTITY_COMPILER_INTERFACE
+    status = compiler.probe()
+    assert status is CidSupportStatus.AVAILABLE
+    assert probe_cid_support() is CidSupportStatus.AVAILABLE
+    assert cid_support_available() is True
+
+
+def test_compiled_artifacts_to_dict_shape() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    execution = compile_test_execution_key(
+        **_execution_fields(locator.locator_cid)
+    )
+    loc_dict = locator.to_dict()
+    exec_dict = execution.to_dict()
+    assert loc_dict["reusable"] is True
+    assert loc_dict["locator_cid"] == locator.locator_cid
+    assert loc_dict["content_identity"]["interface"] == CONTENT_IDENTITY_INTERFACE
+    assert exec_dict["execution_cid"] == execution.execution_cid
+    assert exec_dict["locator_cid"] == locator.locator_cid
+
+
+def test_normalize_pytest_node_id() -> None:
+    assert (
+        normalize_pytest_node_id("  path\\to//test.py::test_x  ")
+        == "path/to/test.py::test_x"
+    )
+    with pytest.raises(TestExecutionIdentityError):
+        normalize_pytest_node_id("   ")
+
+
+def test_module_entry_points_match_compiler() -> None:
+    fields = _locator_fields()
+    via_fn = compile_test_locator(**fields)
+    via_cls = TestExecutionIdentityCompiler().compile_locator(**fields)
+    assert via_fn.locator_cid == via_cls.locator_cid
+
+    exec_fields = _execution_fields(via_fn.locator_cid)
+    e1 = compile_test_execution_key(**exec_fields)
+    e2 = TestExecutionIdentityCompiler().compile_execution_key(**exec_fields)
+    assert e1.execution_cid == e2.execution_cid
+
+
+def test_key_order_does_not_affect_execution_cid() -> None:
+    locator = compile_test_locator(**_locator_fields())
+    a = compile_test_execution_key(
+        **_execution_fields(
+            locator.locator_cid,
+            metadata={"b": 2, "a": 1},
+            components={"z": "1", "a": "2"},
+        )
+    )
+    b = compile_test_execution_key(
+        **_execution_fields(
+            locator.locator_cid,
+            metadata={"a": 1, "b": 2},
+            components={"a": "2", "z": "1"},
+        )
+    )
+    assert a.execution_cid == b.execution_cid
+    assert a.content_identity is not None
+    assert b.content_identity is not None
+    assert a.content_identity.canonical_bytes == b.content_identity.canonical_bytes
+
+
+def test_compiled_types_are_not_collected_as_tests() -> None:
+    assert getattr(ContentIdentity, "__test__", True) is False
+    assert getattr(CompiledTestLocator, "__test__", True) is False
+    assert getattr(CompiledTestExecutionKey, "__test__", True) is False
+    assert getattr(TestExecutionIdentityCompiler, "__test__", True) is False
+    assert getattr(TestExecutionIdentityError, "__test__", True) is False

--- a/test/api/test_agent_supervisor_test_execution_identity_vectors.py
+++ b/test/api/test_agent_supervisor_test_execution_identity_vectors.py
@@ -1,0 +1,362 @@
+"""PTR-012: independent cross-package ContentIdentity@1 vectors.
+
+These vectors deliberately retain literal canonical bytes, SHA-256 digests,
+and CIDs.  Each provider must independently reach those literals; agreement
+obtained by round-tripping a value from one provider is not sufficient.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+import pytest
+from ipfs_datasets_py.utils.cid_utils import (
+    canonical_dag_json_bytes as datasets_canonical_dag_json_bytes,
+)
+from ipfs_datasets_py.utils.cid_utils import (
+    cid_for_bytes as datasets_cid_for_bytes,
+)
+from ipfs_datasets_py.utils.cid_utils import (
+    cid_for_dag_json as datasets_cid_for_dag_json,
+)
+from ipfs_datasets_py.utils.cid_utils import (
+    validate_cid as datasets_validate_cid,
+)
+from multiformats import CID, multihash
+
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    CID_BASE,
+    CID_CODEC,
+    CID_VERSION,
+    CONTENT_IDENTITY_INTERFACE,
+    DIGEST_SIZE,
+    MH_TYPE,
+    ContentIdentity,
+    TestExecutionIdentityError,
+    mint_content_identity,
+    reject_pseudo_cid,
+)
+
+
+@dataclass(frozen=True)
+class IdentityVector:
+    """A fixed external expectation, not output captured from an implementation."""
+
+    name: str
+    payload: Mapping[str, Any]
+    canonical_bytes: bytes
+    digest_hex: str
+    cid: str
+
+
+KNOWN_VECTORS = (
+    IdentityVector(
+        name="nested-ascii",
+        # Deliberately not insertion-sorted.
+        payload={
+            "values": [True, None, 3],
+            "nested": {"z": 2, "a": 1},
+            "name": "ascii",
+            "interface": "ContentIdentity@1",
+        },
+        canonical_bytes=(
+            b'{"interface":"ContentIdentity@1","name":"ascii",'
+            b'"nested":{"a":1,"z":2},"values":[true,null,3]}'
+        ),
+        digest_hex=(
+            "ac163a0ec8c38368846bf4491ce35ab4"
+            "3e2f17c88d14a3a56a409ed77b5c4d3c"
+        ),
+        cid="baguqeeravqldudwiyobwrbdl6rerzy22wq7c6f6irukkhjlkicpno624ju6a",
+    ),
+    IdentityVector(
+        name="utf8-unicode",
+        payload={
+            "text": "café λ",
+            "name": "unicode",
+            "interface": "ContentIdentity@1",
+            "values": [False, 0],
+        },
+        canonical_bytes=(
+            b'{"interface":"ContentIdentity@1","name":"unicode",'
+            b'"text":"caf\xc3\xa9 \xce\xbb","values":[false,0]}'
+        ),
+        digest_hex=(
+            "fd5d4485ed3fb993501b229f71603689"
+            "9108540d4e5a407bdefe74184df08d65"
+        ),
+        cid="baguqeera7voujbpnh64zgua3ekpxcybwrgiqqvanjznea6667z2bqtpqrvsq",
+    ),
+)
+
+
+class ContradictionKind(str, Enum):
+    """Typed reason that a claimed CID contradicts retained identity bytes."""
+
+    VERSION = "version"
+    BASE = "base"
+    CODEC = "codec"
+    MULTIHASH = "multihash"
+    DIGEST = "digest"
+    MALFORMED_MULTIHASH = "malformed_multihash"
+
+
+class CIDIdentityContradiction(AssertionError):
+    """Independent oracle failure with a stable, inspectable contradiction kind."""
+
+    def __init__(self, kind: ContradictionKind, detail: str) -> None:
+        self.kind = kind
+        super().__init__(f"{kind.value} contradiction: {detail}")
+
+
+def _require_frozen_claim(cid: str, retained_bytes: bytes) -> CID:
+    """Decode and compare a claim without calling supervisor or dataset helpers."""
+
+    try:
+        decoded = CID.decode(cid)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise CIDIdentityContradiction(
+            ContradictionKind.MALFORMED_MULTIHASH,
+            "CID or its multihash cannot be decoded",
+        ) from exc
+
+    if decoded.version != CID_VERSION:
+        raise CIDIdentityContradiction(
+            ContradictionKind.VERSION,
+            f"expected {CID_VERSION}, got {decoded.version}",
+        )
+    if decoded.base.name != CID_BASE:
+        raise CIDIdentityContradiction(
+            ContradictionKind.BASE,
+            f"expected {CID_BASE}, got {decoded.base.name}",
+        )
+    if decoded.codec.name != CID_CODEC:
+        raise CIDIdentityContradiction(
+            ContradictionKind.CODEC,
+            f"expected {CID_CODEC}, got {decoded.codec.name}",
+        )
+    if decoded.hashfun.name != MH_TYPE or len(decoded.raw_digest) != DIGEST_SIZE:
+        raise CIDIdentityContradiction(
+            ContradictionKind.MULTIHASH,
+            "expected a 32-byte sha2-256 multihash",
+        )
+
+    expected_digest = hashlib.sha256(retained_bytes).digest()
+    if bytes(decoded.raw_digest) != expected_digest:
+        raise CIDIdentityContradiction(
+            ContradictionKind.DIGEST,
+            "decoded digest does not hash the retained bytes",
+        )
+    return decoded
+
+
+@pytest.mark.parametrize("vector", KNOWN_VECTORS, ids=lambda vector: vector.name)
+def test_known_vectors_match_three_independent_providers(
+    vector: IdentityVector,
+) -> None:
+    """Supervisor, datasets, and direct multiformats must match fixed literals."""
+
+    supervisor_identity = mint_content_identity(vector.payload)
+    datasets_bytes = datasets_canonical_dag_json_bytes(vector.payload)
+    datasets_cid_from_bytes = datasets_cid_for_bytes(
+        datasets_bytes,
+        base=CID_BASE,
+        codec=CID_CODEC,
+        mh_type=MH_TYPE,
+        version=CID_VERSION,
+    )
+    datasets_cid_from_value = datasets_cid_for_dag_json(
+        vector.payload,
+        base=CID_BASE,
+        mh_type=MH_TYPE,
+        version=CID_VERSION,
+    )
+    direct_digest = hashlib.sha256(vector.canonical_bytes).digest()
+    direct_cid = str(
+        CID(
+            CID_BASE,
+            CID_VERSION,
+            CID_CODEC,
+            multihash.digest(vector.canonical_bytes, MH_TYPE),
+        )
+    )
+
+    assert datasets_bytes == vector.canonical_bytes
+    assert supervisor_identity.canonical_bytes == vector.canonical_bytes
+    assert direct_digest.hex() == vector.digest_hex
+    assert supervisor_identity.digest_hex == vector.digest_hex
+    assert datasets_cid_from_bytes == vector.cid
+    assert datasets_cid_from_value == vector.cid
+    assert direct_cid == vector.cid
+    assert supervisor_identity.cid == vector.cid
+
+    decoded = _require_frozen_claim(vector.cid, vector.canonical_bytes)
+    assert decoded.version == 1
+    assert decoded.base.name == "base32"
+    assert decoded.codec.name == "dag-json"
+    assert decoded.hashfun.name == "sha2-256"
+    assert bytes(multihash.unwrap(decoded.digest)).hex() == vector.digest_hex
+    assert (
+        datasets_validate_cid(
+            vector.cid,
+            codecs=("dag-json",),
+            mh_type="sha2-256",
+            version=1,
+            base="base32",
+        )
+        == vector.cid
+    )
+    assert supervisor_identity.interface == CONTENT_IDENTITY_INTERFACE
+    assert supervisor_identity.verify() is supervisor_identity
+
+
+def _contradictory_cids(vector: IdentityVector) -> tuple[tuple[str, ContradictionKind], ...]:
+    retained_multihash = multihash.digest(vector.canonical_bytes, MH_TYPE)
+    return (
+        (
+            str(CID("base58btc", 0, "dag-pb", retained_multihash)),
+            ContradictionKind.VERSION,
+        ),
+        (
+            str(CID("base58btc", CID_VERSION, CID_CODEC, retained_multihash)),
+            ContradictionKind.BASE,
+        ),
+        (
+            str(CID(CID_BASE, CID_VERSION, "raw", retained_multihash)),
+            ContradictionKind.CODEC,
+        ),
+        (
+            str(
+                CID(
+                    CID_BASE,
+                    CID_VERSION,
+                    CID_CODEC,
+                    multihash.digest(vector.canonical_bytes + b"\n", MH_TYPE),
+                )
+            ),
+            ContradictionKind.DIGEST,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("claimed_cid", "expected_kind"),
+    _contradictory_cids(KNOWN_VECTORS[0]),
+    ids=("version", "base", "codec", "digest"),
+)
+def test_profile_differences_are_typed_contradictions_and_rejected(
+    claimed_cid: str,
+    expected_kind: ContradictionKind,
+) -> None:
+    vector = KNOWN_VECTORS[0]
+
+    with pytest.raises(CIDIdentityContradiction) as contradiction:
+        _require_frozen_claim(claimed_cid, vector.canonical_bytes)
+    assert contradiction.value.kind is expected_kind
+
+    # The datasets boundary validates the frozen CID profile.  A digest
+    # contradiction is structurally valid and is rejected only when the CID is
+    # bound to retained bytes; the other profile contradictions fail here.
+    if expected_kind is ContradictionKind.DIGEST:
+        assert (
+            datasets_validate_cid(
+                claimed_cid,
+                codecs=(CID_CODEC,),
+                mh_type=MH_TYPE,
+                version=CID_VERSION,
+                base=CID_BASE,
+            )
+            == claimed_cid
+        )
+        assert bytes(CID.decode(claimed_cid).raw_digest) != hashlib.sha256(
+            vector.canonical_bytes
+        ).digest()
+    else:
+        with pytest.raises(ValueError):
+            datasets_validate_cid(
+                claimed_cid,
+                codecs=(CID_CODEC,),
+                mh_type=MH_TYPE,
+                version=CID_VERSION,
+                base=CID_BASE,
+            )
+
+    # ContentIdentity binds the profile-valid CID to the retained bytes and
+    # therefore rejects every contradiction, including the digest-only case.
+    with pytest.raises(ValueError):
+        ContentIdentity(
+            cid=claimed_cid,
+            digest_hex=vector.digest_hex,
+            canonical_bytes=vector.canonical_bytes,
+        ).verify()
+
+
+LEGACY_PSEUDO_CIDS = (
+    "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+    "cid:not-a-cid",
+    "sha256:deadbeef",
+    "tree:sha256:111",
+    "repo:fixture",
+    "BAGAAQEERA",
+    "",
+)
+
+
+@pytest.mark.parametrize("legacy_value", LEGACY_PSEUDO_CIDS)
+def test_legacy_kit_hashes_are_never_admitted_as_cids(legacy_value: str) -> None:
+    with pytest.raises(TestExecutionIdentityError):
+        reject_pseudo_cid(legacy_value)
+    with pytest.raises(ValueError):
+        datasets_validate_cid(legacy_value, codecs=(CID_CODEC,))
+
+
+def _base32_cid_from_binary(raw: bytes) -> str:
+    return "b" + base64.b32encode(raw).decode("ascii").lower().rstrip("=")
+
+
+@pytest.mark.parametrize("declared_size, actual_digest_size", ((32, 31), (31, 32)))
+def test_malformed_multihash_lengths_are_rejected(
+    declared_size: int,
+    actual_digest_size: int,
+) -> None:
+    vector = KNOWN_VECTORS[0]
+    digest = bytes.fromhex(vector.digest_hex)[:actual_digest_size]
+    # CIDv1 | dag-json varint(0x0129) | sha2-256 | declared size | digest.
+    malformed = _base32_cid_from_binary(
+        b"\x01\xa9\x02\x12" + bytes((declared_size,)) + digest
+    )
+
+    with pytest.raises(CIDIdentityContradiction) as contradiction:
+        _require_frozen_claim(malformed, vector.canonical_bytes)
+    assert contradiction.value.kind is ContradictionKind.MALFORMED_MULTIHASH
+
+    with pytest.raises(ValueError):
+        CID.decode(malformed)
+    with pytest.raises(ValueError):
+        datasets_validate_cid(malformed, codecs=(CID_CODEC,))
+    with pytest.raises(ValueError):
+        ContentIdentity(
+            cid=malformed,
+            digest_hex=vector.digest_hex,
+            canonical_bytes=vector.canonical_bytes,
+        ).verify()
+
+
+@pytest.mark.parametrize(
+    "invalid_payload",
+    (
+        {"value": float("nan")},
+        {1: "non-string key"},
+        {"value": b"bytes must not be coerced"},
+    ),
+    ids=("non-finite", "non-string-key", "unsupported-type"),
+)
+def test_strict_dag_json_vectors_reject_coercion(invalid_payload: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        datasets_canonical_dag_json_bytes(invalid_payload)
+    with pytest.raises(TestExecutionIdentityError):
+        mint_content_identity(invalid_payload)

--- a/test/api/test_agent_supervisor_test_identity_components.py
+++ b/test/api/test_agent_supervisor_test_identity_components.py
@@ -1,0 +1,484 @@
+"""PTR-011 identity-component compilation and privacy tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from ipfs_accelerate_py.agent_supervisor.analysis.test_identity_components import (
+    TEST_IDENTITY_COMPONENTS_INTERFACE,
+    TestIdentityComponentError,
+    TestIdentityComponents,
+    UnsupportedPytestParameter,
+    canonicalize_pytest_parameter,
+    collect_dependency_identity,
+    collect_environment_identity,
+    collect_fixture_hook_identity,
+)
+
+
+def _runtime_facts() -> dict[str, dict[str, object]]:
+    return {
+        "interpreter_facts": {
+            "implementation": "cpython",
+            "version": [3, 12, 4, "final", 0],
+            "cache_tag": "cpython-312",
+            "abi_flags": "",
+            "byteorder": "little",
+            "pointer_bits": 64,
+        },
+        "platform_facts": {
+            "system": "linux",
+            "release": "6.8",
+            "machine": "x86_64",
+            "python_compiler": "GCC 13.2",
+            "libc": ["glibc", "2.39"],
+        },
+        "hardware_facts": {
+            "architecture": "x86_64",
+            "cpu_count": 8,
+            "accelerator_backend": "cuda",
+            "accelerator_count": 1,
+            "accelerator_architectures": ["sm_80"],
+        },
+    }
+
+
+def _compile(**changes: object) -> TestIdentityComponents:
+    values: dict[str, object] = {
+        "parameter_value": {"model": "tiny", "shards": (1, 2)},
+        "parameter_id": "tiny-two-shards",
+        "fixtures": [
+            {
+                "name": "model",
+                "scope": "session",
+                "definition": "def model(): return build_model()\n",
+                "value_adapter_cid": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3udm4nw2v4xkmms",
+                "dependencies": ["tmp_path_factory"],
+            }
+        ],
+        "conftests": [
+            {
+                "path": "test/conftest.py",
+                "content": "def pytest_configure(config): pass\n",
+            }
+        ],
+        "hooks": [
+            {
+                "name": "pytest_collection_modifyitems",
+                "implementation": "def pytest_collection_modifyitems(items): pass\n",
+                "distribution": "pytest",
+                "version": "8.3.2",
+                "order": 1,
+            }
+        ],
+        "plugins": [
+            {
+                "name": "proof-reuse",
+                "implementation": "def pytest_configure(config): pass\n",
+                "distribution": "ipfs-accelerate-py",
+                "version": "1.0.0",
+            }
+        ],
+        "lock_files": {"uv.lock": b"version = 1\n"},
+        "installed_distributions": {"pytest": "8.3.2", "pluggy": "1.5.0"},
+        "environment": {
+            "CI": "true",
+            "PYTHONHASHSEED": "7",
+            "SECRET_TOKEN": "must-not-enter-identity",
+        },
+        "environment_allowlist": ("CI", "PYTHONHASHSEED"),
+        "capability_facts": {
+            "cuda": {"available": True, "runtime": "12.4"}
+        },
+        "capability_allowlist": ("cuda",),
+        **_runtime_facts(),
+    }
+    values.update(changes)
+    return TestIdentityComponents.compile(**values)  # type: ignore[arg-type]
+
+
+def test_parameters_are_type_preserving_and_order_canonical() -> None:
+    first = canonicalize_pytest_parameter(
+        {"z": {3, 1, 2}, "a": [True, None, b"\x00"]}
+    )
+    second = canonicalize_pytest_parameter(
+        {"a": [True, None, b"\x00"], "z": {2, 3, 1}}
+    )
+
+    assert first == second
+    assert canonicalize_pytest_parameter([1, 2]) != canonicalize_pytest_parameter(
+        (1, 2)
+    )
+    assert canonicalize_pytest_parameter(True) != canonicalize_pytest_parameter(1)
+
+
+@pytest.mark.parametrize(
+    "value, reason",
+    [
+        (1.25, "unsupported_pytest_parameter_float"),
+        (object(), "unsupported_pytest_parameter_type"),
+        ({1: "not-a-string-key"}, "pytest_parameter_mapping_key_not_string"),
+    ],
+)
+def test_unsupported_parameters_are_rejected_without_repr(
+    value: object, reason: str
+) -> None:
+    with pytest.raises(UnsupportedPytestParameter, match=reason):
+        canonicalize_pytest_parameter(value)
+
+
+def test_parameter_subclasses_are_not_treated_as_reviewed_builtin_types() -> None:
+    class CustomString(str):
+        pass
+
+    with pytest.raises(
+        UnsupportedPytestParameter, match="unsupported_pytest_parameter_type"
+    ):
+        canonicalize_pytest_parameter(CustomString("looks-safe"))
+    with pytest.raises(
+        UnsupportedPytestParameter, match="pytest_parameter_mapping_key_not_string"
+    ):
+        canonicalize_pytest_parameter({CustomString("key"): "value"})
+
+
+def test_compile_marks_unsupported_parameter_explicitly_non_reusable() -> None:
+    compiled = _compile(parameter_value=object())
+
+    assert compiled.reusable is False
+    assert compiled.non_reusable_reasons == (
+        "unsupported_pytest_parameter_type",
+    )
+    assert "object at 0x" not in json.dumps(compiled.to_dict())
+
+
+def test_fixture_scope_definition_value_and_conftest_are_bound() -> None:
+    base = _compile()
+    scope = _compile(
+        fixtures=[
+            {
+                "name": "model",
+                "scope": "function",
+                "definition": "def model(): return build_model()\n",
+                "value_adapter_cid": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3udm4nw2v4xkmms",
+                "dependencies": ["tmp_path_factory"],
+            }
+        ]
+    )
+    definition = _compile(
+        fixtures=[
+            {
+                "name": "model",
+                "scope": "session",
+                "definition": "def model(): return build_other_model()\n",
+                "value_adapter_cid": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3udm4nw2v4xkmms",
+                "dependencies": ["tmp_path_factory"],
+            }
+        ]
+    )
+    conftest = _compile(
+        conftests=[
+            {
+                "path": "test/conftest.py",
+                "content": "def pytest_configure(config): config.changed = True\n",
+            }
+        ]
+    )
+
+    assert base.fixture_cids != scope.fixture_cids
+    assert base.fixture_cids != definition.fixture_cids
+    assert base.conftest_closure_cid != conftest.conftest_closure_cid
+
+
+def test_fixture_values_are_hashed_not_retained() -> None:
+    identity = collect_fixture_hook_identity(
+        fixtures=[
+            {
+                "name": "credential_fixture",
+                "scope": "function",
+                "definition": "def credential_fixture(): ...\n",
+                "value": "private-fixture-value",
+            }
+        ]
+    )
+
+    assert "private-fixture-value" not in repr(identity)
+    assert identity.fixture_cids[0].startswith("b")
+
+
+def test_uncontrolled_or_unsupported_fixture_values_disable_reuse() -> None:
+    uncontrolled = _compile(
+        fixtures=[
+            {
+                "name": "dynamic",
+                "scope": "function",
+                "definition": "def dynamic(): ...\n",
+            }
+        ]
+    )
+    unsupported = _compile(
+        fixtures=[
+            {
+                "name": "dynamic",
+                "scope": "function",
+                "definition": "def dynamic(): ...\n",
+                "value": object(),
+            }
+        ]
+    )
+
+    assert uncontrolled.non_reusable_reasons == ("uncontrolled_fixture_value",)
+    assert unsupported.non_reusable_reasons == ("unsupported_fixture_value",)
+    assert uncontrolled.reusable is unsupported.reusable is False
+
+
+def test_hooks_plugins_registration_order_and_versions_are_bound() -> None:
+    base = _compile()
+    changed_order = _compile(
+        hooks=[
+            {
+                "name": "pytest_collection_modifyitems",
+                "implementation": "def pytest_collection_modifyitems(items): pass\n",
+                "distribution": "pytest",
+                "version": "8.3.2",
+                "order": 2,
+            }
+        ]
+    )
+    changed_version = _compile(
+        plugins=[
+            {
+                "name": "proof-reuse",
+                "implementation": "def pytest_configure(config): pass\n",
+                "distribution": "ipfs-accelerate-py",
+                "version": "1.0.1",
+            }
+        ]
+    )
+
+    assert base.hook_plugin_cids != changed_order.hook_plugin_cids
+    assert base.hook_plugin_cids != changed_version.hook_plugin_cids
+
+
+def test_locks_and_distributions_are_normalized_and_bound() -> None:
+    first = collect_dependency_identity(
+        lock_files={"requirements.lock": "pytest==8.3.2\n"},
+        installed_distributions={"pytest": "8.3.2", "IPFS_Accelerate.Py": "1.0"},
+    )
+    same = collect_dependency_identity(
+        lock_files={"requirements.lock": b"pytest==8.3.2\n"},
+        installed_distributions=[("ipfs-accelerate-py", "1.0"), ("pytest", "8.3.2")],
+    )
+    changed_lock = collect_dependency_identity(
+        lock_files={"requirements.lock": "pytest==8.3.3\n"},
+        installed_distributions={"pytest": "8.3.2", "ipfs-accelerate-py": "1.0"},
+    )
+    changed_distribution = collect_dependency_identity(
+        lock_files={"requirements.lock": "pytest==8.3.2\n"},
+        installed_distributions={"pytest": "8.3.3", "ipfs-accelerate-py": "1.0"},
+    )
+
+    assert first == same
+    assert first.dependency_lock_cid != changed_lock.dependency_lock_cid
+    assert (
+        first.installed_distributions_cid
+        != changed_distribution.installed_distributions_cid
+    )
+
+
+def test_lock_paths_reject_absolute_traversal_and_non_lock_files() -> None:
+    with pytest.raises(TestIdentityComponentError, match="absolute path|traversal"):
+        collect_dependency_identity(lock_files={"/home/alice/uv.lock": b"x"})
+    with pytest.raises(TestIdentityComponentError, match="allowlisted"):
+        collect_dependency_identity(lock_files={"requirements.txt": b"x"})
+
+
+def test_environment_uses_fixed_allowlist_and_ignores_secrets() -> None:
+    facts = _runtime_facts()
+    with_secret_a = collect_environment_identity(
+        environment={"CI": "true", "API_TOKEN": "one"},
+        environment_allowlist=("CI",),
+        **facts,
+    )
+    with_secret_b = collect_environment_identity(
+        environment={"CI": "true", "API_TOKEN": "two"},
+        environment_allowlist=("CI",),
+        **facts,
+    )
+    changed_allowed = collect_environment_identity(
+        environment={"CI": "false", "API_TOKEN": "one"},
+        environment_allowlist=("CI",),
+        **facts,
+    )
+
+    assert with_secret_a == with_secret_b
+    assert with_secret_a.environment_cid != changed_allowed.environment_cid
+    assert "API_TOKEN" not in repr(with_secret_a)
+    assert "true" not in repr(with_secret_a)
+    with pytest.raises(TestIdentityComponentError, match="non-reviewed"):
+        collect_environment_identity(
+            environment={"API_TOKEN": "one"},
+            environment_allowlist=("API_TOKEN",),
+            **facts,
+        )
+
+
+def test_unset_allowlisted_environment_differs_from_set_empty() -> None:
+    facts = _runtime_facts()
+    unset = collect_environment_identity(
+        environment={},
+        environment_allowlist=("CI",),
+        **facts,
+    )
+    empty = collect_environment_identity(
+        environment={"CI": ""},
+        environment_allowlist=("CI",),
+        **facts,
+    )
+
+    assert unset.environment_cid != empty.environment_cid
+
+
+def test_empty_device_selection_is_valid_and_bound_as_set() -> None:
+    facts = _runtime_facts()
+    unset = collect_environment_identity(
+        environment={},
+        environment_allowlist=("CUDA_VISIBLE_DEVICES",),
+        **facts,
+    )
+    empty = collect_environment_identity(
+        environment={"CUDA_VISIBLE_DEVICES": ""},
+        environment_allowlist=("CUDA_VISIBLE_DEVICES",),
+        **facts,
+    )
+
+    assert unset.environment_cid != empty.environment_cid
+
+
+def test_duplicate_hook_or_plugin_identity_is_rejected() -> None:
+    hook = {
+        "name": "pytest_collection_modifyitems",
+        "implementation": "def pytest_collection_modifyitems(items): pass\n",
+        "distribution": "pytest",
+        "version": "8.3.2",
+    }
+
+    with pytest.raises(TestIdentityComponentError, match="duplicate hook/plugin"):
+        collect_fixture_hook_identity(hooks=[hook, hook])
+
+
+def test_interpreter_platform_hardware_and_capabilities_are_bound() -> None:
+    base = _compile()
+    python_changed = _compile(
+        interpreter_facts={
+            **_runtime_facts()["interpreter_facts"],
+            "cache_tag": "cpython-313",
+        }
+    )
+    platform_changed = _compile(
+        platform_facts={
+            **_runtime_facts()["platform_facts"],
+            "machine": "aarch64",
+        }
+    )
+    hardware_changed = _compile(
+        hardware_facts={
+            **_runtime_facts()["hardware_facts"],
+            "accelerator_architectures": ["sm_90"],
+        }
+    )
+    capability_changed = _compile(
+        capability_facts={"cuda": {"available": True, "runtime": "12.5"}}
+    )
+
+    assert base.interpreter_abi_cid != python_changed.interpreter_abi_cid
+    assert base.platform_cid != platform_changed.platform_cid
+    assert base.hardware_capability_cid != hardware_changed.hardware_capability_cid
+    assert (
+        base.hardware_capability_cid
+        != capability_changed.hardware_capability_cid
+    )
+
+
+def test_runtime_fact_allowlists_require_complete_reviewed_profiles() -> None:
+    facts = _runtime_facts()
+    incomplete_interpreter = {
+        key: value
+        for key, value in facts["interpreter_facts"].items()
+        if key != "cache_tag"
+    }
+
+    with pytest.raises(TestIdentityComponentError, match="missing a required"):
+        collect_environment_identity(
+            environment={},
+            environment_allowlist=(),
+            interpreter_facts=incomplete_interpreter,
+            platform_facts=facts["platform_facts"],
+            hardware_facts=facts["hardware_facts"],
+        )
+
+
+def test_capabilities_are_fail_closed_to_explicit_allowlist() -> None:
+    facts = _runtime_facts()
+    with pytest.raises(TestIdentityComponentError, match="non-allowlisted"):
+        collect_environment_identity(
+            environment={},
+            environment_allowlist=(),
+            capability_facts={"cuda": {"available": True}},
+            capability_allowlist=(),
+            **facts,
+        )
+
+    absent = collect_environment_identity(
+        environment={},
+        environment_allowlist=(),
+        capability_facts={},
+        capability_allowlist=("cuda",),
+        **facts,
+    )
+    present = collect_environment_identity(
+        environment={},
+        environment_allowlist=(),
+        capability_facts={"cuda": {"available": False}},
+        capability_allowlist=("cuda",),
+        **facts,
+    )
+    assert absent.hardware_capability_cid != present.hardware_capability_cid
+
+
+def test_component_bundle_is_stable_and_maps_to_execution_key_fields() -> None:
+    first = _compile()
+    second = _compile(
+        installed_distributions=[("pluggy", "1.5.0"), ("pytest", "8.3.2")]
+    )
+
+    assert first.to_dict()["interface"] == TEST_IDENTITY_COMPONENTS_INTERFACE
+    assert first.component_root_cid == second.component_root_cid
+    fields = first.execution_key_fields()
+    assert fields["parameter_source_cid"] == first.parameter_cid
+    assert fields["fixture_cids"] == first.fixture_cids
+    assert fields["environment_cid"] == first.environment_cid
+    assert fields["components"]["parameter"] == first.parameter_cid
+    assert fields["components"]["identity_components"] == first.component_root_cid
+
+
+def test_every_required_component_mutation_changes_bundle_root() -> None:
+    base = _compile()
+    mutations = [
+        _compile(parameter_value={"model": "other", "shards": (1, 2)}),
+        _compile(lock_files={"uv.lock": b"version = 2\n"}),
+        _compile(installed_distributions={"pytest": "8.3.3", "pluggy": "1.5.0"}),
+        _compile(environment={"CI": "false", "PYTHONHASHSEED": "7"}),
+        _compile(
+            hardware_facts={
+                **_runtime_facts()["hardware_facts"],
+                "cpu_count": 16,
+            }
+        ),
+        _compile(capability_facts={"cuda": {"available": False, "runtime": "12.4"}}),
+    ]
+
+    assert all(
+        changed.component_root_cid != base.component_root_cid
+        for changed in mutations
+    )

--- a/test/api/test_agent_supervisor_test_runtime_dependency_trace.py
+++ b/test/api/test_agent_supervisor_test_runtime_dependency_trace.py
@@ -1,0 +1,550 @@
+"""PTR-021 contract tests for bounded runtime dependency tracing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    ContentIdentity,
+    mint_content_identity,
+)
+from ipfs_accelerate_py.agent_supervisor.analysis.test_runtime_dependency_trace import (
+    RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE,
+    RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA,
+    RUNTIME_TRACE_INSTRUMENTATION_INTERFACE,
+    RUNTIME_TRACE_LIMITS_INTERFACE,
+    RuntimeTestDependencyTracer,
+    RuntimeTraceCompleteness,
+    RuntimeTraceError,
+    RuntimeTraceLimits,
+    trace_runtime_dependencies,
+)
+from multiformats import CID
+
+
+def _cid(label: str) -> str:
+    return mint_content_identity({"label": label}).cid
+
+
+def _tracer(tmp_path: Path, **kwargs: object) -> RuntimeTestDependencyTracer:
+    values: dict[str, object] = {
+        "allowed_roots": {"repo": tmp_path},
+        "capture_code_objects": False,
+    }
+    values.update(kwargs)
+    return RuntimeTestDependencyTracer(**values)  # type: ignore[arg-type]
+
+
+def _assert_profile_cid(trace_cid: str, canonical_bytes: bytes) -> None:
+    parsed = CID.decode(trace_cid)
+    assert parsed.version == 1
+    assert parsed.base.name == "base32"
+    assert parsed.codec.name == "dag-json"
+    assert parsed.hashfun.name == "sha2-256"
+    assert bytes(parsed.raw_digest) == hashlib.sha256(canonical_bytes).digest()
+
+
+def test_empty_trace_is_complete_canonical_and_content_addressed(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path)
+    with tracer:
+        pass
+    trace = tracer.result
+
+    assert trace is not None
+    assert trace.interface == RUNTIME_TEST_DEPENDENCY_TRACE_INTERFACE
+    assert trace.schema == RUNTIME_TEST_DEPENDENCY_TRACE_SCHEMA
+    assert trace.completeness is RuntimeTraceCompleteness.COMPLETE
+    assert trace.complete is True
+    assert trace.completeness_reasons == ()
+    assert trace.content_identity is not None
+    assert trace.verify() is trace
+    assert (
+        json.dumps(
+            trace.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+        == trace.canonical_bytes
+    )
+    _assert_profile_cid(trace.cid, trace.canonical_bytes)
+
+    payload = trace.to_dict()
+    assert payload["limits"]["interface"] == RUNTIME_TRACE_LIMITS_INTERFACE
+    assert payload["instrumentation"]["interface"] == RUNTIME_TRACE_INSTRUMENTATION_INTERFACE
+    assert payload["instrumentation_cid"].startswith("b")
+    assert payload["health"]["audit_hook_healthy"] is True
+
+
+@pytest.mark.parametrize(
+    ("changes", "match"),
+    [
+        ({"max_events": 0}, "max_events"),
+        ({"max_events": True}, "max_events"),
+        ({"max_file_bytes": 100_000_000}, "max_file_bytes"),
+        ({"max_trace_seconds": 0}, "max_trace_seconds"),
+        ({"max_text_chars": 8}, "max_text_chars"),
+    ],
+)
+def test_trace_limits_are_hard_validated(changes: dict[str, object], match: str) -> None:
+    with pytest.raises(RuntimeTraceError, match=match):
+        RuntimeTraceLimits(**changes)  # type: ignore[arg-type]
+
+
+def test_configuration_rejects_unreviewed_environment_and_fake_tool_identity(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RuntimeTraceError, match="non-reviewed"):
+        _tracer(tmp_path, environment_allowlist=("AWS_SECRET_ACCESS_KEY",))
+    with pytest.raises(RuntimeTraceError, match="canonical CID"):
+        _tracer(tmp_path, subprocess_allowlist={"python": "sha256:not-a-cid"})
+    with pytest.raises(RuntimeTraceError, match="canonical CID"):
+        _tracer(tmp_path, subprocess_allowlist={"python": "b" + "a" * 60})
+
+
+def test_dependency_order_does_not_change_canonical_trace(tmp_path: Path) -> None:
+    data = tmp_path / "data.json"
+    data.write_text('{"ok":true}', encoding="utf-8")
+
+    first = _tracer(tmp_path, environment_allowlist=("TZ",))
+    first.start()
+    assert first.record_environment_read("TZ", "UTC")
+    assert first.record_module("demo.module", source_path=data)
+    assert first.record_file_read(data)
+    trace_a = first.stop()
+
+    second = _tracer(tmp_path, environment_allowlist=("TZ",))
+    second.start()
+    assert second.record_file_read(data)
+    assert second.record_module("demo.module", source_path=data)
+    assert second.record_environment_read("TZ", "UTC")
+    trace_b = second.stop()
+
+    assert trace_a.complete and trace_b.complete
+    assert trace_a.cid == trace_b.cid
+    assert trace_a.canonical_bytes == trace_b.canonical_bytes
+    assert trace_a.recorded_fact_count == 3
+
+
+def test_file_fact_is_relative_and_binds_content(tmp_path: Path) -> None:
+    nested = tmp_path / "fixtures"
+    nested.mkdir()
+    data = nested / "payload.bin"
+    data.write_bytes(b"dependency bytes")
+
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert tracer.record_file_read(data)
+    trace = tracer.stop()
+
+    fact = trace.to_dict()["dependencies"]["files"][0]
+    assert fact == {
+        "root_id": "repo",
+        "path": "fixtures/payload.bin",
+        "size_bytes": len(b"dependency bytes"),
+        "content_sha256": hashlib.sha256(b"dependency bytes").hexdigest(),
+    }
+    assert str(tmp_path) not in trace.canonical_bytes.decode()
+    assert trace.complete
+
+
+def test_private_path_marks_incomplete_without_leaking_path_or_body(
+    tmp_path: Path,
+) -> None:
+    private_dir = tmp_path.parent / "private-runtime-trace"
+    private_dir.mkdir(exist_ok=True)
+    private_file = private_dir / "credential-token.txt"
+    private_file.write_text("super-secret-body", encoding="utf-8")
+
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert tracer.record_file_read(private_file) is False
+    trace = tracer.stop()
+
+    encoded = trace.canonical_bytes.decode()
+    assert not trace.complete
+    assert "private_event" in trace.completeness_reasons
+    assert "credential-token" not in encoded
+    assert "super-secret-body" not in encoded
+    assert str(private_file) not in encoded
+    assert trace.to_dict()["health"]["private_event_kinds"] == ["file_path"]
+
+
+def test_symlink_is_private_and_never_retained(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("public content", encoding="utf-8")
+    link = tmp_path / "linked-secret-name.txt"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert tracer.record_file_read(link) is False
+    trace = tracer.stop()
+    assert not trace.complete
+    assert "linked-secret-name" not in trace.canonical_bytes.decode()
+    assert "symlink" in trace.to_dict()["health"]["private_event_kinds"]
+
+
+def test_file_size_and_event_overflow_are_explicit(tmp_path: Path) -> None:
+    data = tmp_path / "large.bin"
+    data.write_bytes(b"0123456789")
+    limits = RuntimeTraceLimits(max_file_bytes=4, max_events=2)
+    tracer = _tracer(tmp_path, limits=limits)
+    tracer.start()
+    assert tracer.record_file_read(data) is False
+    assert tracer.record_module("one")
+    assert tracer.record_module("two")
+    assert tracer.record_module("three") is False
+    trace = tracer.stop()
+
+    assert trace.completeness is RuntimeTraceCompleteness.INCOMPLETE
+    assert "overflow" in trace.completeness_reasons
+    assert trace.dropped_event_count == 1
+    assert len(trace.to_dict()["dependencies"]["modules"]) == 2
+    assert trace.to_dict()["dependencies"]["files"] == []
+
+
+def test_allowlisted_environment_is_value_cid_only(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path, environment_allowlist=("TZ",))
+    tracer.start()
+    assert tracer.record_environment_read("TZ", "Never/Retain/This/Raw")
+    trace = tracer.stop()
+
+    encoded = trace.canonical_bytes.decode()
+    fact = trace.to_dict()["dependencies"]["environment"][0]
+    assert fact["name"] == "TZ"
+    assert fact["value_cid"].startswith("b")
+    assert "Never/Retain/This/Raw" not in encoded
+    assert trace.complete
+
+
+def test_internal_identity_minting_is_not_observed_as_test_activity(
+    tmp_path: Path,
+) -> None:
+    private_probe = str(tmp_path.parent / "private-cid-provider-input")
+
+    def auditing_identity_minter(value: object) -> ContentIdentity:
+        sys.audit("open", private_probe, "r", 0)
+        sys.audit("provider.private-operation")
+        return mint_content_identity(value)
+
+    tracer = _tracer(
+        tmp_path,
+        environment_allowlist=("TZ",),
+        identity_minter=auditing_identity_minter,
+    )
+    tracer.start()
+    assert tracer.record_environment_read("TZ", "UTC")
+    trace = tracer.stop()
+
+    assert trace.complete
+    assert trace.to_dict()["health"]["private_event_kinds"] == []
+    assert trace.to_dict()["health"]["unsupported_event_kinds"] == []
+    assert private_probe not in trace.canonical_bytes.decode()
+
+
+def test_private_environment_event_is_incomplete_and_secret_free(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path, environment_allowlist=("TZ",))
+    tracer.start()
+    assert tracer.record_environment_read("AWS_SECRET_ACCESS_KEY", "do-not-retain") is False
+    trace = tracer.stop()
+
+    encoded = trace.canonical_bytes.decode()
+    assert not trace.complete
+    assert "private_event" in trace.completeness_reasons
+    assert "AWS_SECRET_ACCESS_KEY" not in encoded
+    assert "do-not-retain" not in encoded
+
+
+def test_getenv_adapter_preserves_value_and_records_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TZ", "UTC")
+    tracer = _tracer(tmp_path, environment_allowlist=("TZ",))
+    tracer.start()
+    assert tracer.getenv("TZ") == "UTC"
+    trace = tracer.stop()
+    assert trace.complete
+    assert trace.to_dict()["dependencies"]["environment"][0]["name"] == "TZ"
+    assert '"value":"UTC"' not in trace.canonical_bytes.decode()
+
+
+def test_subprocess_arguments_are_digest_only_and_tool_identity_is_bound(
+    tmp_path: Path,
+) -> None:
+    tool_cid = _cid("python-tool")
+    tracer = _tracer(tmp_path, subprocess_allowlist={"python3": tool_cid})
+    tracer.start()
+    assert tracer.record_subprocess("/usr/bin/python3", ["python3", "--token", "do-not-retain"])
+    trace = tracer.stop()
+
+    fact = trace.to_dict()["dependencies"]["subprocesses"][0]
+    assert fact["executable"] == "python3"
+    assert fact["argument_count"] == 3
+    assert fact["tool_identity"] == tool_cid
+    assert len(fact["arguments_sha256"]) == 64
+    encoded = trace.canonical_bytes.decode()
+    assert "do-not-retain" not in encoded
+    assert "--token" not in encoded
+    assert "/usr/bin" not in encoded
+    assert trace.complete
+
+
+def test_unadmitted_subprocess_and_unsupported_audit_event_are_incomplete(
+    tmp_path: Path,
+) -> None:
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert tracer.record_subprocess("curl", ["curl", "https://private.invalid"]) is True
+    tracer.observe_audit_event("vendor.private", ("secret-audit-body",))
+    trace = tracer.stop()
+
+    encoded = trace.canonical_bytes.decode()
+    assert not trace.complete
+    assert "unsupported_event" in trace.completeness_reasons
+    assert "https://private.invalid" not in encoded
+    assert "secret-audit-body" not in encoded
+    assert trace.to_dict()["health"]["unsupported_event_kinds"] == [
+        "subprocess_tool",
+        "unknown_audit_event",
+    ]
+
+
+def test_process_audit_hook_marks_custom_events_without_raising(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    sys.audit("vendor.unsupported-dependency", "private audit detail")
+    trace = tracer.stop()
+    assert not trace.complete
+    assert "private audit detail" not in trace.canonical_bytes.decode()
+    assert "unknown_audit_event" in trace.to_dict()["health"]["unsupported_event_kinds"]
+
+
+def test_silently_suppressed_audit_hook_is_never_reported_healthy() -> None:
+    script = textwrap.dedent(
+        """
+        import sys
+
+        def suppress_new_hook(event, _arguments):
+            if event == "sys.addaudithook":
+                raise RuntimeError("silently suppress hook registration")
+
+        sys.addaudithook(suppress_new_hook)
+        sys.path.insert(0, sys.argv[1])
+
+        from ipfs_accelerate_py.agent_supervisor.analysis.test_runtime_dependency_trace import (
+            RuntimeTestDependencyTracer,
+        )
+
+        tracer = RuntimeTestDependencyTracer(capture_code_objects=False)
+        with tracer:
+            pass
+        trace = tracer.result
+        assert trace is not None
+        payload = trace.to_dict()
+        assert payload["health"]["audit_hook_healthy"] is False
+        assert "instrumentation_failure" in trace.completeness_reasons
+        assert not trace.complete
+        """
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-P",
+            "-c",
+            script,
+            str(Path(__file__).parents[2]),
+        ],
+        cwd=Path(__file__).parents[2],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_service_policy_and_capability_adapters_bind_cids(tmp_path: Path) -> None:
+    adapter = _cid("adapter")
+    snapshot = _cid("snapshot")
+    clock = _cid("clock-policy")
+    random = _cid("random-policy")
+    state = _cid("cuda-state")
+    tracer = _tracer(tmp_path, eligibility_profile="snapshot_bound")
+    tracer.start()
+    assert tracer.record_service("postgres", adapter_identity=adapter, snapshot_identity=snapshot)
+    assert tracer.record_clock_policy(clock)
+    assert tracer.record_randomness_policy(random)
+    assert tracer.record_capability("cuda", adapter_identity=adapter, state_identity=state)
+    trace = tracer.stop()
+
+    assert trace.complete
+    payload = trace.to_dict()
+    assert payload["eligibility_profile"] == "snapshot_bound"
+    assert payload["dependencies"]["services"][0]["snapshot_identity"] == snapshot
+    assert {item["kind"] for item in payload["dependencies"]["policies"]} == {
+        "clock",
+        "randomness",
+    }
+    assert payload["dependencies"]["capabilities"][0]["state_identity"] == state
+
+
+def test_invalid_adapter_identity_is_unsupported_not_an_exception(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert (
+        tracer.record_service("database", adapter_identity="cid:fake", snapshot_identity="secret")
+        is False
+    )
+    assert tracer.record_clock_policy("sha256:fake") is False
+    assert tracer.record_capability("gpu", adapter_identity="bad", state_identity="worse") is False
+    trace = tracer.stop()
+    assert not trace.complete
+    assert "unsupported_event" in trace.completeness_reasons
+    assert "cid:fake" not in trace.canonical_bytes.decode()
+    assert "sha256:fake" not in trace.canonical_bytes.decode()
+
+
+def test_explicit_code_object_uses_relative_path_and_normalized_digest() -> None:
+    test_file = Path(__file__).resolve()
+    root = test_file.parents[2]
+    tracer = RuntimeTestDependencyTracer(
+        allowed_roots={"accelerate": root}, capture_code_objects=False
+    )
+    tracer.start()
+    assert tracer.record_code_object(
+        test_explicit_code_object_uses_relative_path_and_normalized_digest.__code__,
+        __name__,
+    )
+    trace = tracer.stop()
+
+    fact = trace.to_dict()["dependencies"]["code_objects"][0]
+    assert not fact["path"].startswith("/")
+    assert fact["path"].endswith("test/api/test_agent_supervisor_test_runtime_dependency_trace.py")
+    assert len(fact["code_sha256"]) == 64
+    assert str(root) not in trace.canonical_bytes.decode()
+    assert trace.complete
+
+
+def test_native_module_is_retained_as_unknown_frontier(tmp_path: Path) -> None:
+    module = tmp_path / "extension.so"
+    module.write_bytes(b"native-placeholder")
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    assert tracer.record_module("demo.native", source_path=module, native=True)
+    trace = tracer.stop()
+    assert not trace.complete
+    assert trace.to_dict()["dependencies"]["modules"][0]["kind"] == "native"
+    assert "native_module" in trace.to_dict()["health"]["unsupported_event_kinds"]
+
+
+def test_audited_open_records_read_and_write_is_unsupported(tmp_path: Path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("observed", encoding="utf-8")
+    output = tmp_path / "output.txt"
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    with source.open("rb") as stream:
+        assert stream.read() == b"observed"
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("effect")
+    trace = tracer.stop()
+
+    paths = {fact["path"] for fact in trace.to_dict()["dependencies"]["files"]}
+    assert "source.txt" in paths
+    assert "output.txt" not in paths
+    assert not trace.complete
+    assert "file_write" in trace.to_dict()["health"]["unsupported_event_kinds"]
+
+
+def test_recording_failure_never_changes_test_exception(tmp_path: Path) -> None:
+    class TestSentinel(RuntimeError):
+        __test__ = False
+
+    tracer = _tracer(tmp_path)
+    sentinel = TestSentinel("test outcome")
+    with pytest.raises(TestSentinel) as caught:
+        with tracer:
+            tracer.observe_audit_event("unsupported", (object(),))
+            raise sentinel
+    assert caught.value is sentinel
+    assert tracer.result is not None
+    assert not tracer.result.complete
+
+
+def test_identity_provider_failure_is_incomplete_and_does_not_escape(
+    tmp_path: Path,
+) -> None:
+    def fail_identity(_value: object) -> ContentIdentity:
+        raise RuntimeError("provider failure with private detail")
+
+    tracer = _tracer(tmp_path, identity_minter=fail_identity)
+    with tracer:
+        observed_test_value = 42
+    trace = tracer.result
+    assert observed_test_value == 42
+    assert trace is not None
+    assert not trace.complete
+    assert trace.cid == ""
+    assert "instrumentation_failure" in trace.completeness_reasons
+    assert "private detail" not in trace.canonical_bytes.decode()
+
+
+def test_identity_provider_cannot_substitute_different_canonical_bytes(
+    tmp_path: Path,
+) -> None:
+    def wrong_value_identity(_value: object) -> ContentIdentity:
+        return mint_content_identity(
+            {"schema": "unrelated/provider-output@1", "secret": "do-not-retain"}
+        )
+
+    tracer = _tracer(tmp_path, identity_minter=wrong_value_identity)
+    with tracer:
+        observed_test_value = 42
+    trace = tracer.result
+
+    assert observed_test_value == 42
+    assert trace is not None
+    assert not trace.complete
+    assert trace.cid == ""
+    assert "instrumentation_failure" in trace.completeness_reasons
+    assert "do-not-retain" not in trace.canonical_bytes.decode()
+
+
+def test_stop_is_idempotent(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path)
+    tracer.start()
+    first = tracer.stop()
+    second = tracer.stop()
+    assert second is first
+
+
+def test_trace_runtime_dependencies_returns_value_and_trace(tmp_path: Path) -> None:
+    tracer = _tracer(tmp_path)
+    value, trace = trace_runtime_dependencies(lambda left, right: left + right, 2, 3, tracer=tracer)
+    assert value == 5
+    assert trace is tracer.result
+    assert trace.complete
+
+
+def test_trace_runtime_dependencies_preserves_operation_exception(tmp_path: Path) -> None:
+    class OperationError(Exception):
+        pass
+
+    error = OperationError("original")
+    tracer = _tracer(tmp_path)
+
+    def fail() -> None:
+        raise error
+
+    with pytest.raises(OperationError) as caught:
+        trace_runtime_dependencies(fail, tracer=tracer)
+    assert caught.value is error
+    assert tracer.result is not None

--- a/test/api/test_agent_supervisor_test_static_dependency_trace.py
+++ b/test/api/test_agent_supervisor_test_static_dependency_trace.py
@@ -1,0 +1,398 @@
+"""PTR-020 contract tests for deterministic static dependency tracing."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.machinery
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+import pytest
+from ipfs_accelerate_py.agent_supervisor.analysis.analysis_ast_index import (
+    AnalysisASTIndex,
+    build_analysis_ast_index,
+)
+from ipfs_accelerate_py.agent_supervisor.analysis.test_execution_identity import (
+    mint_content_identity,
+)
+from ipfs_accelerate_py.agent_supervisor.analysis.test_static_dependency_trace import (
+    STATIC_TEST_DEPENDENCY_TRACE_INTERFACE,
+    STATIC_TEST_DEPENDENCY_TRACE_SCHEMA,
+    STATIC_TRACE_ANALYZER_INTERFACE,
+    STATIC_TRACE_LIMITS_INTERFACE,
+    StaticTestDependencyTracer,
+    StaticTraceError,
+    StaticTraceLimits,
+    trace_static_dependencies,
+)
+from ipfs_accelerate_py.agent_supervisor.core.conflict_graph import (
+    build_python_ast_blob_record,
+)
+from multiformats import CID
+
+
+def _index(
+    root: Path,
+    sources: Mapping[str, str],
+    *,
+    order: Iterable[str] | None = None,
+) -> AnalysisASTIndex:
+    records = []
+    for relative in order if order is not None else sources:
+        source = sources[relative]
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+        records.append(
+            (
+                relative,
+                build_python_ast_blob_record(
+                    source,
+                    blob_identity=f"blob:{relative}:{hashlib.sha256(source.encode()).hexdigest()}",
+                ),
+            )
+        )
+    return build_analysis_ast_index(records)
+
+
+def _frontier_kinds(trace: object) -> set[str]:
+    return {item.kind for item in trace.unknown_frontier}  # type: ignore[attr-defined]
+
+
+def _assert_profile_cid(trace_cid: str, canonical_bytes: bytes) -> None:
+    parsed = CID.decode(trace_cid)
+    assert parsed.version == 1
+    assert parsed.base.name == "base32"
+    assert parsed.codec.name == "dag-json"
+    assert parsed.hashfun.name == "sha2-256"
+    assert bytes(parsed.raw_digest) == hashlib.sha256(canonical_bytes).digest()
+
+
+def test_trace_is_deterministic_canonical_content_addressed_and_body_free(
+    tmp_path: Path,
+) -> None:
+    sources = {
+        "tests/test_demo.py": """from app.util import helper
+
+def test_demo(answer):
+    assert helper() == answer
+""",
+        "tests/conftest.py": """@pytest.fixture
+def answer():
+    return 42
+""",
+        "app/util.py": """def helper():
+    ignored_body_literal = \"BODY-MUST-NOT-BE-PERSISTED\"
+    return 42
+""",
+    }
+    forward = _index(tmp_path, sources)
+    reverse = _index(tmp_path, sources, order=reversed(tuple(sources)))
+
+    first = trace_static_dependencies(
+        forward,
+        "tests/test_demo.py",
+        repository_root=tmp_path,
+        test_symbol="test_demo",
+    )
+    second = StaticTestDependencyTracer(reverse, tmp_path).trace(
+        "tests/test_demo.py", node_id="tests/test_demo.py::test_demo[param-value]"
+    )
+
+    assert first.cid == second.cid
+    assert first.canonical_bytes == second.canonical_bytes
+    assert first.complete and first.completeness == "complete"
+    assert first.interface == STATIC_TEST_DEPENDENCY_TRACE_INTERFACE
+    assert first.schema == STATIC_TEST_DEPENDENCY_TRACE_SCHEMA
+    assert first.verify() is first
+    assert (
+        json.dumps(
+            first.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+        == first.canonical_bytes
+    )
+    _assert_profile_cid(first.cid, first.canonical_bytes)
+
+    payload = first.to_dict()
+    assert payload["limits"]["interface"] == STATIC_TRACE_LIMITS_INTERFACE
+    assert payload["analyzer"]["interface"] == STATIC_TRACE_ANALYZER_INTERFACE
+    assert payload["analyzer_cid"].startswith("b")
+    assert {edge["kind"] for edge in payload["dependencies"]["edges"]} == {
+        "decorator",
+        "fixture",
+        "import",
+    }
+    assert all("source" not in row for row in payload["dependencies"]["nodes"])
+    serialized = first.canonical_bytes.decode()
+    assert "BODY-MUST-NOT-BE-PERSISTED" not in serialized
+    assert str(tmp_path) not in serialized
+
+
+@pytest.mark.parametrize(
+    ("changes", "match"),
+    [
+        ({"max_files": 0}, "max_files"),
+        ({"max_edges": True}, "max_edges"),
+        ({"max_source_bytes": 100_000_000}, "max_source_bytes"),
+        ({"max_text_chars": 8}, "max_text_chars"),
+    ],
+)
+def test_trace_limits_are_hard_validated(changes: dict[str, object], match: str) -> None:
+    with pytest.raises(StaticTraceError, match=match):
+        StaticTraceLimits(**changes)  # type: ignore[arg-type]
+
+
+def test_fixtures_hooks_plugins_configuration_and_data_are_closed(
+    tmp_path: Path,
+) -> None:
+    sources = {
+        "tests/test_integration.py": """def test_integration(dependent):
+    with open(\"payload.txt\") as stream:
+        assert stream.read() == dependent
+""",
+        "tests/conftest.py": """pytest_plugins = (\"plugins.local\",)
+
+@pytest.fixture
+def base():
+    return \"payload\"
+
+@pytest.fixture
+def dependent(base):
+    return base
+
+def pytest_collection_modifyitems(items):
+    pass
+""",
+        "plugins/local.py": 'PLUGIN_NAME = "local"\n',
+    }
+    index = _index(tmp_path, sources)
+    (tmp_path / "tests/payload.txt").write_text("payload", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\naddopts = '-q'\n", encoding="utf-8"
+    )
+
+    trace = trace_static_dependencies(
+        index,
+        "tests/test_integration.py",
+        repository_root=tmp_path,
+        test_symbol="test_integration",
+    )
+
+    assert trace.complete
+    payload = trace.to_dict()
+    edges = payload["dependencies"]["edges"]
+    assert {edge["kind"] for edge in edges} == {
+        "config",
+        "data",
+        "decorator",
+        "fixture",
+        "hook",
+        "plugin",
+    }
+    nodes = payload["dependencies"]["nodes"]
+    assert {node["path"] for node in nodes} == {
+        "plugins/local.py",
+        "pyproject.toml",
+        "tests/conftest.py",
+        "tests/payload.txt",
+        "tests/test_integration.py",
+    }
+    assert {node["kind"] for node in nodes} == {"data", "source"}
+    assert payload["health"]["source_hashes_verified"] is True
+
+
+def test_dynamic_import_reflection_opaque_decorator_and_missing_import_are_unknown(
+    tmp_path: Path,
+) -> None:
+    index = _index(
+        tmp_path,
+        {
+            "test_unknown.py": """import absent_package
+from importlib import import_module as load
+
+@custom_decorator
+def test_unknown(module_name):
+    imported = load(module_name)
+    return getattr(imported, module_name)
+"""
+        },
+    )
+
+    trace = trace_static_dependencies(
+        index,
+        "test_unknown.py",
+        repository_root=tmp_path,
+        test_symbol="test_unknown",
+    )
+
+    assert not trace.complete
+    assert {
+        "dynamic_import",
+        "reflection",
+        "opaque_decorator",
+        "missing_file",
+        "unresolved_fixture",
+    }.issubset(_frontier_kinds(trace))
+    assert all(
+        item.frontier_id.startswith("static-frontier:sha256:") for item in trace.unknown_frontier
+    )
+
+
+def test_native_extension_import_is_an_explicit_unknown_frontier(tmp_path: Path) -> None:
+    suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    (tmp_path / f"native_dependency{suffix}").write_bytes(b"not executed")
+    index = _index(
+        tmp_path, {"test_native.py": "import native_dependency\n\ndef test_native(): pass\n"}
+    )
+
+    trace = trace_static_dependencies(
+        index, "test_native.py", repository_root=tmp_path, test_symbol="test_native"
+    )
+
+    assert "native_code" in _frontier_kinds(trace)
+    native = next(item for item in trace.unknown_frontier if item.kind == "native_code")
+    assert native.target == "native_dependency"
+
+
+def test_path_reads_close_over_data_and_path_writes_are_uncontrolled(
+    tmp_path: Path,
+) -> None:
+    index = _index(
+        tmp_path,
+        {
+            "test_paths.py": """from pathlib import Path
+
+
+def test_paths():
+    assert Path("payload.txt").read_text() == "payload"
+    Path("output.txt").open("w")
+""",
+        },
+    )
+    (tmp_path / "payload.txt").write_text("payload", encoding="utf-8")
+
+    trace = trace_static_dependencies(
+        index, "test_paths.py", repository_root=tmp_path, test_symbol="test_paths"
+    )
+
+    dependencies = trace.to_dict()["dependencies"]
+    nodes = dependencies["nodes"]
+    assert any(node["kind"] == "data" and node["path"] == "payload.txt" for node in nodes)
+    assert not any(node["path"] == "output.txt" for node in nodes)
+    assert any(
+        edge["kind"] == "effect" and edge["target_symbol"] == "filesystem_write"
+        for edge in dependencies["edges"]
+    )
+    assert any(
+        item.kind == "uncontrolled_effect" and item.target == "filesystem_write"
+        for item in trace.unknown_frontier
+    )
+
+
+def test_analysis_file_and_frontier_bounds_are_explicit_and_deterministic(
+    tmp_path: Path,
+) -> None:
+    sources = {
+        "test_bound.py": """import one
+import two
+import three
+
+def test_bound(): pass
+""",
+        "one.py": "ONE = 1\n",
+        "two.py": "TWO = 2\n",
+        "three.py": "THREE = 3\n",
+    }
+    index = _index(tmp_path, sources)
+    limits = StaticTraceLimits(max_files=1, max_frontier=1)
+
+    first = trace_static_dependencies(
+        index,
+        "test_bound.py",
+        repository_root=tmp_path,
+        test_symbol="test_bound",
+        limits=limits,
+    )
+    second = trace_static_dependencies(
+        index,
+        "test_bound.py",
+        repository_root=tmp_path,
+        test_symbol="test_bound",
+        limits=limits,
+    )
+
+    assert first.cid == second.cid
+    assert len(first.unknown_frontier) == 1
+    assert first.unknown_frontier[0].kind == "analysis_bound"
+    assert first.unknown_frontier[0].target == "frontier"
+    assert first.to_dict()["health"]["analysis_bounds_reached"] == [
+        "files",
+        "frontier",
+    ]
+
+
+def test_stale_ast_index_fails_closed_without_parsing_new_source(tmp_path: Path) -> None:
+    index = _index(tmp_path, {"test_stale.py": "def test_stale(): return 1\n"})
+    (tmp_path / "test_stale.py").write_text(
+        "def test_stale(): return 'changed body'\n", encoding="utf-8"
+    )
+
+    trace = trace_static_dependencies(
+        index, "test_stale.py", repository_root=tmp_path, test_symbol="test_stale"
+    )
+
+    assert _frontier_kinds(trace) == {"stale_ast_index"}
+    assert trace.analyzed_file_count == 0
+    assert trace.to_dict()["health"]["source_hashes_verified"] is False
+    assert "changed body" not in trace.canonical_bytes.decode()
+
+
+def test_missing_and_unparseable_root_files_have_typed_frontiers(tmp_path: Path) -> None:
+    missing_index = build_analysis_ast_index([])
+    missing = trace_static_dependencies(missing_index, "test_missing.py", repository_root=tmp_path)
+    assert _frontier_kinds(missing) == {"missing_file"}
+
+    broken_source = "def test_broken(:\n"
+    broken_index = _index(tmp_path, {"test_broken.py": broken_source})
+    broken = trace_static_dependencies(broken_index, "test_broken.py", repository_root=tmp_path)
+    assert _frontier_kinds(broken) == {"parse_error"}
+    assert broken.to_dict()["health"]["parser_healthy"] is False
+
+
+def test_relative_import_resolution_and_import_cycles_terminate(tmp_path: Path) -> None:
+    sources = {
+        "pkg/test_relative.py": "from .helper import value\n\ndef test_relative(): assert value == 1\n",
+        "pkg/helper.py": "from .other import other\nvalue = other\n",
+        "pkg/other.py": "from .helper import value\nother = 1\n",
+    }
+    index = _index(tmp_path, sources)
+
+    trace = trace_static_dependencies(
+        index,
+        "pkg/test_relative.py",
+        repository_root=tmp_path,
+        test_symbol="test_relative",
+    )
+
+    assert trace.complete
+    assert trace.analyzed_file_count == 3
+    assert {
+        edge["target_path"]
+        for edge in trace.to_dict()["dependencies"]["edges"]
+        if edge["kind"] == "import"
+    } == {"pkg/helper.py", "pkg/other.py"}
+
+
+def test_identity_provider_cannot_substitute_noncanonical_trace_bytes(
+    tmp_path: Path,
+) -> None:
+    index = _index(tmp_path, {"test_identity.py": "def test_identity(): pass\n"})
+
+    with pytest.raises(StaticTraceError, match="analyzer identity bytes"):
+        trace_static_dependencies(
+            index,
+            "test_identity.py",
+            repository_root=tmp_path,
+            identity_minter=lambda _value: mint_content_identity({"substituted": True}),
+        )


### PR DESCRIPTION
## Summary
Follow-up to #120: replace scaffolding with the **full** PTR identity modules and their dedicated unit/vector suites recovered from the proof-reuse worktree.

| Module | Lines (approx) |
|--------|----------------|
| `test_execution_identity.py` | ~1400 |
| `test_identity_components.py` | ~1300 |
| `test_static_dependency_trace.py` | ~1400 |
| `test_runtime_dependency_trace.py` | ~1250 |
| `test_candidate_context_store.py` | ~2300 |

Also lands dedicated suites:
- `test_agent_supervisor_test_execution_identity{,_vectors}.py`
- `test_agent_supervisor_test_identity_components.py`
- `test_agent_supervisor_test_static_dependency_trace.py`
- `test_agent_supervisor_test_runtime_dependency_trace.py`
- `test_agent_supervisor_test_candidate_context_store.py`

## Test plan
- [x] Combined identity/activation suites: **135 passed**, 1 pre-existing cold-import pollution
- [x] Dedicated vector/unit modules included

## Notes
Does not claim warm-skip authority without reviewed certificate artifacts.