### PR TITLE
docs: close documentation-refresh program (DOC-001–028)

### DIFF
--- a/docs/architecture/DOCUMENTATION_REFRESH_PLAN_2026_08.md
+++ b/docs/architecture/DOCUMENTATION_REFRESH_PLAN_2026_08.md
@@ -2,7 +2,7 @@
 
 **Status:** completed (sealed 28-task tranche closed)
 **Baseline:** `d7da3d6bf8ca2f7ec870d03742b09f26e3e16d15` (2026-08-03)
-**Closeout tip revalidated:** `3d20671f5ce1806afe74b7d79f4ab459b5c2a61b` (2026-08-05)
+**Closeout tip revalidated:** `6c564578af0b0361741483e80ebcaf405efa1064` (2026-08-05)
 **Program:** `ipfs-accelerate-documentation-refresh-v1`
 **Task prefix:** `DOC-`
 **Objective heap:** [documentation_refresh.objectives.md](documentation_refresh.objectives.md)

--- a/docs/architecture/DOCUMENTATION_REFRESH_PLAN_2026_08.md
+++ b/docs/architecture/DOCUMENTATION_REFRESH_PLAN_2026_08.md
@@ -1,11 +1,14 @@
 # IPFS Accelerate documentation refresh and architecture guide plan
 
-**Status:** active execution plan
+**Status:** completed (sealed 28-task tranche closed)
 **Baseline:** `d7da3d6bf8ca2f7ec870d03742b09f26e3e16d15` (2026-08-03)
+**Closeout tip revalidated:** `3d20671f5ce1806afe74b7d79f4ab459b5c2a61b` (2026-08-05)
 **Program:** `ipfs-accelerate-documentation-refresh-v1`
 **Task prefix:** `DOC-`
 **Objective heap:** [documentation_refresh.objectives.md](documentation_refresh.objectives.md)
 **Executable board:** [documentation_refresh.todo.md](documentation_refresh.todo.md)
+**Authoritative board status:** all `DOC-001`–`DOC-028` tasks marked completed
+**Integrated receipt:** [DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md](../development/DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md)
 
 ## Outcome
 

--- a/docs/architecture/documentation_refresh.objectives.md
+++ b/docs/architecture/documentation_refresh.objectives.md
@@ -38,7 +38,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G000 Accurate, rationale-rich documentation
 
-- Status: active
+- Status: completed
 - Parent:
 - Parent goal IDs JSON: []
 - Depends on:
@@ -67,7 +67,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G010 Evidence baseline and documentation governance
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on:
@@ -93,7 +93,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G011 Reproducible drift inventory
 
-- Status: active
+- Status: completed
 - Parent: DOC-G010
 - Parent goal IDs JSON: ["DOC-G010"]
 - Depends on:
@@ -119,7 +119,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G012 Lifecycle, status and source-of-truth policy
 
-- Status: active
+- Status: completed
 - Parent: DOC-G010
 - Parent goal IDs JSON: ["DOC-G010"]
 - Depends on:
@@ -145,7 +145,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G013 Architecture-writing and decision-record conventions
 
-- Status: active
+- Status: completed
 - Parent: DOC-G010
 - Parent goal IDs JSON: ["DOC-G010"]
 - Depends on:
@@ -171,7 +171,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G020 Maintained product architecture guides
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on: DOC-G010
@@ -197,7 +197,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G021 System context and inference runtime
 
-- Status: active
+- Status: completed
 - Parent: DOC-G020
 - Parent goal IDs JSON: ["DOC-G020"]
 - Depends on: DOC-G011, DOC-G013
@@ -223,7 +223,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G022 Model/service and MCP control surfaces
 
-- Status: active
+- Status: completed
 - Parent: DOC-G020
 - Parent goal IDs JSON: ["DOC-G020"]
 - Depends on: DOC-G011, DOC-G013
@@ -249,7 +249,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G023 IPFS/P2P and cross-repository boundaries
 
-- Status: active
+- Status: completed
 - Parent: DOC-G020
 - Parent goal IDs JSON: ["DOC-G020"]
 - Depends on: DOC-G011, DOC-G013
@@ -275,7 +275,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G030 Agent-supervisor architecture guides
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on: DOC-G010
@@ -301,7 +301,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G031 Intent, control and authority
 
-- Status: active
+- Status: completed
 - Parent: DOC-G030
 - Parent goal IDs JSON: ["DOC-G030"]
 - Depends on: DOC-G011, DOC-G013
@@ -327,7 +327,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G032 Planning, context, analysis and proof
 
-- Status: active
+- Status: completed
 - Parent: DOC-G030
 - Parent goal IDs JSON: ["DOC-G030"]
 - Depends on: DOC-G011, DOC-G013
@@ -353,7 +353,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G033 Scheduling, execution, merge and recovery
 
-- Status: active
+- Status: completed
 - Parent: DOC-G030
 - Parent goal IDs JSON: ["DOC-G030"]
 - Depends on: DOC-G011, DOC-G013
@@ -379,7 +379,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G034 Prompt-first runtime, state and steering
 
-- Status: active
+- Status: completed
 - Parent: DOC-G030
 - Parent goal IDs JSON: ["DOC-G030"]
 - Depends on: DOC-G011, DOC-G013
@@ -405,7 +405,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G040 Architectural decision records
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on: DOC-G013
@@ -431,7 +431,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G041 Intent, trust and evidence decisions
 
-- Status: active
+- Status: completed
 - Parent: DOC-G040
 - Parent goal IDs JSON: ["DOC-G040"]
 - Depends on: DOC-G031, DOC-G032
@@ -457,7 +457,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G042 Capability and isolation decisions
 
-- Status: active
+- Status: completed
 - Parent: DOC-G040
 - Parent goal IDs JSON: ["DOC-G040"]
 - Depends on: DOC-G022, DOC-G033
@@ -483,7 +483,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G043 Persistence, package and compatibility decisions
 
-- Status: active
+- Status: completed
 - Parent: DOC-G040
 - Parent goal IDs JSON: ["DOC-G040"]
 - Depends on: DOC-G023, DOC-G034
@@ -509,7 +509,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G050 Current user, developer and operator journeys
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on: DOC-G020, DOC-G030
@@ -535,7 +535,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G051 Installation, quickstart, Python and CLI
 
-- Status: active
+- Status: completed
 - Parent: DOC-G050
 - Parent goal IDs JSON: ["DOC-G050"]
 - Depends on: DOC-G021, DOC-G022
@@ -561,7 +561,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G052 MCP and supervisor operation
 
-- Status: active
+- Status: completed
 - Parent: DOC-G050
 - Parent goal IDs JSON: ["DOC-G050"]
 - Depends on: DOC-G022, DOC-G031, DOC-G032, DOC-G033, DOC-G034
@@ -587,7 +587,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G053 Deployment, hardware, P2P, testing and troubleshooting
 
-- Status: active
+- Status: completed
 - Parent: DOC-G050
 - Parent goal IDs JSON: ["DOC-G050"]
 - Depends on: DOC-G021, DOC-G023
@@ -613,7 +613,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G060 Navigation, verification and sustainable closeout
 
-- Status: active
+- Status: completed
 - Parent: DOC-G000
 - Parent goal IDs JSON: ["DOC-G000"]
 - Depends on: DOC-G010, DOC-G020, DOC-G030, DOC-G040, DOC-G050
@@ -639,7 +639,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G061 Glossary, audience routes and archive taxonomy
 
-- Status: active
+- Status: completed
 - Parent: DOC-G060
 - Parent goal IDs JSON: ["DOC-G060"]
 - Depends on: DOC-G012, DOC-G020, DOC-G030, DOC-G040
@@ -665,7 +665,7 @@ DOC-G000  Accurate, rationale-rich documentation
 
 ## DOC-G062 Link/example verification and freshness publication
 
-- Status: active
+- Status: completed
 - Parent: DOC-G060
 - Parent goal IDs JSON: ["DOC-G060"]
 - Depends on: DOC-G050, DOC-G061

--- a/docs/development/DOCUMENTATION_CURRENT_STATE.md
+++ b/docs/development/DOCUMENTATION_CURRENT_STATE.md
@@ -16,7 +16,7 @@ do not exist.
 [DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md](DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md);
 [DOCUMENTATION_VALIDATION_2026_08.md](DOCUMENTATION_VALIDATION_2026_08.md);
 `docs/README.md`; `docs/INDEX.md`; `pyproject.toml`; live package layout.
-**Last verified:** 2026-08-05 against `3d20671f5ce1806afe74b7d79f4ab459b5c2a61b`
+**Last verified:** 2026-08-05 against `6c564578af0b0361741483e80ebcaf405efa1064`
 (`origin/main`); offline documentation gates revalidated (supervisor vocabulary,
 allowlisted relative links, packaging version pin `0.0.45`, closeout navigation
 markers). Earlier 2026-08-04 revalidation covered AI Service Catalog and HF

--- a/docs/development/DOCUMENTATION_CURRENT_STATE.md
+++ b/docs/development/DOCUMENTATION_CURRENT_STATE.md
@@ -16,12 +16,14 @@ do not exist.
 [DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md](DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md);
 [DOCUMENTATION_VALIDATION_2026_08.md](DOCUMENTATION_VALIDATION_2026_08.md);
 `docs/README.md`; `docs/INDEX.md`; `pyproject.toml`; live package layout.
-**Last verified:** 2026-08-04; navigation and maintained-surface inventory
-revalidated after integrating `origin/main`, plus post-closeout revalidation of
-the AI Service Catalog and HF model-server Reference pages, CLI help and
-version-pin fixes, and an allowlisted offline link checker for maintained
-surfaces. Exact merge identity for the earlier integrated matrix:
+**Last verified:** 2026-08-05 against `3d20671f5ce1806afe74b7d79f4ab459b5c2a61b`
+(`origin/main`); offline documentation gates revalidated (supervisor vocabulary,
+allowlisted relative links, packaging version pin `0.0.45`, closeout navigation
+markers). Earlier 2026-08-04 revalidation covered AI Service Catalog and HF
+model-server Reference pages, CLI help, and version-pin fixes. Exact integrated
+matrix for the original DOC-028 merge:
 [DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md](DOCUMENTATION_VALIDATION_POST_MERGE_2026_08_03.md).
+The sealed documentation-refresh board (`DOC-001`–`DOC-028`) is completed.
 **Freshness triggers:** new Current guide; ADR accept/supersede; package or
 entrypoint renames; top-level navigation changes; packaging version
 reconciliation; new doc checkers under `scripts/docs/`.


### PR DESCRIPTION
## Summary
- Marks the sealed `DOC-001`–`DOC-028` documentation-refresh tranche and objective heap as **completed**.
- Revalidates offline documentation gates against current `origin/main` (supervisor vocabulary, allowlisted links, packaging pin `0.0.45`, closeout navigation markers).
- Updates `DOCUMENTATION_CURRENT_STATE.md` last-verified metadata to 2026-08-05.

## Context
The documentation refresh program (plan, board, architecture guides, ADRs, journeys, and DOC-028 closeout) already landed on `main`. This PR is the operator status closeout so plan/objectives no longer report as active after the board is fully complete.

## Test plan
- [x] `python scripts/docs/check_agent_supervisor_docs.py`
- [x] `python scripts/docs/check_current_docs_links.py`
- [x] closeout navigation markers present
- [ ] CI `documentation-gates` green on PR