### PR TITLE
perf(agent-supervisor): proof-carrying reuse plan + scan/idle diagnostics

### DIFF
--- a/docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md
+++ b/docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md
@@ -1,0 +1,499 @@
+# Agent Supervisor Proof-Carrying Test Reuse Plan
+
+**Program:** `PTR`
+**Status:** proposed; implementation disabled by default
+**Objective heap:** `agent_supervisor_proof_carrying_test_reuse.objectives.md`
+**Taskboard:** `agent_supervisor_proof_carrying_test_reuse.todo.md`
+**Task prefix:** `PTR-`
+**Namespace:** `agent-supervisor-proof-carrying-test-reuse-v1`
+
+## Outcome
+
+Extend `ipfs_accelerate_py.agent_supervisor` so it can reuse a prior successful
+validation without executing the command again when the supervisor can prove
+that every input capable of affecting that validation is unchanged.
+
+The user-visible result is **not a fabricated new pass**. It is a typed
+`proved_reuse_pass` disposition that:
+
+1. references a prior authoritative, successful test receipt;
+2. binds the current repository forest, test selection, semantic dependency
+   slice, fixtures, configuration, runtime, toolchain, policy, and capabilities;
+3. proves equality of the prior and current validation-input roots;
+4. re-verifies all receipts and proofs at the point of use; and
+5. is accepted as pass-equivalent only by an explicit, versioned reuse policy.
+
+An incomplete graph, ambiguous dynamic behavior, stale receipt, changed input,
+unsupported language, unavailable verifier, or capability loss causes normal
+test execution. It never causes an optimistic pass.
+
+## Why this is an extension, not a new subsystem
+
+The repository already contains most required primitives:
+
+| Existing surface | Reuse |
+| --- | --- |
+| `analysis.analysis_ast_index` | Incremental, current-snapshot AST index |
+| `program_ast_adapters` | Content-bound Python/JS/TS/JSON/Markdown evidence |
+| `program_graph` / `program_call_resolver` | Conservative typed call edges and unknown frontiers |
+| `analysis.code_evidence_graph.CodeImpactIndex` | Direct and transitive impact selection |
+| `repository_forest` | Commit, tree, gitlink, dirty-overlay, and policy identity |
+| `multiformats_identity` | Strict CIDv1, DAG-JSON/raw, sha2-256 identity |
+| `program_analysis_cache` | Dependency-aware cache and authority namespaces |
+| `validation.validation_scheduler` | Exact successful-result cache, impact DAG, hermetic runtime |
+| `program_analysis_zkp` | Public commitments, private witness policy, verifier conformance |
+| `runtime_cas` / cache coordinator | Immutable artifacts, invalidation, quotas, single-flight |
+
+The current validation cache is intentionally exact: it binds the whole target
+commit and candidate dependency state. That safely reuses an identical
+candidate, but a commit change invalidates the result even when the test's
+complete semantic slice is unchanged. PTR adds a narrower, independently
+verified **validation-input root** and a proof-carrying reuse decision. It does
+not weaken or replace the exact cache.
+
+## Non-negotiable correctness rules
+
+1. **No hash-only shortcut.** Equality of one source file or function is not
+   enough. The complete admitted test-input closure must match.
+2. **No AST-completeness assumption.** A CID proves identity of the encoded
+   object, not that the parser or resolver found every relevant dependency.
+3. **No ZK semantic overclaim.** A ZK proof may prove commitment openings,
+   membership, equality, and supported trace transitions. It does not prove
+   Python semantics, call-graph completeness, or that a historical test truly
+   passed.
+4. **Prior execution remains the root observation.** Reuse starts from a
+   trusted successful execution receipt produced by the existing hermetic
+   validation path.
+5. **Fail closed.** Unknown, partial, truncated, ambiguous, stale, corrupt,
+   untrusted, unsupported, or unavailable means execute.
+6. **No trust upgrade on cache hit.** Lookups re-derive authority from typed
+   evidence. Serialized `passed`, `verified`, or `authoritative` flags are not
+   trusted.
+7. **No silent result conflation.** Executed, exact-cache, and proved-reuse
+   passes remain distinguishable in receipts, metrics, CLI output, and audits.
+8. **Broad and release tests stay policy-controlled.** A project may require
+   periodic execution even when reuse is sound, particularly for flaky,
+   timing-sensitive, hardware, network, security, release, and soak tests.
+9. **TOCTOU is closed.** The observed tree and input root must be rechecked
+   immediately before admitting reuse and again before merge/completion.
+10. **Rollback is instant.** One policy switch disables reuse without disabling
+    ordinary validation or deleting evidence.
+
+## Claim and outcome taxonomy
+
+Add a typed validation disposition rather than overloading `cache_hit`:
+
+| Disposition | Meaning | Command executed now |
+| --- | --- | --- |
+| `executed_pass` | Current hermetic command passed | yes |
+| `exact_cache_pass` | Existing exact validation key matched | no |
+| `proved_reuse_pass` | Cross-tree validation-input equality was independently verified | no |
+| `reuse_shadow_match` | Reuse predicted pass and shadow execution passed | yes |
+| `reuse_shadow_mismatch` | Reuse predicted pass but execution did not pass | yes; blocks promotion |
+| `reuse_ineligible` | Policy or evidence requires execution | yes |
+| existing failure outcomes | Deterministic/flaky/timeout/infrastructure/inconclusive/cancelled | yes |
+
+`proved_reuse_pass` may satisfy a selected validation node only when the node's
+reuse policy allows it and the receipt contains the full current-tree binding.
+It must not be rewritten to look like a freshly executed process.
+
+## Identity hierarchy
+
+All portable identities use the existing frozen multiformats profile:
+CIDv1, lowercase base32, `raw` or canonical `dag-json`, `sha2-256`, 32-byte
+digest. Existing local IDs remain linked through `IdentityLink`.
+
+### 1. Blob identity
+
+`SourceBlobIdentity@1` binds exact bytes, executable mode, repository identity,
+canonical path policy, and generated/vendored classification. Raw-byte CID is
+the leaf identity. Path is a binding, not part of the reusable byte identity.
+
+### 2. AST identity
+
+The existing `ASTBlobRecord` remains canonical for file-level AST evidence.
+Add typed sidecar identities:
+
+- `ASTModuleIdentity@1`: parser/version + complete canonical module AST;
+- `ASTSymbolIdentity@1`: function, async function, method, class, module
+  initializer, schema declaration, or test node;
+- `ASTContextIdentity@1`: defaults, annotations, decorators, closure/free
+  variables, class bases/MRO/metaclass, relevant module globals, imports,
+  registrations, and module-initialization effects;
+- `ASTEdgeIdentity@1`: source symbol, target/frontier, edge kind, resolver rule,
+  confidence/status, and source span.
+
+Source coordinates may be excluded from semantic equality only when a separate
+exact source CID and parser-version binding remains present. Docstrings,
+constants, decorators, defaults, annotations, class construction, and module
+initializers are semantic inputs unless a reviewed language policy proves
+otherwise.
+
+### 3. Semantic call-slice identity
+
+`SemanticSliceManifest@1` is a canonical IPLD DAG containing:
+
+- the selected test nodes;
+- all transitively reachable admitted code symbols;
+- import/re-export edges;
+- fixtures, autouse fixtures, `conftest.py`, test plugins, parametrization,
+  marks, collection hooks, and setup/teardown;
+- schemas, configuration, generated code, data fixtures, resources, and
+  subprocess/MCP/HTTP/IPFS boundaries declared by policy;
+- environment, platform, interpreter, dependency lock, installed distribution,
+  native-extension, and tool identities;
+- explicit unknown and dynamic frontiers;
+- completeness/truncation/coverage receipts; and
+- analyzer, resolver, schema, and policy versions.
+
+The manifest root CID is the semantic-slice root. A Merkle proof can show that
+the same leaves and edges occur in two current-tree projections. It cannot
+establish that omitted leaves never mattered; that is the role of the
+completeness and policy gates.
+
+### 4. Test-input identity
+
+`ValidationInputManifest@1` binds:
+
+- normalized validation command and selected test collection;
+- semantic-slice root;
+- test/fixture/plugin collection root;
+- repository-forest and current dirty-overlay observation;
+- hermetic runtime ID and launcher/interpreter receipts;
+- environment allowlist, dependency manifests, lockfiles, gitlinks, and
+  installed-package inventory;
+- filesystem/network/time/randomness policy;
+- validation, reuse, parser, resolver, and analyzer policy revisions;
+- acceptance criteria and selected impact-DAG node;
+- capabilities and hardware/backend profile; and
+- a nonce only when the policy intentionally forbids reuse.
+
+Its CID is the **validation-input root**. Cross-tree reuse requires exact prior
+and current root equality; comparing hand-selected fields is insufficient.
+
+### 5. Prior pass and reuse proof
+
+`ReusableValidationReceipt@1` wraps an existing successful validation receipt
+and binds its validation-input root, result digest, execution time, stability
+runs, producer, authority, expiration, and revocation domain.
+
+`ValidationReuseProof@1` binds:
+
+- prior and current repository/tree observations;
+- equal prior/current validation-input root;
+- prior pass receipt CID and successful-result digest;
+- AST/call/test manifest roots and completeness receipts;
+- proof method (`direct`, `merkle`, or `zk`);
+- verifier, circuit/key/ceremony identifiers when applicable;
+- policy and capability revisions;
+- freshness, revocation, and TOCTOU checks; and
+- a deterministic reason code for every accepted or rejected condition.
+
+`ValidationReuseDecision@1` is the only object the scheduler may consume.
+
+## What belongs in the dependency closure
+
+The closure must include more than callable AST nodes.
+
+### Always include
+
+- selected tests and their collection metadata;
+- imports, re-exports, module initializers, global reads/writes, decorators,
+  defaults, annotations, closures, class construction, inheritance, and
+  metaclasses;
+- direct and transitive calls with resolver provenance;
+- `conftest.py`, fixtures, plugins, hooks, parametrization, marks, and test
+  configuration;
+- referenced files, schemas, templates, snapshots, golden data, migrations,
+  subprocess commands, and generated artifacts;
+- dependency manifests, lockfiles, gitlinks, interpreter, launcher, installed
+  wheels/distributions, native libraries, and relevant environment;
+- feature flags, backend/capability selection, locale/timezone, and hardware
+  profile where observable; and
+- validation selection, acceptance criteria, and policy.
+
+### Force execution unless a reviewed adapter closes the frontier
+
+- `eval`, `exec`, dynamic source generation, unrestricted reflection, unknown
+  `getattr`, monkey patching, import hooks, namespace-package ambiguity;
+- unpinned network, clock, randomness, process state, external service, GPU,
+  device, kernel, filesystem, or database dependencies;
+- unresolved callback/DI targets, RPC/MCP dispatch, subprocesses, FFI/native
+  extensions, or generated code;
+- test-order dependence, shared mutable state, flaky/quarantined tests, soak,
+  performance, fuzz, mutation, security, release, and deployment gates;
+- parser failures, unsupported languages, inventory gaps, truncated graphs,
+  missing submodules, dirty paths outside the allowed overlay, or a changed
+  symlink/case/Unicode policy.
+
+Adapters may later convert a frontier into a closed, content-bound dependency.
+They may not simply mark it safe.
+
+## Reuse decision algorithm
+
+```text
+selected validation node
+  │
+  ├─ exact validation cache hit?
+  │      └─ verify existing exact receipt → exact_cache_pass
+  │
+  └─ build current ValidationInputManifest
+         │
+         ├─ incomplete/ambiguous/ineligible? → execute
+         ├─ no prior reusable pass?          → execute
+         ├─ prior receipt stale/revoked?     → execute
+         ├─ input root differs?              → execute
+         └─ verify equality/reuse proof
+                ├─ rejected/unavailable      → execute
+                └─ accepted
+                     ├─ shadow policy        → predict, then execute
+                     └─ enforce policy       → proved_reuse_pass
+```
+
+Before merge/completion, rebuild or replay the current manifest from the
+candidate tree and require the same input root. A changed tree may still reuse
+a result, but only because its admitted validation-input root is unchanged.
+
+## Direct, Merkle, and zero-knowledge proof modes
+
+### Direct equality
+
+Inside one trusted supervisor process, compare canonical manifest CIDs and
+re-verify the prior receipt. This is the simplest and preferred mode.
+
+### Merkle/IPLD proof
+
+For distributed caches, transfer the compact manifests, prior receipt, and
+Merkle inclusion/equality proof. Verify content locally against the current
+forest. IPFS availability is transport, not authority.
+
+### Zero knowledge
+
+Use ZK only when a reviewed use case needs to hide source, dependency names,
+test inventory, or other witness material from a verifier across a trust
+boundary. Extend the existing `program_analysis_zkp` public-input contract; do
+not create a second ZK authority.
+
+The circuit may prove:
+
+1. prior/current manifest commitments open correctly;
+2. both use the admitted schema, policy, analyzer, resolver, and toolchain
+   commitments;
+3. required Merkle memberships and closure transitions are satisfied;
+4. prior and current validation-input roots are equal;
+5. the prior receipt commitment is the one referenced publicly; and
+6. the supported trace terminates in `reuse_eligible`.
+
+The circuit does **not** prove:
+
+- that the original test runner honestly executed or passed;
+- that the AST/call graph is complete or semantically sound;
+- arbitrary Python/runtime equivalence;
+- absence of undeclared external state; or
+- correctness beyond the prior test observation.
+
+Those claims remain bound to the original trusted execution receipt,
+independent inventory/completeness policy, and verifier. Simulated ZK remains
+shadow-only. Production ZK requires the existing capability, ceremony, key,
+codec, independent-verifier, and approved-use-case gates.
+
+## Cache and storage design
+
+Keep two explicit tiers:
+
+1. **Exact execution cache** — existing `ValidationResultCache`, keyed by full
+   target/candidate/runtime inputs.
+2. **Proof-carrying reuse index** — maps a validation-input root to immutable
+   prior execution and reuse-proof receipts.
+
+The reuse index uses the existing namespace cache coordinator, authority
+namespaces, quotas, atomic writes, corruption repair, negative TTLs,
+single-flight, and RuntimeCAS/artifact-store boundaries. Large ASTs, manifests,
+proofs, witnesses, and outputs stay in bounded CID-addressed artifacts.
+
+Rules:
+
+- only successful, stable, non-timeout, non-flaky executions are reusable;
+- negative/inconclusive entries never satisfy validation;
+- revocation and policy changes invalidate transitive dependents;
+- cache records contain public receipts and references, never private witness;
+- IPFS/P2P replicas are untrusted until local verification;
+- optional UCAN scope controls who may publish/read receipts, but possession of
+  a UCAN does not make a receipt correct;
+- GC retains any artifact reachable from an unexpired authoritative receipt;
+  and
+- single-flight covers manifest construction, proof generation, and execution.
+
+## Scheduler and daemon integration
+
+Extend `ValidationScheduler` with a `ValidationReusePolicy`:
+
+- `off` — current behavior;
+- `shadow` — compute reuse decision, execute every command, compare;
+- `advisory` — expose eligibility but always execute;
+- `enforce_low_risk` — reuse only deterministic targeted/unit/contract nodes
+  explicitly allowed by repository policy;
+- `enforce_reviewed` — reuse all individually approved classes, preserving
+  periodic-execution requirements.
+
+Add CLI/config controls for mode, receipt age, mandatory rerun interval,
+allowed validation kinds, maximum closure size, proof mode, verifier policy,
+and per-test opt-out. No environment variable alone may enable production
+reuse; a reviewed policy file and digest are required.
+
+The daemon records:
+
+- eligibility and rejection reason codes;
+- prior/current roots and receipt CIDs;
+- proof/verifier mode and latency;
+- execution saved or shadow execution duration;
+- TOCTOU recheck result;
+- policy/capability identity;
+- exact-cache versus proof-reuse counts; and
+- merge/completion authority disposition.
+
+## Security and failure model
+
+Required adversarial coverage:
+
+| Threat | Required response |
+| --- | --- |
+| Poisoned prior receipt | Re-verification rejects; execute |
+| Hash/CID profile confusion or double hashing | Existing strict CID bridge rejects |
+| Forged manifest omits a dependency | Completeness/coverage mismatch; execute |
+| Changed `conftest.py`, plugin, parametrization, or data | Input root changes |
+| Changed lockfile, wheel, native library, interpreter, launcher | Input root changes |
+| Dynamic import/monkey patch/reflection | Unknown frontier; execute |
+| Renamed/moved identical function | Reuse only if path/name bindings are irrelevant under reviewed policy |
+| Changed module initializer/global/decorator/default | Context root changes |
+| Test added or collection changed | Test collection root changes |
+| Flaky/time/network/hardware test | Policy forces execution |
+| Stale/expired/revoked receipt or key | Execute |
+| Simulated ZK or verifier fallback | Non-authoritative; execute |
+| IPFS/P2P cache poisoning | Local CID, schema, authority, and receipt verification |
+| Concurrent tree mutation | Snapshot/TOCTOU mismatch; execute or abort |
+| Partial inventory/parser truncation | Completeness false; execute |
+| Test command broadens selection | Command/collection root changes |
+
+The critical release invariant is:
+
+> There must be zero cases where PTR reuses a pass and executing the same
+> validation under the bound current runtime would produce a non-pass.
+
+Shadow mismatches are severity-one correctness defects and immediately disable
+enforcement for the affected policy/repository/test class.
+
+## Test strategy
+
+### Contract and unit tests
+
+- canonical serialization and CID reproducibility;
+- symbol/context/edge identities;
+- semantic-slice construction and minimality;
+- test/fixture/plugin/data/runtime manifest construction;
+- proof and receipt round trips;
+- stale, corrupt, foreign-authority, and capability-loss rejection;
+- direct/Merkle verification;
+- private-witness no-leak and simulated-ZK non-authority;
+- scheduler outcomes, DAG barriers, completion gates, and rollback.
+
+### Adversarial matrix
+
+Seed one change at a time across function body, signature, decorator, default,
+global, import, caller, transitive callee, fixture, autouse fixture,
+`conftest.py`, plugin, parameter, data file, lockfile, submodule, environment,
+interpreter, native extension, generated code, dynamic import, monkey patch,
+clock, random seed, network response, filesystem, test collection, policy, and
+verifying key. Each seed must either change the input root or force execution.
+
+### Differential shadow oracle
+
+For every predicted reuse in shadow mode, execute the validation and compare
+the real outcome. Store no output secrets. Promotion requires:
+
+- zero false reuse predictions;
+- zero stale authoritative hits;
+- deterministic roots across clean machines;
+- identical decisions across process restart and cache replication;
+- explicit handling of every unknown frontier; and
+- no reduction in mandatory impact-DAG or acceptance coverage.
+
+### Mutation testing
+
+Mutate call-graph edges, manifests, receipts, cache entries, proof bytes,
+environment records, collection manifests, and completeness flags. At least
+one independent verifier must reject every authority-relevant mutation.
+
+## Performance and load plan
+
+Benchmark profiles:
+
+1. exact unchanged candidate;
+2. documentation-only unrelated change;
+3. unrelated source-module change;
+4. unchanged leaf test closure across a large merge;
+5. changed leaf implementation;
+6. changed public interface or shared dependency;
+7. fixture/plugin/config/lockfile/environment drift;
+8. dynamic/unsupported frontier fallback;
+9. cold cache, warm local cache, warm IPFS/P2P replica;
+10. 1/4/16/64 parallel supervisors contending on the same roots.
+
+Measure:
+
+- index and manifest build p50/p95/p99;
+- direct/Merkle/ZK proof and verification latency;
+- cache hit/reject/fallback rates by reason;
+- tests and wall-clock seconds saved;
+- CPU, RSS, disk, network, artifact bytes, and GC time;
+- single-flight collapse ratio;
+- shadow mismatch count;
+- reuse precision (must be 1.0 for promotion);
+- reuse coverage and mandatory-rerun frequency; and
+- merge/completion latency.
+
+Initial performance targets, subject to baseline ratification:
+
+- zero false reuse;
+- at least 50% wall-clock reduction for admitted unrelated-change profiles;
+- p95 direct/Merkle decision under 250 ms for warm bounded slices;
+- incremental index overhead below 10% of the avoided test time;
+- no more than one producer for concurrent identical manifest/proof work; and
+- bounded cache growth with successful quota/GC recovery.
+
+Performance never overrides correctness. Missing a reuse opportunity is safe;
+reusing an invalid pass is not.
+
+## Rollout and rollback
+
+1. **Contracts only:** schemas, identities, reason codes, and policy; no reuse.
+2. **Offline fixtures:** direct and Merkle proofs over synthetic repositories.
+3. **Shadow:** predict and execute every selected validation.
+4. **Canary:** low-risk deterministic tests in an allowlisted repository.
+5. **Bounded enforcement:** targeted/unit/contract tests with periodic reruns.
+6. **Expanded reviewed classes:** only after class-specific shadow evidence.
+7. **Optional ZK:** separate privacy/trust-boundary approval; never required
+   for ordinary local reuse.
+
+Rollback is one policy change to `off`, followed by ordinary validation. Cached
+receipts remain audit evidence but cannot satisfy new decisions while disabled.
+Any mismatch, authority violation, verifier disagreement, unexplained
+incompleteness, or stale hit automatically returns the affected scope to
+shadow/off.
+
+## Definition of done
+
+PTR is production-ready only when:
+
+- the objective and task boards are complete and machine-ingestible;
+- all identity, manifest, proof, receipt, and policy schemas are versioned;
+- every admitted input class has a mutation/invalidation test;
+- unknown/dynamic behavior demonstrably fails closed;
+- prior passes are independently re-verified and current-tree rebound;
+- direct and Merkle modes work without ZK;
+- ZK remains optional and cannot exceed its reviewed claim;
+- scheduler, daemon, status, CLI, and audit surfaces distinguish reuse;
+- shadow testing shows zero false reuse across the ratified corpus and load;
+- rollback and cache-corruption recovery are exercised; and
+- merge/completion authority rejects stale, incomplete, foreign, simulated, or
+  tampered evidence.

--- a/docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md
+++ b/docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md
@@ -1,0 +1,204 @@
+# Agent Supervisor Proof-Carrying Test Reuse Objective Heap (PTR)
+
+Machine-ingestible goals for
+`AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md`. The executable projection
+is `agent_supervisor_proof_carrying_test_reuse.todo.md` with prefix `PTR-`.
+
+## North star
+
+Reuse a prior successful validation across repository trees only when a
+current, complete, content-addressed validation-input manifest is identical to
+the prior manifest and an independently verified proof binds that equality to
+an authoritative prior execution receipt. Unknown means execute.
+
+## Goal tree
+
+```text
+PTR-G000  Production-safe proof-carrying validation reuse
+├── PTR-G010  Doctrine, threat model, outcome and policy contracts
+├── PTR-G020  CIDv1 AST symbol/context/edge identities
+├── PTR-G030  Complete semantic and test dependency closures
+├── PTR-G040  Validation-input manifests and prior-pass receipts
+├── PTR-G050  Direct/Merkle reuse proof and cache integration
+├── PTR-G060  Optional privacy-preserving ZK reuse proof
+├── PTR-G070  Scheduler, daemon, CLI, status, and completion integration
+├── PTR-G080  Adversarial, mutation, differential, and conformance gates
+├── PTR-G090  Performance, concurrency, IPFS replication, and GC
+└── PTR-G100  Shadow, canary, enforcement, rollback, and operations
+```
+
+## Parallel waves
+
+| Wave | Goals | Dependency |
+| --- | --- | --- |
+| 0 | G010 | none |
+| 1 | G020, G040 | G010 |
+| 2 | G030 | G020 |
+| 3 | G050 | G030 + G040 |
+| 4 | G060, G070 | G050; G060 may remain shadow |
+| 5 | G080, G090 | G050 + G070 |
+| 6 | G100 | G080 + G090 |
+
+## PTR-G000 Production-safe proof-carrying validation reuse
+
+- Status: active
+- Parent:
+- Priority: P0
+- Track: proof-test-reuse
+- Bundle: agent-supervisor/proof-test-reuse/root
+- Goal: Deliver an opt-in, fail-closed mechanism that admits a typed prior test pass on a current tree only when all validation inputs are proven unchanged.
+- Evidence: ptr/root-contract@1
+- Outputs: docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+- Validation: test -f docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+- Acceptance: All child goals are implemented or explicitly blocked; ordinary validation remains available; no fake fresh pass; unknown always executes.
+- Conflict policy: Extend existing AST, cache, validation, proof, and ZK contracts; create no second assurance lattice or cache authority.
+
+## PTR-G010 Doctrine, threat model, outcome and policy contracts
+
+- Status: active
+- Parent: PTR-G000
+- Priority: P0
+- Track: contracts
+- Bundle: agent-supervisor/proof-test-reuse/contracts
+- Goal: Define executed, exact-cache, proved-reuse, shadow-match/mismatch, and ineligible outcomes plus reviewed reuse policy modes and non-claims.
+- Evidence: ptr/reuse-contract@1, ptr/reuse-threat-model@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_contracts.py, docs/architecture/agent_supervisor_proof_carrying_test_reuse_threat_model.md
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_contracts.py
+- Acceptance: Typed bounded canonical records; cache hits never upgrade trust; ZK non-claims explicit; off/shadow/advisory/enforce policies; arbitrary environment enablement rejected.
+- Gap task: Implement PTR-002.
+- Conflict policy: Preserve existing `ValidationOutcome`; add orthogonal disposition rather than changing historical meanings.
+
+## PTR-G020 CIDv1 AST symbol, context, and edge identities
+
+- Status: active
+- Parent: PTR-G000, PTR-G010
+- Priority: P0
+- Track: semantic-identity
+- Bundle: agent-supervisor/proof-test-reuse/identity
+- Goal: Produce canonical CIDv1 identities for exact blobs, AST modules, symbols, semantic contexts, and resolved/unknown edges.
+- Evidence: ptr/semantic-identity@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/program_ast_adapters.py, ipfs_accelerate_py/agent_supervisor/multiformats_identity.py, ipfs_accelerate_py/agent_supervisor/validation/semantic_identity.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_semantic_identity.py test/api/test_agent_supervisor_multiformats_identity.py
+- Acceptance: Reproducible across clean machines; parser/policy versions bound; defaults/decorators/globals/class context included; double hashing and profile confusion rejected.
+- Gap task: Implement PTR-003.
+- Conflict policy: Keep `ASTBlobRecord` canonical and add sidecars; do not fork the AST schema.
+
+## PTR-G030 Complete semantic and test dependency closures
+
+- Status: active
+- Parent: PTR-G000, PTR-G020
+- Priority: P0
+- Track: dependency-closure
+- Bundle: agent-supervisor/proof-test-reuse/closure
+- Goal: Build bounded dependency-complete semantic slices for selected tests, including fixtures, plugins, data, runtime, toolchain, and explicit unknown frontiers.
+- Evidence: ptr/semantic-slice@1, ptr/test-dependency-closure@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/semantic_slice.py, ipfs_accelerate_py/agent_supervisor/validation/test_dependency_index.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_semantic_slice.py test/api/test_agent_supervisor_test_dependency_index.py
+- Acceptance: Direct/transitive calls and test collection inputs covered; incomplete/ambiguous/truncated closure cannot be eligible; dynamic and external boundaries have typed fallback reasons.
+- Gap task: Implement PTR-004 through PTR-006.
+- Conflict policy: Reuse `ProgramGraph`, `ProgramCallResolver`, and `CodeImpactIndex`; graph retrieval cannot manufacture edges.
+
+## PTR-G040 Validation-input manifests and prior-pass receipts
+
+- Status: active
+- Parent: PTR-G000, PTR-G010
+- Priority: P0
+- Track: receipt-contract
+- Bundle: agent-supervisor/proof-test-reuse/receipts
+- Goal: Bind command, collection, semantic slice, runtime, forest, dependencies, environment, policy, and capabilities into one validation-input root and wrap eligible prior executions.
+- Evidence: ptr/validation-input-manifest@1, ptr/reusable-validation-receipt@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_receipts.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_receipts.py
+- Acceptance: Only stable successful authoritative executions can be wrapped; stale/revoked/flaky/timeout/incomplete receipts reject; private data stays outside public receipt.
+- Gap task: Implement PTR-007.
+- Conflict policy: Wrap existing validation receipts; do not invent a new execution result.
+
+## PTR-G050 Direct/Merkle reuse proof and cache integration
+
+- Status: active
+- Parent: PTR-G000, PTR-G030, PTR-G040
+- Priority: P0
+- Track: reuse-verifier
+- Bundle: agent-supervisor/proof-test-reuse/verifier
+- Goal: Verify current/prior validation-input equality with direct or IPLD Merkle proofs and index receipts through existing cache/CAS authority.
+- Evidence: ptr/validation-reuse-proof@1, ptr/validation-reuse-decision@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse.py, ipfs_accelerate_py/agent_supervisor/program_analysis_cache.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse.py test/api/test_agent_supervisor_program_analysis_cache.py
+- Acceptance: Current-tree rebuild and TOCTOU recheck; independent receipt verification; exact reason codes; corruption and replica poisoning reject; single-flight and transitive invalidation.
+- Gap task: Implement PTR-008 and PTR-009.
+- Conflict policy: Existing exact validation cache remains tier one; reuse is a separate typed lookup under the same cache coordinator.
+
+## PTR-G060 Optional privacy-preserving ZK reuse proof
+
+- Status: active
+- Parent: PTR-G000, PTR-G050
+- Priority: P1
+- Track: zk-reuse
+- Bundle: agent-supervisor/proof-test-reuse/zk
+- Goal: Add a shadow-only ZK statement for manifest opening/membership/equality when a reviewed private-witness and cross-trust use case exists.
+- Evidence: ptr/zk-reuse-statement@1, ptr/zk-reuse-verification@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/program_analysis_zkp.py, test/api/test_agent_supervisor_validation_reuse_zkp.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_zkp.py test/api/test_agent_supervisor_program_analysis_zkp_conformance.py
+- Acceptance: Simulated proofs never authorize; independent verifier, circuit/key/ceremony/codec pins, no witness leakage, explicit non-claims, direct/Merkle mode remains sufficient.
+- Gap task: Implement PTR-010.
+- Conflict policy: Extend the existing program-analysis ZK public-input contract; no second ZK trust root.
+
+## PTR-G070 Scheduler, daemon, CLI, status, and completion integration
+
+- Status: active
+- Parent: PTR-G000, PTR-G050
+- Priority: P0
+- Track: orchestration
+- Bundle: agent-supervisor/proof-test-reuse/orchestration
+- Goal: Integrate reuse decisions into selected validation DAGs while preserving stage barriers, auditability, merge freshness, and immediate disablement.
+- Evidence: ptr/scheduler-integration@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_scheduler.py, ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_scheduler.py test/api/test_agent_supervisor_validation_dag.py test/api/test_agent_supervisor_todo_daemon_port.py -k 'reuse or validation'
+- Acceptance: Distinct dispositions; off is default; shadow executes; reviewed enforcement only; merge/completion rebind current root; status/metrics/reasons emitted; rollback switch tested.
+- Gap task: Implement PTR-011 through PTR-013.
+- Conflict policy: Preserve ordinary runner and exact cache behavior.
+
+## PTR-G080 Adversarial, mutation, differential, and conformance gates
+
+- Status: active
+- Parent: PTR-G000, PTR-G050, PTR-G070
+- Priority: P0
+- Track: correctness
+- Bundle: agent-supervisor/proof-test-reuse/correctness
+- Goal: Demonstrate zero false reuse under seeded dependency drift, cache/proof mutation, dynamic behavior, and shadow execution.
+- Evidence: ptr/reuse-conformance@1
+- Outputs: test/api/test_agent_supervisor_validation_reuse_adversarial.py, test/integration/test_agent_supervisor_validation_reuse_shadow.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_adversarial.py test/integration/test_agent_supervisor_validation_reuse_shadow.py
+- Acceptance: Every authority-relevant mutation rejects; every dependency seed changes root or forces execution; zero shadow mismatches in ratified corpus; coverage cannot shrink.
+- Gap task: Implement PTR-014 and PTR-015.
+- Conflict policy: A false reuse prediction is a release blocker, not a tolerated flaky result.
+
+## PTR-G090 Performance, concurrency, replication, and GC
+
+- Status: active
+- Parent: PTR-G000, PTR-G050, PTR-G070
+- Priority: P1
+- Track: performance
+- Bundle: agent-supervisor/proof-test-reuse/performance
+- Goal: Quantify saved time and bound indexing, proof, concurrency, storage, IPFS replication, and GC costs without relaxing correctness.
+- Evidence: ptr/reuse-benchmark@1
+- Outputs: benchmarks/agent_supervisor/validation_reuse.py, test/load/test_agent_supervisor_validation_reuse.py
+- Validation: python -m pytest -q test/load/test_agent_supervisor_validation_reuse.py
+- Acceptance: Zero false reuse; warm p95 target measured; unrelated-change time reduction measured; 64-lane single-flight; bounded cache and corruption/GC recovery.
+- Gap task: Implement PTR-016.
+- Conflict policy: Performance targets cannot convert unknown or rejected evidence into reuse.
+
+## PTR-G100 Shadow, canary, enforcement, rollback, and operations
+
+- Status: active
+- Parent: PTR-G000, PTR-G080, PTR-G090
+- Priority: P0
+- Track: rollout
+- Bundle: agent-supervisor/proof-test-reuse/rollout
+- Goal: Operate a reversible shadow-to-enforcement rollout with class-level policy, periodic reruns, mismatch kill switch, and auditable receipts.
+- Evidence: ptr/reuse-rollout@1
+- Outputs: docs/operations/agent_supervisor_validation_reuse.md, ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_rollout.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_rollout.py
+- Acceptance: Off/shadow/canary/enforce transitions; allowlist and mandatory rerun; mismatch auto-disable; status/diagnostics; rollback drill; no dependency on ZK for local operation.
+- Gap task: Implement PTR-017 through PTR-020.
+- Conflict policy: Operators retain explicit control; no autonomous promotion from metrics alone.

--- a/docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+++ b/docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
@@ -1,0 +1,391 @@
+# Agent Supervisor Proof-Carrying Test Reuse Taskboard (PTR)
+
+Consumed by `ipfs_accelerate_py.agent_supervisor` with task prefix `PTR-`.
+Companion plan:
+`AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md`. Companion goals:
+`agent_supervisor_proof_carrying_test_reuse.objectives.md`.
+
+Normative rule: this program reuses a prior authoritative test observation; it
+never manufactures a fresh execution pass. Unknown, incomplete, ambiguous,
+stale, tampered, or unsupported evidence executes the test.
+
+## Parallel lanes
+
+| Lane | Tasks |
+| --- | --- |
+| `ptr-contracts` | PTR-001, PTR-002 |
+| `ptr-identity` | PTR-003 |
+| `ptr-test-index` | PTR-004 |
+| `ptr-call-closure` | PTR-005, PTR-006 |
+| `ptr-receipts` | PTR-007 |
+| `ptr-cache` | PTR-008 |
+| `ptr-verifier` | PTR-009 |
+| `ptr-zk` | PTR-010 |
+| `ptr-scheduler` | PTR-011 |
+| `ptr-daemon` | PTR-012 |
+| `ptr-distribution` | PTR-013 |
+| `ptr-adversarial` | PTR-014 |
+| `ptr-shadow` | PTR-015 |
+| `ptr-performance` | PTR-016 |
+| `ptr-observability` | PTR-017 |
+| `ptr-rollout` | PTR-018, PTR-019, PTR-020 |
+
+## PTR-001 Seal proof-carrying test-reuse planning artifacts
+
+- Status: completed
+- Completion: manual
+- Priority: P0
+- Track: docs
+- Depends on:
+- Goal id: PTR-G000
+- Outputs: docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+- Validation: test -f docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md && test -f docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md && test -f docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/contracts
+- Parallel lane: ptr-contracts
+- Resource class: cpu-small
+- Predicted files: docs/architecture/AGENT_SUPERVISOR_PROOF_CARRYING_TEST_REUSE_PLAN.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.objectives.md, docs/architecture/agent_supervisor_proof_carrying_test_reuse.todo.md
+- Conflict policy: Planning artifacts only; do not enable runtime reuse.
+- Acceptance: Plan inventories current primitives, defines non-claims, identity hierarchy, algorithm, ZK role, threat model, test/load gates, rollout, goals, dependencies, and tasks.
+
+## PTR-002 Implement reuse outcome, decision, and policy contracts
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: contracts
+- Depends on: PTR-001
+- Goal id: PTR-G010
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_contracts.py, test/api/test_agent_supervisor_validation_reuse_contracts.py, docs/architecture/agent_supervisor_proof_carrying_test_reuse_threat_model.md
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_contracts.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/contracts
+- Parallel lane: ptr-contracts
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_contracts.py, test/api/test_agent_supervisor_validation_reuse_contracts.py
+- Conflict policy: Add an orthogonal disposition; preserve `ValidationOutcome`.
+- Acceptance: Canonical bounded records for policy, eligibility, proof method, disposition, reason codes, freshness, revocation, and authority. `off` default; shadow executes; environment-only enablement rejected; cache/ZK cannot upgrade trust.
+
+## PTR-003 Add CIDv1 semantic identities for AST symbols, contexts, and edges
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: semantic-identity
+- Depends on: PTR-002
+- Goal id: PTR-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/semantic_identity.py, test/api/test_agent_supervisor_validation_semantic_identity.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_semantic_identity.py test/api/test_agent_supervisor_multiformats_identity.py test/api/test_agent_supervisor_program_ast_adapters.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/identity
+- Parallel lane: ptr-identity
+- Resource class: cpu-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/semantic_identity.py, ipfs_accelerate_py/agent_supervisor/program_ast_adapters.py, test/api/test_agent_supervisor_validation_semantic_identity.py
+- Conflict policy: Reuse `ASTBlobRecord` and `multiformats_identity`; sidecars only.
+- Acceptance: Raw blob, module, symbol, context, and edge identities use the frozen CID profile. Defaults, decorators, globals, closures, class bases/metaclass, imports, registrations, parser/policy versions, and unknown edges are bound. Cross-machine and mutation tests pass.
+
+## PTR-004 Build the test collection, fixture, plugin, and data dependency index
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: test-index
+- Depends on: PTR-002, PTR-003
+- Goal id: PTR-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/test_dependency_index.py, test/api/test_agent_supervisor_test_dependency_index.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_test_dependency_index.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/closure
+- Parallel lane: ptr-test-index
+- Resource class: cpu-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/test_dependency_index.py, test/api/test_agent_supervisor_test_dependency_index.py
+- Conflict policy: Collection is observational; do not execute arbitrary plugin code during static indexing.
+- Acceptance: Bind selected test nodes, `conftest.py`, fixtures/autouse fixtures, plugins/hooks, parameters, marks, setup/teardown, configs, snapshots/data, and collection identity. Unsupported/dynamic collection is explicit and ineligible.
+
+## PTR-005 Build dependency-complete semantic slices
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: call-closure
+- Depends on: PTR-003, PTR-004
+- Goal id: PTR-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/semantic_slice.py, test/api/test_agent_supervisor_validation_semantic_slice.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_semantic_slice.py test/api/test_agent_supervisor_program_call_resolver.py test/api/test_agent_supervisor_validation_dag.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/closure
+- Parallel lane: ptr-call-closure
+- Resource class: cpu-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/semantic_slice.py, test/api/test_agent_supervisor_validation_semantic_slice.py
+- Conflict policy: Consume `ProgramGraph`, `ProgramCallResolver`, `CodeImpactIndex`; do not infer missing direct edges.
+- Acceptance: Deterministic bounded IPLD manifest contains tests, transitively reachable symbols, imports/initializers/globals, test dependencies, runtime/toolchain/config inputs, coverage, truncation, and unknown frontiers. Minimality does not remove required closure.
+
+## PTR-006 Classify dynamic and external frontiers fail-closed
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: call-closure
+- Depends on: PTR-005
+- Goal id: PTR-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/semantic_slice.py, test/api/test_agent_supervisor_validation_dynamic_frontiers.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_dynamic_frontiers.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/closure
+- Parallel lane: ptr-call-closure
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/semantic_slice.py, test/api/test_agent_supervisor_validation_dynamic_frontiers.py
+- Conflict policy: Adapters may close a frontier only with reviewed content-bound evidence.
+- Acceptance: `eval`/`exec`, reflection, monkey patch, import hooks, callbacks/DI, RPC/MCP, subprocess, FFI/native, generated code, unpinned network/time/random/filesystem/hardware, and parser gaps force execution with stable reason codes.
+
+## PTR-007 Define validation-input manifests and reusable prior-pass receipts
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: receipts
+- Depends on: PTR-002, PTR-004, PTR-005
+- Goal id: PTR-G040
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_receipts.py, test/api/test_agent_supervisor_validation_reuse_receipts.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_receipts.py test/api/test_agent_supervisor_validation_scheduler.py -k cache
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/receipts
+- Parallel lane: ptr-receipts
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_receipts.py, test/api/test_agent_supervisor_validation_reuse_receipts.py
+- Conflict policy: Wrap existing hermetic validation results; do not rewrite history as a new run.
+- Acceptance: Manifest binds command/collection/slice/forest/overlay/runtime/environment/dependencies/toolchain/policy/capabilities/acceptance. Only stable authoritative successful executions produce reusable receipts. Stale, flaky, timeout, revoked, corrupt, or private-witness payloads reject.
+
+## PTR-008 Add a proof-carrying reuse index to the existing cache coordinator
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: cache
+- Depends on: PTR-007
+- Goal id: PTR-G050
+- Outputs: ipfs_accelerate_py/agent_supervisor/program_analysis_cache.py, ipfs_accelerate_py/agent_supervisor/validation/validation_reuse.py, test/api/test_agent_supervisor_validation_reuse_cache.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_cache.py test/api/test_agent_supervisor_program_analysis_cache.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/cache
+- Parallel lane: ptr-cache
+- Resource class: io-artifact
+- Predicted files: ipfs_accelerate_py/agent_supervisor/program_analysis_cache.py, ipfs_accelerate_py/agent_supervisor/validation/validation_reuse.py, test/api/test_agent_supervisor_validation_reuse_cache.py
+- Conflict policy: Exact validation cache remains tier one; reuse index shares authority namespaces, CAS, quotas, GC, and single-flight.
+- Acceptance: Root-to-receipt lookup, authoritative namespace isolation, transitive invalidation, negative TTL, atomic concurrent publish, corruption repair, revocation, quota/GC, and zero stale authoritative hits.
+
+## PTR-009 Implement independent direct and IPLD Merkle reuse verification
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: verifier
+- Depends on: PTR-007, PTR-008
+- Goal id: PTR-G050
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse.py, test/api/test_agent_supervisor_validation_reuse.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/verifier
+- Parallel lane: ptr-verifier
+- Resource class: cpu-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse.py, test/api/test_agent_supervisor_validation_reuse.py
+- Conflict policy: Verification derives authority; serialized decision flags are untrusted.
+- Acceptance: Rebuild current manifest, verify prior receipt, compare roots, verify memberships, check policy/capability/freshness/revocation, close TOCTOU, emit accepted/rejected decision with exact reasons, and fall back to execution on any error.
+
+## PTR-010 Add optional shadow ZK validation-input equality proofs
+
+- Status: todo
+- Completion: manual
+- Priority: P1
+- Track: zk-reuse
+- Depends on: PTR-009
+- Goal id: PTR-G060
+- Outputs: ipfs_accelerate_py/agent_supervisor/program_analysis_zkp.py, test/api/test_agent_supervisor_validation_reuse_zkp.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_zkp.py test/api/test_agent_supervisor_program_analysis_zkp_conformance.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/zk
+- Parallel lane: ptr-zk
+- Resource class: proof-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/program_analysis_zkp.py, test/api/test_agent_supervisor_validation_reuse_zkp.py
+- Conflict policy: Extend existing public inputs/capability gates; simulated ZK cannot authorize.
+- Acceptance: Prove openings, required membership/trace transitions, equal input roots, and bound prior receipt commitment. Explicitly do not claim execution honesty, call-graph completeness, Python equivalence, or broader correctness. Require approved private-witness/cross-trust use case, circuit/key/ceremony/codec pins, independent verification, no witness leakage.
+
+## PTR-011 Integrate reuse decisions into the validation DAG scheduler
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: scheduler
+- Depends on: PTR-002, PTR-009
+- Goal id: PTR-G070
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_scheduler.py, test/api/test_agent_supervisor_validation_reuse_scheduler.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_scheduler.py test/api/test_agent_supervisor_validation_scheduler.py test/api/test_agent_supervisor_validation_dag.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/orchestration
+- Parallel lane: ptr-scheduler
+- Resource class: cpu-medium
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_scheduler.py, test/api/test_agent_supervisor_validation_reuse_scheduler.py
+- Conflict policy: Preserve stage barriers, failure blocking, exact cache, and normal runner.
+- Acceptance: Exact cache checked first; off/advisory/shadow/enforcement behavior exact; `proved_reuse_pass` distinct; reused nodes satisfy only reviewed policy; dependency failures block dependents; current root rechecked before completion.
+
+## PTR-012 Wire daemon configuration, CLI, status, and audit receipts
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: daemon
+- Depends on: PTR-011
+- Goal id: PTR-G070
+- Outputs: ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py, test/api/test_agent_supervisor_validation_reuse_daemon.py, docs/operations/agent_supervisor_validation_reuse.md
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_daemon.py test/api/test_agent_supervisor_todo_daemon_port.py -k validation
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/orchestration
+- Parallel lane: ptr-daemon
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py, test/api/test_agent_supervisor_validation_reuse_daemon.py
+- Conflict policy: Reviewed policy file required for enforcement; environment alone cannot enable.
+- Acceptance: Flags/config for mode, age, rerun interval, allowed kinds, closure bounds, proof/verifier mode, and opt-out. Status records eligibility/reasons/roots/receipts/latency/saved time/TOCTOU. Merge and completion reject stale reuse.
+
+## PTR-013 Verify IPFS/P2P replication and scoped publication
+
+- Status: todo
+- Completion: auto
+- Priority: P1
+- Track: distribution
+- Depends on: PTR-008, PTR-009
+- Goal id: PTR-G070
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_transport.py, test/api/test_agent_supervisor_validation_reuse_transport.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_transport.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/distribution
+- Parallel lane: ptr-distribution
+- Resource class: io-network
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_transport.py, test/api/test_agent_supervisor_validation_reuse_transport.py
+- Conflict policy: Transport and UCAN scope do not grant evidence authority.
+- Acceptance: Offline/local operation; untrusted replica verification; CID/schema/authority/policy checks; bounded fetch; no witness/secret publication; optional UCAN read/publish scope; outage and poisoning fall back to execution.
+
+## PTR-014 Build the adversarial and mutation conformance suite
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: correctness
+- Depends on: PTR-006, PTR-009, PTR-011
+- Goal id: PTR-G080
+- Outputs: test/api/test_agent_supervisor_validation_reuse_adversarial.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_adversarial.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/correctness
+- Parallel lane: ptr-adversarial
+- Resource class: cpu-large
+- Predicted files: test/api/test_agent_supervisor_validation_reuse_adversarial.py
+- Conflict policy: Every false reuse is a hard failure.
+- Acceptance: Seed changes to body/signature/default/decorator/global/import/caller/callee/fixture/plugin/parameter/data/config/lock/submodule/env/interpreter/native/generated/dynamic/network/time/random/filesystem/collection/policy/key. Mutate graphs/manifests/receipts/cache/proofs. Every case changes root or forces execution.
+
+## PTR-015 Run differential shadow validation across real repositories
+
+- Status: todo
+- Completion: manual
+- Priority: P0
+- Track: shadow
+- Depends on: PTR-011, PTR-014
+- Goal id: PTR-G080
+- Outputs: test/integration/test_agent_supervisor_validation_reuse_shadow.py, artifacts/agent_supervisor/validation_reuse/shadow_summary.json
+- Validation: python -m pytest -q test/integration/test_agent_supervisor_validation_reuse_shadow.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/correctness
+- Parallel lane: ptr-shadow
+- Resource class: cpu-large
+- Predicted files: test/integration/test_agent_supervisor_validation_reuse_shadow.py
+- Conflict policy: Shadow prediction never skips execution.
+- Acceptance: Ratified accelerator/datasets/kit/lift fixtures; process restart and replica parity; deterministic roots; zero false reuse and stale hits; no mandatory DAG/acceptance loss; mismatch automatically disables affected scope.
+
+## PTR-016 Benchmark cold/warm reuse, parallel supervisors, storage, and GC
+
+- Status: todo
+- Completion: auto
+- Priority: P1
+- Track: performance
+- Depends on: PTR-008, PTR-009, PTR-011
+- Goal id: PTR-G090
+- Outputs: benchmarks/agent_supervisor/validation_reuse.py, test/load/test_agent_supervisor_validation_reuse.py
+- Validation: python -m pytest -q test/load/test_agent_supervisor_validation_reuse.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/performance
+- Parallel lane: ptr-performance
+- Resource class: cpu-large
+- Predicted files: benchmarks/agent_supervisor/validation_reuse.py, test/load/test_agent_supervisor_validation_reuse.py
+- Conflict policy: Benchmark thresholds never override ineligibility.
+- Acceptance: Exact/doc/unrelated/leaf/interface/fixture/config/dynamic profiles; cold/warm/local/replica; 1/4/16/64 lanes; p50/p95/p99, saved time, CPU/RSS/disk/network, single-flight, cache bounds, GC/corruption recovery, reuse precision and coverage.
+
+## PTR-017 Add reuse metrics, diagnostics, alerting, and mismatch kill switch
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: observability
+- Depends on: PTR-011, PTR-015
+- Goal id: PTR-G100
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_rollout.py, test/api/test_agent_supervisor_validation_reuse_rollout.py
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_rollout.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/rollout
+- Parallel lane: ptr-observability
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_rollout.py, test/api/test_agent_supervisor_validation_reuse_rollout.py
+- Conflict policy: Metrics cannot self-promote enforcement.
+- Acceptance: Counters/latencies/reasons by disposition and policy; shadow mismatch severity-one alert; automatic class/repository disable; redacted diagnostics; current policy/capability/receipt IDs; operator-visible rollback status.
+
+## PTR-018 Implement off, shadow, canary, and reviewed enforcement transitions
+
+- Status: todo
+- Completion: manual
+- Priority: P0
+- Track: rollout
+- Depends on: PTR-015, PTR-016, PTR-017
+- Goal id: PTR-G100
+- Outputs: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_rollout.py, docs/operations/agent_supervisor_validation_reuse.md
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_rollout.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/rollout
+- Parallel lane: ptr-rollout
+- Resource class: cpu-small
+- Predicted files: ipfs_accelerate_py/agent_supervisor/validation/validation_reuse_rollout.py, docs/operations/agent_supervisor_validation_reuse.md
+- Conflict policy: No autonomous promotion; operator review required.
+- Acceptance: Allowlisted repositories/test classes, minimum shadow sample, zero mismatches, mandatory periodic execution, policy expiry, canary budget, promotion/demotion receipts, and direct rollback to off.
+
+## PTR-019 Exercise corruption, capability-loss, mismatch, and emergency rollback
+
+- Status: todo
+- Completion: manual
+- Priority: P0
+- Track: rollout
+- Depends on: PTR-018
+- Goal id: PTR-G100
+- Outputs: test/integration/test_agent_supervisor_validation_reuse_rollback.py, artifacts/agent_supervisor/validation_reuse/rollback_receipt.json
+- Validation: python -m pytest -q test/integration/test_agent_supervisor_validation_reuse_rollback.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/rollout
+- Parallel lane: ptr-rollout
+- Resource class: cpu-medium
+- Predicted files: test/integration/test_agent_supervisor_validation_reuse_rollback.py
+- Conflict policy: Rollback uses ordinary validation and does not delete audit evidence.
+- Acceptance: Cache corruption, stale receipt, verifier/key loss, capability drift, shadow mismatch, TOCTOU drift, and operator kill switch all stop reuse immediately and resume normal validation without supervisor restart.
+
+## PTR-020 Ratify production readiness and retain ZK as optional sidecar
+
+- Status: todo
+- Completion: manual
+- Priority: P0
+- Track: rollout
+- Depends on: PTR-014, PTR-015, PTR-016, PTR-018, PTR-019
+- Goal id: PTR-G100
+- Outputs: docs/operations/agent_supervisor_validation_reuse.md, artifacts/agent_supervisor/validation_reuse/release_decision.json
+- Validation: python -m pytest -q test/api/test_agent_supervisor_validation_reuse_adversarial.py test/integration/test_agent_supervisor_validation_reuse_shadow.py test/load/test_agent_supervisor_validation_reuse.py test/integration/test_agent_supervisor_validation_reuse_rollback.py
+- Board namespace: agent-supervisor-proof-carrying-test-reuse-v1
+- Bundle: agent-supervisor/proof-test-reuse/rollout
+- Parallel lane: ptr-rollout
+- Resource class: cpu-large
+- Predicted files: docs/operations/agent_supervisor_validation_reuse.md
+- Conflict policy: Release decision is external/operator-reviewed; local task completion cannot manufacture it.
+- Acceptance: Zero false reuse and stale hits; cross-machine deterministic roots; all mutation gates pass; bounded performance and storage; audit/rollback verified; local direct/Merkle reuse works without ZK; any ZK enforcement has a separately approved private-witness/cross-trust decision and production verifier conformance.

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -8362,7 +8362,15 @@ class PortalImplementationDaemon:
             ),
             "child_process": (),
             "lease": tuple(lease_paths),
-            "validation": (Path(self.validation_cache_dir),),
+            # The shared validation cache is an optimization, not an
+            # authoritative scheduling input. SQLite journal creation and
+            # single-flight bookkeeping mutate this directory even for cache
+            # reads; watching it makes an idle pass wake itself and every peer
+            # lane, followed by a full repository reconciliation. Real work is
+            # already signalled by task-board, merge-queue, child-process, and
+            # policy events, with the bounded safety reconciliation covering a
+            # missed notification.
+            "validation": (),
             "provider_capacity": (),
             "policy": tuple(policy_paths),
             "observation_window": (),

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -165,6 +165,11 @@ from ..runtime.resource_scheduler import (
     admit_compiled_execution_assignments,
     evaluate_capacity_drift,
 )
+from .implementation_daemon_runner import (
+    IDLE_DAEMON_PASS_LOG_INTERVAL_SECONDS,
+    daemon_pass_is_idle,
+    log_daemon_pass_result,
+)
 from ..task_sources.taskboard_store import (
     ProjectionDeltaCheckpointStore,
     locked_taskboard,
@@ -50839,9 +50844,23 @@ def main(argv: list[str] | None = None) -> None:
             if not result.get("cleared") and not result.get("already_clear"):
                 raise SystemExit(2)
             return
+        last_idle_info_at: float | None = None
         while True:
             result = daemon.run_once()
-            logger.info("Portal implementation daemon pass complete: %s", result)
+            now = time.monotonic()
+            emit_idle_info = (
+                bool(args.once)
+                or last_idle_info_at is None
+                or now - last_idle_info_at >= IDLE_DAEMON_PASS_LOG_INTERVAL_SECONDS
+            )
+            log_daemon_pass_result(
+                logger,
+                "Portal implementation daemon pass complete: %s",
+                result,
+                emit_idle_info=emit_idle_info,
+            )
+            if daemon_pass_is_idle(result) and emit_idle_info:
+                last_idle_info_at = now
             if args.once:
                 break
             daemon.wait_for_wake(timeout=args.interval)

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon_runner.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon_runner.py
@@ -24,6 +24,54 @@ from ..runtime.event_log import append_jsonl_event
 
 DAEMON_HOOK_TIMEOUT_ENV = "IPFS_ACCELERATE_AGENT_DAEMON_HOOK_TIMEOUT_SECONDS"
 DEFAULT_DAEMON_HOOK_TIMEOUT_SECONDS = 60.0
+IDLE_DAEMON_PASS_LOG_INTERVAL_SECONDS = 300.0
+
+
+def daemon_pass_is_idle(result: Mapping[str, Any]) -> bool:
+    """Return whether a pass made no durable or implementation progress."""
+
+    return (
+        result.get("unchanged") is True
+        and int(result.get("write_count", 0) or 0) == 0
+        and not result.get("implementation_result")
+        and not result.get("merge_reconciliation")
+        and not result.get("completion_receipt_writes")
+        and not result.get("retry_budget_resets")
+    )
+
+
+def compact_daemon_pass_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the bounded operator heartbeat used for an idle daemon pass."""
+
+    keys = (
+        "task_count",
+        "completed_count",
+        "ready_count",
+        "blocked_count",
+        "active_task_id",
+        "selection_idle_reason",
+        "source_digest",
+        "wake_kinds",
+        "requirement_id",
+    )
+    return {key: result[key] for key in keys if key in result}
+
+
+def log_daemon_pass_result(
+    logger: logging.Logger,
+    pass_complete_message: str,
+    result: Mapping[str, Any],
+    *,
+    emit_idle_info: bool,
+) -> None:
+    """Log changed passes in full and throttle bounded summaries for idle passes."""
+
+    if not daemon_pass_is_idle(result):
+        logger.info(pass_complete_message, result)
+        return
+    logger.debug("Full idle daemon pass result: %s", result)
+    if emit_idle_info:
+        logger.info(pass_complete_message, compact_daemon_pass_result(result))
 
 
 def bounded_daemon_wait_timeout(
@@ -1255,6 +1303,7 @@ def run_portal_implementation_daemon_loop(
     )
     effective_hooks = () if authority_revalidation_only else hooks
     pass_index = 0
+    last_idle_info_at: float | None = None
     try:
         while True:
             pass_context = context.for_pass(pass_index)
@@ -1271,7 +1320,20 @@ def run_portal_implementation_daemon_loop(
                 context=pass_context,
                 logger=logger,
             )
-            logger.info(pass_complete_message, result)
+            now = time.monotonic()
+            emit_idle_info = (
+                bool(parsed.once)
+                or last_idle_info_at is None
+                or now - last_idle_info_at >= IDLE_DAEMON_PASS_LOG_INTERVAL_SECONDS
+            )
+            log_daemon_pass_result(
+                logger,
+                pass_complete_message,
+                result,
+                emit_idle_info=emit_idle_info,
+            )
+            if daemon_pass_is_idle(result) and emit_idle_info:
+                last_idle_info_at = now
             if parsed.once:
                 break
             pass_index += 1

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
@@ -1188,6 +1188,7 @@ class PortalSupervisorConfig:
     objective_scan_min_open_tasks: int = 0
     objective_scan_max_findings: int = 5
     objective_scan_cooldown_seconds: int = 21600
+    objective_scan_exclude_paths: tuple[str, ...] = field(default_factory=tuple)
     objective_refill_timeout_seconds: float = 0.0
     objective_scan_depends_on: tuple[str, ...] = field(default_factory=tuple)
     objective_max_refinement_children: int = 3
@@ -10264,6 +10265,10 @@ class PortalImplementationSupervisor:
                 "IPFS_ACCELERATE_COMPLETION_EVIDENCE_PATH": str(
                     evidence_path if evidence_path is not None else ""
                 ),
+                "IPFS_ACCELERATE_COMPLETION_SCAN_EXCLUDE_PATHS": json.dumps(
+                    list(self.config.objective_scan_exclude_paths),
+                    separators=(",", ":"),
+                ),
             }
         )
         started_at = utc_now()
@@ -10367,6 +10372,7 @@ class PortalImplementationSupervisor:
             completion_evidence_records=evidence_records,
             completion_gate_records=gate_records,
             completion_control_paths=control_paths,
+            scan_exclude_paths=self.config.objective_scan_exclude_paths,
             require_artifact_binding=bool(control_paths),
         )
         return {
@@ -11448,6 +11454,7 @@ class PortalImplementationSupervisor:
                 self.config.objective_summary_prefix or DEFAULT_OBJECTIVE_TASK_SUMMARY_PREFIX
             ),
             discovery_output_path=discovery_output_path,
+            scan_exclude_path=list(self.config.objective_scan_exclude_paths),
             depends_on=list(self.config.objective_scan_depends_on),
             seen_fingerprint=sorted(seen_fingerprints),
             force_goal_id=sorted(set(force_goal_ids)),
@@ -14257,6 +14264,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--objective-scan-max-findings", type=int, default=5)
     parser.add_argument("--objective-scan-cooldown-seconds", type=int, default=21600)
     parser.add_argument(
+        "--objective-scan-exclude-path",
+        action="append",
+        default=[],
+        help=(
+            "Repo-relative operational or control path excluded from objective "
+            "evidence scans and completion-tree identity. May be repeated or "
+            "comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--objective-refill-timeout-seconds",
         type=float,
         default=0.0,
@@ -14524,6 +14541,9 @@ def supervisor_config_from_args(
         objective_scan_min_open_tasks=args.objective_scan_min_open_tasks,
         objective_scan_max_findings=args.objective_scan_max_findings,
         objective_scan_cooldown_seconds=args.objective_scan_cooldown_seconds,
+        objective_scan_exclude_paths=split_csv_values(
+            args.objective_scan_exclude_path
+        ),
         objective_refill_timeout_seconds=args.objective_refill_timeout_seconds,
         objective_scan_depends_on=split_csv_values(args.objective_scan_depends_on),
         objective_max_refinement_children=args.objective_max_refinement_children,

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
@@ -10391,6 +10391,59 @@ class PortalImplementationSupervisor:
             callback=callback,
         )
 
+    def _cached_disabled_scan_identity(
+        self,
+        *,
+        scan_mode: str,
+        analyzer_version: str,
+    ) -> Mapping[str, str] | None:
+        """Reuse a prior non-evidentiary identity for an unchanged disabled scan.
+
+        A disabled scanner reports configuration state and is never safe for
+        completion reasoning.  Recomputing the dirty repository identity for
+        that same report can be expensive in long-running supervisors with
+        large generated-state directories.  The persisted projection already
+        supplies the exact identity whose receipt will be reused by
+        ``persist_supervisor_scan_receipt``.
+        """
+
+        if scan_mode != "disabled":
+            return None
+        strategy = load_json_dict(self.config.strategy_path) or {}
+        per_kind = strategy.get("scan_receipts")
+        if not isinstance(per_kind, Mapping):
+            return None
+        for kind_state in per_kind.values():
+            if not isinstance(kind_state, Mapping):
+                continue
+            projection = kind_state.get("latest_attempted_scan")
+            if not isinstance(projection, Mapping):
+                continue
+            if (
+                str(projection.get("terminal_reason") or "") != "disabled"
+                or str(projection.get("scan_mode") or "") != scan_mode
+                or str(projection.get("analyzer_version") or "")
+                != analyzer_version
+                or projection.get("safe_for_completion_reasoning") is not False
+            ):
+                continue
+            repository_id = str(
+                projection.get("repository_id")
+                or projection.get("repository_identity")
+                or ""
+            ).strip()
+            tree_id = str(
+                projection.get("tree_id")
+                or projection.get("tree_identity")
+                or ""
+            ).strip()
+            if repository_id and tree_id:
+                return {
+                    "repository_id": repository_id,
+                    "tree_id": tree_id,
+                }
+        return None
+
     def _terminal_refill_result(
         self,
         reason: ScanTerminalReason,
@@ -10405,6 +10458,13 @@ class PortalImplementationSupervisor:
     ) -> RefillScanResult:
         """Build a repository-bound refill receipt for supervisor-owned scans."""
 
+        identity = None
+        reason_value = reason.value if isinstance(reason, ScanTerminalReason) else str(reason)
+        if reason_value == ScanTerminalReason.DISABLED.value:
+            identity = self._cached_disabled_scan_identity(
+                scan_mode=scan_mode,
+                analyzer_version=analyzer_version,
+            )
         return build_scan_result(
             reason,
             scan_mode,
@@ -10415,6 +10475,7 @@ class PortalImplementationSupervisor:
             safe_for_completion_reasoning=safe_for_completion_reasoning,
             error=error,
             metadata=metadata,
+            identity=identity,
         )
 
     def _persist_refill_result(

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor_runner.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor_runner.py
@@ -434,6 +434,42 @@ def persist_supervisor_scan_receipt(
 ) -> dict[str, Any]:
     """Persist one refill result and publish its compact state projection."""
 
+    try:
+        strategy_payload = json.loads(strategy_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        strategy_payload = {}
+    if not isinstance(strategy_payload, dict):
+        strategy_payload = {}
+    per_kind = strategy_payload.get("scan_receipts")
+    kind_state = (
+        per_kind.get(scan_kind)
+        if isinstance(per_kind, Mapping)
+        else None
+    )
+    prior_projection = (
+        kind_state.get("latest_attempted_scan")
+        if isinstance(kind_state, Mapping)
+        else None
+    )
+    # A disabled scanner reports configuration state, not an observation
+    # about repository contents. Re-emitting that state on every maintenance
+    # pass made the receipt itself change the dirty-tree identity, which then
+    # produced another distinct receipt on the next pass. Retain the first
+    # content-addressed receipt per analyzer/kind and reuse its projection
+    # until scanning is enabled or the analyzer configuration changes.
+    if (
+        result.terminal_reason.value == "disabled"
+        and isinstance(prior_projection, Mapping)
+        and str(prior_projection.get("terminal_reason") or "") == "disabled"
+        and str(prior_projection.get("scan_kind") or "") == str(scan_kind)
+        and str(prior_projection.get("scan_mode") or "") == result.scan_mode
+        and str(prior_projection.get("analyzer_version") or "")
+        == result.analyzer_version
+        and int(prior_projection.get("generated_count") or 0) == 0
+        and prior_projection.get("safe_for_completion_reasoning") is False
+    ):
+        return dict(prior_projection)
+
     projection = append_scan_receipt_event(
         events_path,
         result,
@@ -441,12 +477,6 @@ def persist_supervisor_scan_receipt(
         scan_kind=scan_kind,
         relative_to=state_dir,
     )
-    try:
-        strategy_payload = json.loads(strategy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        strategy_payload = {}
-    if not isinstance(strategy_payload, dict):
-        strategy_payload = {}
     _write_json_atomic(
         strategy_path,
         apply_scan_receipt_projection(strategy_payload, projection),

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor_runner.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor_runner.py
@@ -1181,6 +1181,7 @@ class ObjectiveRefillDefaults:
     objective_scan_min_open_tasks: int | None = None
     objective_scan_max_findings: int | None = None
     objective_scan_cooldown_seconds: int | None = None
+    objective_scan_exclude_paths: Sequence[str] = ()
     objective_refill_timeout_seconds: int | None = None
     objective_todo_vector_index_path: Path | None = None
     objective_surplus_findings_per_goal: int | None = None
@@ -1234,6 +1235,7 @@ def build_objective_refill_defaults_from_paths(
     objective_scan_min_open_tasks: int | None = None,
     objective_scan_max_findings: int | None = None,
     objective_scan_cooldown_seconds: int | None = None,
+    objective_scan_exclude_paths: Sequence[str] = (),
     objective_refill_timeout_seconds: int | None = None,
     objective_todo_vector_index_path_key: str | None = None,
     objective_todo_vector_index_path: Path | str | None = None,
@@ -1285,6 +1287,7 @@ def build_objective_refill_defaults_from_paths(
         objective_scan_min_open_tasks=objective_scan_min_open_tasks,
         objective_scan_max_findings=objective_scan_max_findings,
         objective_scan_cooldown_seconds=objective_scan_cooldown_seconds,
+        objective_scan_exclude_paths=objective_scan_exclude_paths,
         objective_refill_timeout_seconds=objective_refill_timeout_seconds,
         objective_todo_vector_index_path=_optional_path_from_mapping(
             paths,
@@ -1396,6 +1399,7 @@ def build_objective_refill_defaults_factory(
     objective_scan_min_open_tasks: int | None = None,
     objective_scan_max_findings: int | None = None,
     objective_scan_cooldown_seconds: int | None = None,
+    objective_scan_exclude_paths: Sequence[str] = (),
     objective_refill_timeout_seconds: int | None = None,
     objective_todo_vector_index_path_key: str | None = None,
     objective_todo_vector_index_path: Path | str | None = None,
@@ -1442,6 +1446,7 @@ def build_objective_refill_defaults_factory(
             objective_scan_min_open_tasks=objective_scan_min_open_tasks,
             objective_scan_max_findings=objective_scan_max_findings,
             objective_scan_cooldown_seconds=objective_scan_cooldown_seconds,
+            objective_scan_exclude_paths=objective_scan_exclude_paths,
             objective_refill_timeout_seconds=objective_refill_timeout_seconds,
             objective_todo_vector_index_path_key=objective_todo_vector_index_path_key,
             objective_todo_vector_index_path=objective_todo_vector_index_path,
@@ -1528,6 +1533,7 @@ def build_namespace_objective_refill_defaults_factory(
     objective_scan_min_open_tasks: int | None = None,
     objective_scan_max_findings: int | None = None,
     objective_scan_cooldown_seconds: int | None = None,
+    objective_scan_exclude_paths: Sequence[str] = (),
     objective_refill_timeout_seconds: int | None = None,
     objective_surplus_findings_per_goal: int | None = None,
     objective_surplus_min_terms_per_todo: int | None = None,
@@ -1574,6 +1580,7 @@ def build_namespace_objective_refill_defaults_factory(
         objective_scan_min_open_tasks=objective_scan_min_open_tasks,
         objective_scan_max_findings=objective_scan_max_findings,
         objective_scan_cooldown_seconds=objective_scan_cooldown_seconds,
+        objective_scan_exclude_paths=objective_scan_exclude_paths,
         objective_refill_timeout_seconds=objective_refill_timeout_seconds,
         objective_surplus_findings_per_goal=objective_surplus_findings_per_goal,
         objective_surplus_min_terms_per_todo=objective_surplus_min_terms_per_todo,
@@ -1734,6 +1741,12 @@ def apply_portal_implementation_supervisor_defaults(
             "--objective-scan-cooldown-seconds",
             objective.objective_scan_cooldown_seconds,
         )
+        if objective.objective_scan_exclude_paths:
+            args = with_repeated_default(
+                args,
+                "--objective-scan-exclude-path",
+                objective.objective_scan_exclude_paths,
+            )
         args = _with_optional_default(
             args,
             "--objective-refill-timeout-seconds",

--- a/test/api/test_agent_supervisor_implementation_daemon_runner.py
+++ b/test/api/test_agent_supervisor_implementation_daemon_runner.py
@@ -694,6 +694,66 @@ def test_run_portal_implementation_daemon_loop_suppresses_hooks_for_revalidation
 
     assert calls == ["run_once"]
 
+def test_idle_daemon_pass_logging_is_compact_and_throttled(caplog):
+    from ipfs_accelerate_py.agent_supervisor.todo_daemon.implementation_daemon_runner import (
+        log_daemon_pass_result,
+    )
+
+    result = {
+        "task_count": 51,
+        "completed_count": 41,
+        "ready_count": 0,
+        "blocked_count": 10,
+        "selection_idle_reason": "no_shard_selectable_ready_tasks",
+        "unchanged": True,
+        "write_count": 0,
+        "implementation_result": None,
+        "merge_reconciliation": [],
+        "completion_receipt_writes": [],
+        "retry_budget_resets": [],
+        "large_diagnostic": "x" * 10_000,
+    }
+    logger = logging.getLogger("test-idle-daemon-pass-logging")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        log_daemon_pass_result(
+            logger,
+            "pass complete: %s",
+            result,
+            emit_idle_info=True,
+        )
+        log_daemon_pass_result(
+            logger,
+            "pass complete: %s",
+            result,
+            emit_idle_info=False,
+        )
+
+    assert caplog.text.count("pass complete:") == 1
+    assert "no_shard_selectable_ready_tasks" in caplog.text
+    assert "large_diagnostic" not in caplog.text
+
+
+def test_changed_daemon_pass_logging_keeps_full_diagnostics(caplog):
+    from ipfs_accelerate_py.agent_supervisor.todo_daemon.implementation_daemon_runner import (
+        log_daemon_pass_result,
+    )
+
+    result = {
+        "unchanged": False,
+        "write_count": 1,
+        "implementation_result": {"task_id": "KGP-001"},
+    }
+    logger = logging.getLogger("test-changed-daemon-pass-logging")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        log_daemon_pass_result(
+            logger,
+            "pass complete: %s",
+            result,
+            emit_idle_info=False,
+        )
+
+    assert "KGP-001" in caplog.text
+
 
 def test_run_configured_portal_implementation_daemon_builds_and_runs_once(tmp_path: Path):
     board = tmp_path / "tasks.todo.md"

--- a/test/api/test_agent_supervisor_implementation_supervisor_runner.py
+++ b/test/api/test_agent_supervisor_implementation_supervisor_runner.py
@@ -78,6 +78,7 @@ def test_apply_portal_implementation_supervisor_defaults_preserves_user_values(t
             objective_scan_min_open_tasks=3,
             objective_scan_max_findings=7,
             objective_scan_cooldown_seconds=60,
+            objective_scan_exclude_paths=("data/state", "var/runtime"),
             objective_todo_vector_index_path=tmp_path / "bundles" / "todo_vector_index.json",
             objective_surplus_findings_per_goal=4,
             objective_surplus_min_terms_per_todo=2,
@@ -115,6 +116,7 @@ def test_apply_portal_implementation_supervisor_defaults_preserves_user_values(t
     assert parsed.todo_path == tmp_path / "tasks.todo.md"
     assert parsed.state_prefix == "custom"
     assert parsed.objective_scan_max_findings == 99
+    assert parsed.objective_scan_exclude_path == ["data/state", "var/runtime"]
     assert parsed.objective_goal_migration_preview is True
     assert parsed.objective_goal_migration_batch_size == 7
     assert parsed.objective_goal_completion_gate_path == tmp_path / "completion-gate.json"

--- a/test/api/test_agent_supervisor_implementation_supervisor_runner.py
+++ b/test/api/test_agent_supervisor_implementation_supervisor_runner.py
@@ -448,6 +448,51 @@ def test_persist_supervisor_scan_receipt_keeps_strategy_projection_compact(tmp_p
     assert marker in Path(state_dir / generated_projection["artifact_path"]).read_text(encoding="utf-8")
 
 
+def test_persist_supervisor_scan_receipt_deduplicates_disabled_maintenance(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / "state"
+    strategy_path = state_dir / "example_strategy.json"
+    events_path = state_dir / "example_supervisor_events.jsonl"
+    first = _scan_result(ScanTerminalReason.DISABLED)
+    first = RefillScanResult(
+        **{
+            **first.__dict__,
+            "scan_mode": "disabled",
+        }
+    )
+    second = RefillScanResult(
+        terminal_reason=ScanTerminalReason.DISABLED,
+        scan_mode="disabled",
+        analyzer_version=first.analyzer_version,
+        repository_id=first.repository_id,
+        tree_id="tree-changed-by-supervisor-artifacts",
+        started_at=first.finished_at + timedelta(seconds=1),
+        finished_at=first.finished_at + timedelta(seconds=2),
+    )
+
+    first_projection = persist_supervisor_scan_receipt(
+        first,
+        scan_kind="codebase",
+        state_dir=state_dir,
+        state_prefix="example",
+        strategy_path=strategy_path,
+        events_path=events_path,
+    )
+    second_projection = persist_supervisor_scan_receipt(
+        second,
+        scan_kind="codebase",
+        state_dir=state_dir,
+        state_prefix="example",
+        strategy_path=strategy_path,
+        events_path=events_path,
+    )
+
+    assert second_projection == first_projection
+    assert len(list((state_dir / "example_scan_receipts").glob("*.json"))) == 1
+    assert len(events_path.read_text(encoding="utf-8").splitlines()) == 1
+
+
 def test_goal_completion_projection_updates_strategy_and_live_status(tmp_path: Path):
     state_dir = tmp_path / "state"
     state_dir.mkdir()

--- a/test/api/test_agent_supervisor_todo_daemon_port.py
+++ b/test/api/test_agent_supervisor_todo_daemon_port.py
@@ -22263,6 +22263,73 @@ def test_implementation_supervisor_forwards_scan_exclusions_to_completion_reconc
     assert captured["scan_exclude_paths"] == ("state", "var/runtime")
 
 
+def test_disabled_refills_reuse_prior_identity_without_rescanning_repo(
+    tmp_path,
+    monkeypatch,
+):
+    from ipfs_accelerate_py.agent_supervisor.objectives import scan_receipts
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_dir = repo / "state"
+    state_dir.mkdir()
+    todo_path = repo / "todo.md"
+    todo_path.write_text("# Drained board\n", encoding="utf-8")
+    strategy_path = state_dir / "strategy.json"
+    strategy_path.write_text(
+        json.dumps(
+            {
+                "scan_receipts": {
+                    "objective": {
+                        "latest_attempted_scan": {
+                            "terminal_reason": "disabled",
+                            "scan_mode": "disabled",
+                            "analyzer_version": "objective-daemon-v1",
+                            "repository_id": "cached-repository",
+                            "tree_id": "cached-objective-tree",
+                            "safe_for_completion_reasoning": False,
+                        }
+                    },
+                    "codebase": {
+                        "latest_attempted_scan": {
+                            "terminal_reason": "disabled",
+                            "scan_mode": "disabled",
+                            "analyzer_version": "codebase-scan-v1",
+                            "repository_id": "cached-repository",
+                            "tree_id": "cached-codebase-tree",
+                            "safe_for_completion_reasoning": False,
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        scan_receipts,
+        "scan_identity",
+        lambda _repo: pytest.fail("disabled refill must not rescan repository"),
+    )
+    supervisor = TodoImplementationSupervisor(
+        TodoSupervisorConfig(
+            todo_path=todo_path,
+            state_path=state_dir / "task_state.json",
+            strategy_path=strategy_path,
+            events_path=state_dir / "events.jsonl",
+            state_dir=state_dir,
+            repo_root=repo,
+        )
+    )
+
+    objective = supervisor.refill_objective_backlog()
+    codebase = supervisor.refill_codebase_backlog()
+
+    assert objective.tree_id == "cached-objective-tree"
+    assert codebase.tree_id == "cached-codebase-tree"
+    assert objective.safe_for_completion_reasoning is False
+    assert codebase.safe_for_completion_reasoning is False
+
+
 def test_disabled_objective_janitor_ignores_stale_force_goal_ids(
     tmp_path,
     monkeypatch,

--- a/test/api/test_agent_supervisor_todo_daemon_port.py
+++ b/test/api/test_agent_supervisor_todo_daemon_port.py
@@ -13208,6 +13208,30 @@ def test_resource_claim_deferral_passes_do_not_grow_state_or_events(
     assert holder._release_implementation_resource_claims(holder_claims)
 
 
+def test_validation_cache_bookkeeping_does_not_wake_idle_daemon(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    todo_path = repo / "todo.md"
+    todo_path.write_text("# Agent Todos\n", encoding="utf-8")
+    cache_dir = repo / "shared-validation-cache"
+    cache_dir.mkdir()
+    daemon = TodoImplementationDaemon(
+        todo_path=todo_path,
+        state_path=repo / "state" / "task_state.json",
+        strategy_path=repo / "state" / "strategy.json",
+        events_path=repo / "state" / "events.jsonl",
+        repo_root=repo,
+        validation_cache_dir=cache_dir,
+    )
+
+    before, _ = daemon._runtime_source_head()
+    (cache_dir / "single-flight.sqlite3-journal").write_bytes(b"bookkeeping")
+    after, sources = daemon._runtime_source_head()
+
+    assert sources["validation"] == []
+    assert after == before
+
+
 def test_implementation_resource_claims_preserve_disjoint_submodule_parallelism(
     tmp_path,
     monkeypatch,

--- a/test/api/test_agent_supervisor_todo_daemon_port.py
+++ b/test/api/test_agent_supervisor_todo_daemon_port.py
@@ -3760,6 +3760,10 @@ def test_supervisor_config_from_args_applies_embedding_overrides(tmp_path):
             "hallucinate_app,swissknife",
             "--objective-interoperability-component-path",
             "hallucinate_app, external/ipfs_accelerate",
+            "--objective-scan-exclude-path",
+            "data/state",
+            "--objective-scan-exclude-path",
+            "var/runtime,logs",
             "--no-worktree-reconciliation",
             "--worktree-reconciliation-max-merges",
             "3",
@@ -3815,6 +3819,11 @@ def test_supervisor_config_from_args_applies_embedding_overrides(tmp_path):
     assert config.objective_interoperability_component_paths == (
         "hallucinate_app",
         "external/ipfs_accelerate",
+    )
+    assert config.objective_scan_exclude_paths == (
+        "data/state",
+        "var/runtime",
+        "logs",
     )
 
 
@@ -22163,6 +22172,7 @@ def test_implementation_supervisor_forwards_completion_paths_and_generation_cap(
         captured["generation_max_new_work"] = (
             args.objective_generation_max_new_work
         )
+        captured["scan_exclude_path"] = args.scan_exclude_path
         return {"generated_count": 0, "task_ids": []}
 
     monkeypatch.setattr(
@@ -22182,6 +22192,7 @@ def test_implementation_supervisor_forwards_completion_paths_and_generation_cap(
             objective_path=objective_path,
             objective_scan_min_open_tasks=0,
             objective_scan_max_findings=6,
+            objective_scan_exclude_paths=("state", "var/runtime"),
             objective_goal_completion_gate_path=gate_path,
             objective_goal_completion_evidence_path=evidence_path,
             objective_persist_ast_dataset=False,
@@ -22195,7 +22206,61 @@ def test_implementation_supervisor_forwards_completion_paths_and_generation_cap(
         "evidence_path": evidence_path,
         "generation_path": state_dir.parent / "objective_generation.json",
         "generation_max_new_work": 6,
+        "scan_exclude_path": ["state", "var/runtime"],
     }
+
+
+def test_implementation_supervisor_forwards_scan_exclusions_to_completion_reconciler(
+    tmp_path,
+    monkeypatch,
+):
+    from ipfs_accelerate_py.agent_supervisor.objectives import objective_tracker
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    objective_path = repo / "objective.md"
+    objective_path.write_text(
+        "## G1 Goal\n\n- Status: provisionally_complete\n- Acceptance: criterion\n",
+        encoding="utf-8",
+    )
+    todo_path = repo / "todo.md"
+    todo_path.write_text("# Drained board\n", encoding="utf-8")
+    state_dir = repo / "state"
+    captured = {}
+
+    def capture_reconcile(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            completed_goal_ids=(),
+            completed_goal_count=0,
+            validation_results={},
+            decisions={},
+        )
+
+    monkeypatch.setattr(
+        objective_tracker,
+        "reconcile_objective_goal_completion",
+        capture_reconcile,
+    )
+    supervisor = TodoImplementationSupervisor(
+        TodoSupervisorConfig(
+            todo_path=todo_path,
+            state_path=state_dir / "task_state.json",
+            strategy_path=state_dir / "strategy.json",
+            events_path=state_dir / "events.jsonl",
+            state_dir=state_dir,
+            repo_root=repo,
+            objective_path=objective_path,
+            objective_scan_exclude_paths=("state", "var/runtime"),
+        )
+    )
+
+    result = supervisor._reconcile_objective_goal_completion_artifacts(
+        objective_path=objective_path,
+    )
+
+    assert result["attempted"] is True
+    assert captured["scan_exclude_paths"] == ("state", "var/runtime")
 
 
 def test_disabled_objective_janitor_ignores_stale_force_goal_ids(
@@ -22381,6 +22446,7 @@ def test_completion_artifact_refresh_is_explicit_argv_without_shell(
                 "python refresh_completion.py --mode docs"
             ),
             objective_goal_completion_artifact_refresh_timeout_seconds=17,
+            objective_scan_exclude_paths=("state", "var/runtime"),
         )
     )
 
@@ -22403,6 +22469,11 @@ def test_completion_artifact_refresh_is_explicit_argv_without_shell(
         captured["kwargs"]["env"]["IPFS_ACCELERATE_COMPLETION_EVIDENCE_PATH"]
         == str((state_dir / "evidence.json").resolve())
     )
+    assert json.loads(
+        captured["kwargs"]["env"][
+            "IPFS_ACCELERATE_COMPLETION_SCAN_EXCLUDE_PATHS"
+        ]
+    ) == ["state", "var/runtime"]
 
 
 def test_completion_artifact_refresh_wraps_launch_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Cherry-picks the unique worktree commits from `codex/agent-supervisor-proof-carrying-test-reuse-plan` onto current `origin/main`.

### Included
- Docs: proof-carrying test reuse plan / objectives / todo
- Deduplicate disabled scan receipts
- Bind objective scan exclusions
- Reuse disabled scan identity (perf)
- Ignore cache bookkeeping wakes (perf)
- Throttle idle pass diagnostics (perf; conflict-resolved onto revalidation-only hooks path)

### Intentionally omitted
- `fix(agent-supervisor): unblock reconciliation and Profile-G lanes` — superseded on main by `_profile_g_task_spec_attempt_limit` and stronger reconciliation assertions

## Test plan
- [ ] CI green
- [ ] `test_idle_daemon_pass_logging_is_compact_and_throttled`
- [ ] `test_run_portal_implementation_daemon_loop_suppresses_hooks_for_revalidation_only`