### PR TITLE
fix(accelerate): package-root cold-import surface

### DIFF
--- a/ipfs_accelerate_py/__init__.py
+++ b/ipfs_accelerate_py/__init__.py
@@ -1,285 +1,566 @@
-"""
-IPFS Accelerate Python package.
+"""IPFS Accelerate Python package.
 
-This package provides a framework for hardware-accelerated machine learning inference
-with IPFS network-based distribution and acceleration. Key features include:
-
-- Hardware acceleration (CPU, GPU, OpenVINO, WebNN, WebGPU)
-- IPFS-based content distribution and caching
-- Browser integration for client-side inference
-- Model type detection and optimization
-- Cross-platform support
+The package root is intentionally a discovery surface, not an initialization
+surface.  Optional implementations are imported only when a public attribute
+is explicitly requested.  This keeps pytest plugins and other lightweight
+subpackages safe to import in environments without accelerator providers.
 """
+
+from __future__ import annotations
 
 import importlib
 import os
 import sys
 import threading
-from pathlib import Path
+import time
 from types import ModuleType
+from typing import Any
+
 
 SKIP_CORE = os.environ.get("IPFS_ACCEL_SKIP_CORE", "0") == "1"
 
-# HF Space transport symbols historically imported requests at package root.
-# Keep them lazy so Planner/Doctor cold discovery never loads network clients.
-_HF_SPACE_EXPORT_NAMES = frozenset(
+_UNRESOLVED = object()
+_GROUP_LOCK = threading.RLock()
+_GROUP_LOADING: set[str] = set()
+_GROUP_RESOLVED: set[str] = set()
+_GROUP_FAILED_AT: dict[str, float] = {}
+_GROUP_FAILED_MODULE_STATE: dict[str, tuple[tuple[str, bool], ...]] = {}
+_PUBLIC_VALUES: dict[str, Any] = {}
+_PUBLIC_RESOLVED: set[str] = set()
+_FAILED_GROUP_RETRY_SECONDS = 0.25
+
+
+# Each entry names the implementation module and attribute.  ``None`` means
+# the module itself is the historical public value.
+_GROUP_MEMBERS: dict[str, dict[str, tuple[str, str | None]]] = {
+    "hf_space": {
+        "EndpointContract": (".hf_space_inference", "EndpointContract"),
+        "SpaceRuntimeInfo": (".hf_space_inference", "SpaceRuntimeInfo"),
+        "OutputBackend": (".hf_space_inference", "OutputBackend"),
+        "LocalFileSystemBackend": (
+            ".hf_space_inference",
+            "LocalFileSystemBackend",
+        ),
+        "HFBucketBackend": (".hf_space_inference", "HFBucketBackend"),
+        "HFBucketBackendError": (
+            ".hf_space_inference",
+            "HFBucketBackendError",
+        ),
+        "HFSpaceClient": (".hf_space_inference", "HFSpaceClient"),
+        "RefreshableGradioFile": (
+            ".hf_space_inference",
+            "RefreshableGradioFile",
+        ),
+        "BatchState": (".hf_space_inference", "BatchState"),
+        "BatchProcessor": (".hf_space_inference", "BatchProcessor"),
+        "is_hf_space_transport_error": (
+            ".hf_space_inference",
+            "is_hf_space_transport_error",
+        ),
+        "is_retryable_hf_space_error": (
+            ".hf_space_inference",
+            "is_retryable_hf_space_error",
+        ),
+        "is_stale_gradio_file_error": (
+            ".hf_space_inference",
+            "is_stale_gradio_file_error",
+        ),
+        "normalize_api_name": (".hf_space_inference", "normalize_api_name"),
+    },
+    "backends": {
+        "backends": (".container_backends", "backends"),
+    },
+    "install_depends": {
+        "install_depends": (".install_depends.install_depends", None),
+    },
+    "core": {
+        "ipfs_accelerate_py": (".ipfs_accelerate", "ipfs_accelerate_py"),
+    },
+    "multiformats": {
+        "ipfs_multiformats_py": (
+            ".ipfs_multiformats",
+            "ipfs_multiformats_py",
+        ),
+    },
+    "config": {
+        "config": (".config.config", "config"),
+    },
+    "webnn": {
+        "accelerate_with_browser": (
+            ".webnn_webgpu_integration",
+            "accelerate_with_browser",
+        ),
+        "WebNNWebGPUAccelerator": (
+            ".webnn_webgpu_integration",
+            "WebNNWebGPUAccelerator",
+        ),
+        "get_accelerator": (
+            ".webnn_webgpu_integration",
+            "get_accelerator",
+        ),
+    },
+    "model_manager": {
+        "ModelManager": (".model_manager", "ModelManager"),
+        "get_default_model_manager": (
+            ".model_manager",
+            "get_default_model_manager",
+        ),
+    },
+    "logs": {
+        "get_system_logs": (".logs", "get_system_logs"),
+        "SystemLogs": (".logs", "SystemLogs"),
+    },
+    "p2p_workflow": {
+        "P2PWorkflowScheduler": (
+            ".p2p_workflow_scheduler",
+            "P2PWorkflowScheduler",
+        ),
+        "P2PTask": (".p2p_workflow_scheduler", "P2PTask"),
+        "WorkflowTag": (".p2p_workflow_scheduler", "WorkflowTag"),
+        "MerkleClock": (".p2p_workflow_scheduler", "MerkleClock"),
+        "FibonacciHeap": (".p2p_workflow_scheduler", "FibonacciHeap"),
+        "calculate_hamming_distance": (
+            ".p2p_workflow_scheduler",
+            "calculate_hamming_distance",
+        ),
+    },
+    "ipfs_kit": {
+        "IPFSKitStorage": (".ipfs_kit_integration", "IPFSKitStorage"),
+        "get_storage": (".ipfs_kit_integration", "get_storage"),
+        "reset_storage": (".ipfs_kit_integration", "reset_storage"),
+        "StorageBackendConfig": (
+            ".ipfs_kit_integration",
+            "StorageBackendConfig",
+        ),
+    },
+    "backend_manager": {
+        "InferenceBackendManager": (
+            ".inference_backend_manager",
+            "InferenceBackendManager",
+        ),
+        "get_backend_manager": (
+            ".inference_backend_manager",
+            "get_backend_manager",
+        ),
+        "register_backend_from_config": (
+            ".inference_backend_manager",
+            "register_backend_from_config",
+        ),
+    },
+    "auto_patch": {
+        "auto_patch_transformers": (".auto_patch_transformers", None),
+    },
+    "llm_router": {
+        "generate_text": (".llm_router", "generate_text"),
+        "get_llm_provider": (".llm_router", "get_llm_provider"),
+        "register_llm_provider": (".llm_router", "register_llm_provider"),
+        "clear_llm_router_caches": (
+            ".llm_router",
+            "clear_llm_router_caches",
+        ),
+        "LLMProvider": (".llm_router", "LLMProvider"),
+        "MistralVibeInstallResult": (
+            ".llm_router",
+            "MistralVibeInstallResult",
+        ),
+        "ensure_mistral_vibe": (".llm_router", "ensure_mistral_vibe"),
+        "RouterDeps": (".router_deps", "RouterDeps"),
+        "get_default_router_deps": (
+            ".router_deps",
+            "get_default_router_deps",
+        ),
+        "set_default_router_deps": (
+            ".router_deps",
+            "set_default_router_deps",
+        ),
+    },
+    "embeddings_router": {
+        "embed_texts": (".embeddings_router", "embed_texts"),
+        "embed_texts_batched": (
+            ".embeddings_router",
+            "embed_texts_batched",
+        ),
+        "embed_text": (".embeddings_router", "embed_text"),
+        "get_embeddings_provider": (
+            ".embeddings_router",
+            "get_embeddings_provider",
+        ),
+        "get_embedding_progress": (
+            ".embeddings_router",
+            "get_embedding_progress",
+        ),
+        "get_last_embedding_trace": (
+            ".embeddings_router",
+            "get_last_embedding_trace",
+        ),
+        "register_embeddings_provider": (
+            ".embeddings_router",
+            "register_embeddings_provider",
+        ),
+        "clear_embeddings_router_caches": (
+            ".embeddings_router",
+            "clear_embeddings_router_caches",
+        ),
+        "EmbeddingsRouterError": (
+            ".embeddings_router",
+            "EmbeddingsRouterError",
+        ),
+        "EmbeddingsProvider": (
+            ".embeddings_router",
+            "EmbeddingsProvider",
+        ),
+    },
+    "multimodal_router": {
+        "generate_multimodal": (
+            ".multimodal_router",
+            "generate_multimodal",
+        ),
+        "get_multimodal_provider": (
+            ".multimodal_router",
+            "get_multimodal_provider",
+        ),
+        "register_multimodal_provider": (
+            ".multimodal_router",
+            "register_multimodal_provider",
+        ),
+        "clear_multimodal_router_caches": (
+            ".multimodal_router",
+            "clear_multimodal_router_caches",
+        ),
+        "MultimodalProvider": (
+            ".multimodal_router",
+            "MultimodalProvider",
+        ),
+    },
+    "voice_router": {
+        "text_to_speech": (".voice_router", "text_to_speech"),
+        "speech_to_text": (".voice_router", "speech_to_text"),
+        "get_voice_provider": (".voice_router", "get_voice_provider"),
+        "register_voice_provider": (
+            ".voice_router",
+            "register_voice_provider",
+        ),
+        "get_voice_provider_capabilities": (
+            ".voice_router",
+            "get_voice_provider_capabilities",
+        ),
+        "clear_voice_router_caches": (
+            ".voice_router",
+            "clear_voice_router_caches",
+        ),
+        "VoiceProvider": (".voice_router", "VoiceProvider"),
+        "VoiceProviderCapabilities": (
+            ".voice_router",
+            "VoiceProviderCapabilities",
+        ),
+        "ProviderInfo": (".voice_router", "ProviderInfo"),
+        "VOICE_TURN_CONTRACT_VERSION": (
+            ".voice_router",
+            "VOICE_TURN_CONTRACT_VERSION",
+        ),
+        "VOICE_STAGE_STATUSES": (
+            ".voice_router",
+            "VOICE_STAGE_STATUSES",
+        ),
+        "VOICE_TURN_STATUSES": (
+            ".voice_router",
+            "VOICE_TURN_STATUSES",
+        ),
+        "DEFAULT_GROUNDED_FALLBACK": (
+            ".voice_router",
+            "DEFAULT_GROUNDED_FALLBACK",
+        ),
+        "GroundingEvidence": (".voice_router", "GroundingEvidence"),
+        "VoiceGroundingSource": (
+            ".voice_router",
+            "VoiceGroundingSource",
+        ),
+        "GroundedSlot": (".voice_router", "GroundedSlot"),
+        "VoiceResponsePlan": (".voice_router", "VoiceResponsePlan"),
+        "VoiceTemplateProvider": (
+            ".voice_router",
+            "VoiceTemplateProvider",
+        ),
+        "GraphRAGVoiceTemplateProvider": (
+            ".voice_router",
+            "GraphRAGVoiceTemplateProvider",
+        ),
+        "buildVoiceGraphRagPromptParts": (
+            ".voice_router",
+            "buildVoiceGraphRagPromptParts",
+        ),
+        "VoiceStageTrace": (".voice_router", "VoiceStageTrace"),
+        "VoiceTurnRequest": (".voice_router", "VoiceTurnRequest"),
+        "VoiceTurnProvenance": (
+            ".voice_router",
+            "VoiceTurnProvenance",
+        ),
+        "VoiceTurnResult": (".voice_router", "VoiceTurnResult"),
+        "voice_turn_cache_key": (
+            ".voice_router",
+            "voice_turn_cache_key",
+        ),
+        "process_voice_turn": (".voice_router", "process_voice_turn"),
+        "get_tts_provider": (".voice_router", "get_tts_provider"),
+        "register_tts_provider": (
+            ".voice_router",
+            "register_tts_provider",
+        ),
+        "clear_tts_router_caches": (
+            ".voice_router",
+            "clear_tts_router_caches",
+        ),
+        "TTSProvider": (".voice_router", "TTSProvider"),
+    },
+}
+
+_GROUP_AVAILABILITY: dict[str, tuple[str, ...]] = {
+    "webnn": ("webnn_webgpu_available",),
+    "model_manager": ("model_manager_available",),
+    "backend_manager": ("inference_backend_manager_available",),
+    "llm_router": ("llm_router_available",),
+    "embeddings_router": ("embeddings_router_available",),
+    "multimodal_router": ("multimodal_router_available",),
+    "voice_router": ("voice_router_available", "tts_router_available"),
+}
+
+_CORE_GROUPS = {
+    "install_depends",
+    "core",
+    "multiformats",
+    "config",
+    "webnn",
+    "logs",
+    "p2p_workflow",
+    "ipfs_kit",
+    "backend_manager",
+    "auto_patch",
+    "llm_router",
+    "embeddings_router",
+    "multimodal_router",
+    "voice_router",
+}
+
+_NAME_TO_GROUP = {
+    name: group
+    for group, members in _GROUP_MEMBERS.items()
+    for name in members
+}
+_NAME_TO_GROUP.update(
     {
-        "BatchProcessor",
-        "BatchState",
-        "EndpointContract",
-        "HFBucketBackend",
-        "HFBucketBackendError",
-        "HFSpaceClient",
-        "LocalFileSystemBackend",
-        "OutputBackend",
-        "RefreshableGradioFile",
-        "SpaceRuntimeInfo",
-        "is_hf_space_transport_error",
-        "is_retryable_hf_space_error",
-        "is_stale_gradio_file_error",
-        "normalize_api_name",
+        name: group
+        for group, names in _GROUP_AVAILABILITY.items()
+        for name in names
     }
 )
-_hf_space_exports = None
-_hf_space_lock = threading.Lock()
+
+_GROUP_TRANSITION_MODULES: dict[str, tuple[str, ...]] = {
+    "multiformats": ("multiformats",),
+    "core": ("ipfs_kit_py", "ipfs_model_manager_py", "ipfs_transformers_py"),
+    "ipfs_kit": ("ipfs_kit_py",),
+}
 
 
-def _load_hf_space_exports():
-    """Resolve HF Space symbols on first explicit access only."""
-
-    global _hf_space_exports
-    with _hf_space_lock:
-        if _hf_space_exports is not None:
-            return _hf_space_exports
-        from .hf_space_inference import (
-            BatchProcessor,
-            BatchState,
-            EndpointContract,
-            HFBucketBackend,
-            HFBucketBackendError,
-            HFSpaceClient,
-            LocalFileSystemBackend,
-            OutputBackend,
-            RefreshableGradioFile,
-            SpaceRuntimeInfo,
-            is_hf_space_transport_error,
-            is_retryable_hf_space_error,
-            is_stale_gradio_file_error,
-            normalize_api_name,
-        )
-
-        resolved = {
-            "BatchProcessor": BatchProcessor,
-            "BatchState": BatchState,
-            "EndpointContract": EndpointContract,
-            "HFBucketBackend": HFBucketBackend,
-            "HFBucketBackendError": HFBucketBackendError,
-            "HFSpaceClient": HFSpaceClient,
-            "LocalFileSystemBackend": LocalFileSystemBackend,
-            "OutputBackend": OutputBackend,
-            "RefreshableGradioFile": RefreshableGradioFile,
-            "SpaceRuntimeInfo": SpaceRuntimeInfo,
-            "is_hf_space_transport_error": is_hf_space_transport_error,
-            "is_retryable_hf_space_error": is_retryable_hf_space_error,
-            "is_stale_gradio_file_error": is_stale_gradio_file_error,
-            "normalize_api_name": normalize_api_name,
-        }
-        for name, value in resolved.items():
-            globals()[name] = value
-        existing_export = globals().get("export")
-        if isinstance(existing_export, dict):
-            for name, value in resolved.items():
-                dict.__setitem__(existing_export, name, value)
-        _hf_space_exports = resolved
-        return resolved
+def _unavailable_ipfs_accelerate_py(*args: Any, **kwargs: Any) -> Any:
+    raise NotImplementedError(
+        "IPFS Accelerate core is not available (missing dependencies) or "
+        "disabled. Set IPFS_ACCEL_SKIP_CORE=0 and install core dependencies "
+        "to enable."
+    )
 
 
-# Import original components (skip heavy backends under cold/skip-core profiles).
-if not SKIP_CORE:
-    try:
-        from .container_backends import backends
-    except Exception:
-        backends = None
-else:
-    backends = None
+_unavailable_ipfs_accelerate_py.__name__ = "ipfs_accelerate_py"
+_unavailable_ipfs_accelerate_py.__qualname__ = "ipfs_accelerate_py"
 
-if not SKIP_CORE:
-    try:
-        from .install_depends import install_depends
-    except Exception:
-        install_depends = None
-else:
-    install_depends = None
 
-def _add_external_package(package_name: str) -> None:
-    """Ensure external bundled packages are importable without pip install."""
-    repo_root = Path(__file__).resolve().parents[1]
-    candidate = repo_root / "external" / package_name
-    if candidate.exists() and str(candidate) not in sys.path:
-        sys.path.insert(0, str(candidate))
+def _publish_public_value(name: str, value: Any) -> None:
+    _PUBLIC_VALUES[name] = value
+    _PUBLIC_RESOLVED.add(name)
+    globals()[name] = value
+    export_map = globals().get("export")
+    if isinstance(export_map, dict) and dict.__contains__(export_map, name):
+        dict.__setitem__(export_map, name, value)
 
-# Optionally skip importing the heavy core (avoids ipfs_kit_py import at import-time)
-if not SKIP_CORE:
-    try:
-        _add_external_package("ipfs_kit_py")
-        _add_external_package("ipfs_model_manager_py")
-        _add_external_package("ipfs_transformers_py")
-        from .ipfs_accelerate import ipfs_accelerate_py as original_ipfs_accelerate_py
-    except Exception:
-        original_ipfs_accelerate_py = None
-else:
-    original_ipfs_accelerate_py = None
 
-if not SKIP_CORE:
-    try:
-        from .ipfs_multiformats import ipfs_multiformats_py
-    except Exception:
-        ipfs_multiformats_py = None
+def _group_module_state(group: str) -> tuple[tuple[str, bool], ...]:
+    names = {
+        f"{__name__}{module_name}"
+        for module_name, _ in _GROUP_MEMBERS[group].values()
+    }
+    names.update(_GROUP_TRANSITION_MODULES.get(group, ()))
+    return tuple(
+        (name, name in sys.modules)
+        for name in sorted(names)
+    )
 
-    # ``worker`` is resolved by the module-level ``__getattr__`` below.  Keep
-    # package discovery light: importing the legacy worker package eagerly
-    # loads every model skillset (including torch and transformers).
 
-    try:
-        from .config import config
-    except Exception:
-        config = None
-else:
-    ipfs_multiformats_py = None
-    worker = None
-    config = None
+def _failed_group_retry_ready(group: str) -> bool:
+    previous_state = _GROUP_FAILED_MODULE_STATE.get(group, ())
+    if _group_module_state(group) != previous_state:
+        # An authorized installer/importer changed process capabilities.
+        return True
+    failed_at = _GROUP_FAILED_AT.get(group, 0.0)
+    return time.monotonic() - failed_at >= _FAILED_GROUP_RETRY_SECONDS
 
-# Import WebNN/WebGPU integration (skip when core is disabled)
-if not SKIP_CORE:
-    try:
-        from .webnn_webgpu_integration import (
-            accelerate_with_browser,
-            WebNNWebGPUAccelerator,
-            get_accelerator
-        )
-        webnn_webgpu_available = True
-    except Exception:
-        webnn_webgpu_available = False
-        
-        # Create stubs if not available
-        def accelerate_with_browser(*args, **kwargs):
-            raise NotImplementedError("WebNN/WebGPU integration is not available")
-        
-        def get_accelerator(*args, **kwargs):
-            raise NotImplementedError("WebNN/WebGPU integration is not available")
-        
-        class WebNNWebGPUAccelerator:
-            def __init__(self, *args, **kwargs):
-                raise NotImplementedError("WebNN/WebGPU integration is not available")
-else:
-    webnn_webgpu_available = False
-    def accelerate_with_browser(*args, **kwargs):
-        raise NotImplementedError("WebNN/WebGPU integration is disabled (IPFS_ACCEL_SKIP_CORE=1)")
-    def get_accelerator(*args, **kwargs):
-        raise NotImplementedError("WebNN/WebGPU integration is disabled (IPFS_ACCEL_SKIP_CORE=1)")
-    class WebNNWebGPUAccelerator:
-        def __init__(self, *args, **kwargs):
-            raise NotImplementedError("WebNN/WebGPU integration is disabled (IPFS_ACCEL_SKIP_CORE=1)")
 
-# Import Model Manager (skip by default to avoid heavy optional deps at import time)
-if os.environ.get("IPFS_ACCEL_IMPORT_EAGER", "0") == "1":
-    try:
-        from .model_manager import (
-            ModelManager, ModelMetadata, IOSpec, ModelType, DataType,
-            ServingConfig, create_model_from_huggingface, get_default_model_manager
-        )
-        model_manager_available = True
-    except Exception:
-        model_manager_available = False
-        def get_default_model_manager(*args, **kwargs):
-            raise NotImplementedError("Model Manager is not available")
-        class ModelManager:
-            def __init__(self, *args, **kwargs):
-                raise NotImplementedError("Model Manager is not available")
-else:
-    model_manager_available = True
+def _resolve_group(group: str) -> None:
+    """Resolve and cache one optional public group exactly once."""
 
-    def _lazy_import_model_manager():
+    with _GROUP_LOCK:
+        if group in _GROUP_RESOLVED:
+            return
+        if group in _GROUP_LOADING:
+            # A provider importing its own package root must not recurse.
+            return
+        if group in _GROUP_FAILED_AT and not _failed_group_retry_ready(group):
+            return
+        _GROUP_LOADING.add(group)
+        members = _GROUP_MEMBERS[group]
+        enabled = not (SKIP_CORE and group in _CORE_GROUPS)
+        values: dict[str, Any] = {}
+        available = False
         try:
-            from .model_manager import (
-                ModelManager as _RealModelManager,
-                ModelMetadata as _RealModelMetadata,
-                IOSpec as _RealIOSpec,
-                ModelType as _RealModelType,
-                DataType as _RealDataType,
-                ServingConfig as _RealServingConfig,
-                create_model_from_huggingface as _create_model_from_huggingface,
-                get_default_model_manager as _real_get_default_model_manager,
-            )
-            return {
-                "ModelManager": _RealModelManager,
-                "ModelMetadata": _RealModelMetadata,
-                "IOSpec": _RealIOSpec,
-                "ModelType": _RealModelType,
-                "DataType": _RealDataType,
-                "ServingConfig": _RealServingConfig,
-                "create_model_from_huggingface": _create_model_from_huggingface,
-                "get_default_model_manager": _real_get_default_model_manager,
-            }
-        except Exception as e:
-            raise NotImplementedError(f"Model Manager is not available: {e}") from e
+            if enabled:
+                loaded_modules: dict[str, ModuleType] = {}
+                for name, (module_name, attribute_name) in members.items():
+                    module = loaded_modules.get(module_name)
+                    if module is None:
+                        module = importlib.import_module(
+                            f"{__name__}{module_name}"
+                        )
+                        loaded_modules[module_name] = module
+                    values[name] = (
+                        module
+                        if attribute_name is None
+                        else getattr(module, attribute_name)
+                    )
+                available = True
+        except Exception:
+            values.clear()
+            available = False
+        finally:
+            for name in members:
+                value = values.get(name)
+                if name == "ipfs_accelerate_py" and value is None:
+                    value = _unavailable_ipfs_accelerate_py
+                _publish_public_value(name, value)
+            for name in _GROUP_AVAILABILITY.get(group, ()):
+                _publish_public_value(name, available)
+            if available or not enabled:
+                _GROUP_RESOLVED.add(group)
+                _GROUP_FAILED_AT.pop(group, None)
+                _GROUP_FAILED_MODULE_STATE.pop(group, None)
+            else:
+                _GROUP_FAILED_AT[group] = time.monotonic()
+                _GROUP_FAILED_MODULE_STATE[group] = _group_module_state(group)
+            _GROUP_LOADING.discard(group)
 
-    def get_default_model_manager(*args, **kwargs):
-        exports = _lazy_import_model_manager()
-        return exports["get_default_model_manager"](*args, **kwargs)
 
-    class ModelManager:
-        def __new__(cls, *args, **kwargs):
-            exports = _lazy_import_model_manager()
-            return exports["ModelManager"](*args, **kwargs)
+def _resolve_public(name: str) -> Any:
+    group = _NAME_TO_GROUP.get(name)
+    if group is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    if group in _GROUP_FAILED_AT and _failed_group_retry_ready(group):
+        _resolve_group(group)
+    if name in _PUBLIC_RESOLVED:
+        return _PUBLIC_VALUES[name]
+    _resolve_group(group)
+    return _PUBLIC_VALUES.get(name)
 
-_global_instance = None
 
-# Public constructor/entrypoint (may be unavailable when core is disabled or missing deps)
-if original_ipfs_accelerate_py is not None:
-    ipfs_accelerate_py = original_ipfs_accelerate_py
+def refresh_optional_exports(*names: str) -> dict[str, Any]:
+    """Retry failed optional imports after a controlled capability change.
 
-    def get_instance(**kwargs):
-        """Get or create a process-wide singleton instance of ipfs_accelerate_py.
+    This is deliberately outside ``__all__`` and the historical ``export``
+    manifest.  Lazy installers may call it after changing import availability;
+    ordinary callers get bounded automatic retries on explicit access.
+    """
 
-        Accepts optional dependency injections (e.g., ``deps``, ``ipfs_kit``) and
-        forwards them to the constructor on first creation.
-        """
-        global _global_instance
+    requested = tuple(names)
+    groups = {
+        _NAME_TO_GROUP[name]
+        for name in requested
+        if name in _NAME_TO_GROUP
+    }
+    if not requested:
+        groups = set(_GROUP_FAILED_AT)
+    with _GROUP_LOCK:
+        for group in groups:
+            if SKIP_CORE and group in _CORE_GROUPS:
+                continue
+            _GROUP_RESOLVED.discard(group)
+            _GROUP_FAILED_AT.pop(group, None)
+            _GROUP_FAILED_MODULE_STATE.pop(group, None)
+            for public_name in (
+                *tuple(_GROUP_MEMBERS[group]),
+                *_GROUP_AVAILABILITY.get(group, ()),
+            ):
+                _PUBLIC_VALUES.pop(public_name, None)
+                _PUBLIC_RESOLVED.discard(public_name)
+                globals().pop(public_name, None)
+                export_map = globals().get("export")
+                if (
+                    isinstance(export_map, dict)
+                    and dict.__contains__(export_map, public_name)
+                ):
+                    dict.__setitem__(export_map, public_name, None)
+    return {
+        name: _resolve_public(name)
+        for name in requested
+        if name in _NAME_TO_GROUP
+    }
+
+
+_global_instance: Any = None
+_instance_lock = threading.Lock()
+
+
+def get_instance(**kwargs: Any) -> Any:
+    """Get or create the process-wide accelerator with optional injections."""
+
+    global _global_instance
+    constructor = _resolve_public("ipfs_accelerate_py")
+    if constructor is _unavailable_ipfs_accelerate_py:
+        return constructor(**kwargs)
+    with _instance_lock:
         if _global_instance is None:
-            _global_instance = ipfs_accelerate_py(**kwargs)
+            _global_instance = constructor(**kwargs)
         elif kwargs:
-            # Best-effort: attach injected deps to existing singleton.
-            for k, v in kwargs.items():
+            for key, value in kwargs.items():
                 try:
-                    setattr(_global_instance, k, v)
+                    setattr(_global_instance, key, value)
                 except Exception:
                     pass
-        return _global_instance
-else:
-    def ipfs_accelerate_py(*args, **kwargs):
-        raise NotImplementedError(
-            "IPFS Accelerate core is not available (missing deps) or disabled. "
-            "Set IPFS_ACCEL_SKIP_CORE=0 and install core dependencies to enable."
-        )
+    return _global_instance
 
-    def get_instance():
-        raise NotImplementedError(
-            "IPFS Accelerate core is not available (missing deps) or disabled. "
-            "Set IPFS_ACCEL_SKIP_CORE=0 and install core dependencies to enable."
-        )
 
+def cli_main(*args: Any, **kwargs: Any) -> Any:
+    """Load the command-line implementation only when invoked."""
+
+    from .cli_entry import main
+
+    return main(*args, **kwargs)
+
+
+_PUBLIC_VALUES["get_instance"] = get_instance
+_PUBLIC_RESOLVED.add("get_instance")
+if not SKIP_CORE:
+    _PUBLIC_VALUES["cli_main"] = cli_main
+    _PUBLIC_RESOLVED.add("cli_main")
+
+
+# ``worker`` retains its historical synchronized module-valued contract.  It
+# is the only compatibility surface that intentionally exposes a module-like
+# raw snapshot through ``dict(export)``.
 _WORKER_UNRESOLVED = object()
-_worker_export_value = None if SKIP_CORE else _WORKER_UNRESOLVED
+_worker_export_value: Any = None if SKIP_CORE else _WORKER_UNRESOLVED
 _worker_loading = False
-_worker_loader_thread_id = None
+_worker_loader_thread_id: int | None = None
 _worker_condition = threading.Condition()
 
 
 class _LazyWorkerSnapshot(ModuleType):
-    """Module-like value used only by raw, non-virtual dictionary copies."""
-
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         resolved = _load_legacy_worker()
         if resolved is None:
             raise AttributeError(
@@ -288,7 +569,7 @@ class _LazyWorkerSnapshot(ModuleType):
             )
         return getattr(resolved, name)
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         resolved = _load_legacy_worker()
         return [] if resolved is None else dir(resolved)
 
@@ -299,17 +580,14 @@ _worker_snapshot = _LazyWorkerSnapshot(
 )
 
 
-def _load_legacy_worker():
-    """Resolve the historical module-valued worker export on explicit access."""
-
+def _load_legacy_worker() -> Any:
     global _worker_export_value, _worker_loading, _worker_loader_thread_id
+
     current_thread_id = threading.get_ident()
     with _worker_condition:
         if _worker_export_value is not _WORKER_UNRESOLVED:
             return _worker_export_value
         if _worker_loading and _worker_loader_thread_id == current_thread_id:
-            # Same-thread recursion can occur while importlib installs the
-            # worker package on this parent module.
             return globals().get("worker")
         while _worker_loading:
             _worker_condition.wait()
@@ -325,9 +603,9 @@ def _load_legacy_worker():
         with _worker_condition:
             _worker_export_value = resolved
             globals()["worker"] = resolved
-            existing_export = globals().get("export")
-            if isinstance(existing_export, dict):
-                dict.__setitem__(existing_export, "worker", resolved)
+            export_map = globals().get("export")
+            if isinstance(export_map, dict):
+                dict.__setitem__(export_map, "worker", resolved)
             return resolved
     finally:
         with _worker_condition:
@@ -336,21 +614,10 @@ def _load_legacy_worker():
             _worker_condition.notify_all()
 
 
-class _LazyRootExport(dict):
-    """Dictionary-compatible exports with optional lazy legacy values.
+class _LazyRootExport(dict[str, Any]):
+    """Dictionary-compatible root export manifest with exact lazy values."""
 
-    Virtual mapping access resolves ``worker`` and HF Space transport symbols.
-    Raw base-dict inspection keeps a module-like lazy worker snapshot so
-    provider-free discovery remains possible without exposing a misleading
-    permanent ``None`` value, and without loading network clients.
-    """
-
-    def __contains__(self, key):
-        if key in _HF_SPACE_EXPORT_NAMES:
-            return True
-        return dict.__contains__(self, key)
-
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         if key == "worker":
             with _worker_condition:
                 if not dict.__contains__(self, key):
@@ -359,23 +626,24 @@ class _LazyRootExport(dict):
                 if stored is not _worker_snapshot:
                     return stored
             return _load_legacy_worker()
-        if key in _HF_SPACE_EXPORT_NAMES:
-            if dict.__contains__(self, key):
-                return dict.__getitem__(self, key)
-            return _load_hf_space_exports()[key]
-        return super().__getitem__(key)
+        if key in _NAME_TO_GROUP and dict.__contains__(self, key):
+            return _resolve_public(key)
+        return dict.__getitem__(self, key)
 
-    def __setitem__(self, key, value):
-        if key != "worker":
-            return super().__setitem__(key, value)
-        # Route public-dictionary monkeypatches through the same synchronized
-        # assignment contract as ``package.worker = value``.
-        setattr(sys.modules[__name__], "worker", value)
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key == "worker":
+            setattr(sys.modules[__name__], "worker", value)
+            return
+        if key in _NAME_TO_GROUP:
+            _publish_public_value(key, value)
+            return
+        dict.__setitem__(self, key, value)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         global _worker_export_value
         if key != "worker":
-            return super().__delitem__(key)
+            dict.__delitem__(self, key)
+            return
         with _worker_condition:
             while (
                 _worker_loading
@@ -384,62 +652,62 @@ class _LazyRootExport(dict):
                 _worker_condition.wait()
             if not dict.__contains__(self, key):
                 raise KeyError(key)
-            _worker_export_value = (
-                None if SKIP_CORE else _WORKER_UNRESOLVED
-            )
+            _worker_export_value = None if SKIP_CORE else _WORKER_UNRESOLVED
             globals().pop("worker", None)
             dict.__delitem__(self, key)
             _worker_condition.notify_all()
 
-    def get(self, key, default=None):
-        if key == "worker" and key in self:
+    def get(self, key: str, default: Any = None) -> Any:
+        if key in self:
             return self[key]
-        if key in _HF_SPACE_EXPORT_NAMES:
+        return default
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        if key == "worker":
+            with _worker_condition:
+                if dict.__contains__(self, key):
+                    return dict.__getitem__(self, key)
+                self[key] = default
+                return default
+        if dict.__contains__(self, key):
             return self[key]
-        return super().get(key, default)
+        self[key] = default
+        return default
 
-    def setdefault(self, key, default=None):
-        if key != "worker":
-            return super().setdefault(key, default)
-        with _worker_condition:
-            if dict.__contains__(self, key):
-                # Preserve the raw lazy snapshot behavior of the historical
-                # dict API without causing provider imports.
-                return dict.__getitem__(self, key)
-            self[key] = default
-            return default
-
-    def update(self, *args, **kwargs):
-        staged = {}
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        staged: dict[str, Any] = {}
         dict.update(staged, *args, **kwargs)
         for key, value in staged.items():
             self[key] = value
 
-    def __ior__(self, other):
+    def __ior__(self, other: Any) -> "_LazyRootExport":
         self.update(other)
         return self
 
-    def pop(self, key, *default):
+    def pop(self, key: str, *default: Any) -> Any:
         if len(default) > 1:
-            raise TypeError(f"pop expected at most 2 arguments, got {1 + len(default)}")
-        if key != "worker":
-            return super().pop(key, *default)
-        with _worker_condition:
-            if not dict.__contains__(self, key):
-                if default:
-                    return default[0]
-                raise KeyError(key)
-            value = dict.__getitem__(self, key)
-            self.__delitem__(key)
-            return value
+            raise TypeError(
+                f"pop expected at most 2 arguments, got {1 + len(default)}"
+            )
+        if not dict.__contains__(self, key):
+            if default:
+                return default[0]
+            raise KeyError(key)
+        value = (
+            dict.__getitem__(self, key)
+            if key == "worker"
+            else self[key]
+        )
+        self.__delitem__(key)
+        return value
 
-    def popitem(self):
+    def popitem(self) -> tuple[str, Any]:
         if not self:
             raise KeyError("popitem(): dictionary is empty")
         key = next(reversed(self))
         return key, self.pop(key)
 
-    def clear(self):
+    def clear(self) -> None:
         global _worker_export_value
         with _worker_condition:
             while (
@@ -456,502 +724,284 @@ class _LazyRootExport(dict):
                 globals().pop("worker", None)
             _worker_condition.notify_all()
 
-    def items(self):
-        if "worker" in self:
-            self["worker"]
-        return super().items()
+    def items(self) -> Any:
+        for key in tuple(dict.keys(self)):
+            if key == "worker" or key in _NAME_TO_GROUP:
+                self[key]
+        return dict.items(self)
 
-    def values(self):
-        if "worker" in self:
-            self["worker"]
-        return super().values()
+    def values(self) -> Any:
+        self.items()
+        return dict.values(self)
 
-    def copy(self):
-        if "worker" in self:
-            self["worker"]
-        return super().copy()
-
-
-# Export all components. HF Space transport symbols resolve on first access so
-# cold Planner/Doctor imports never load requests/httpx through package root.
-export = _LazyRootExport({
-    "backends": backends,
-    "config": config,
-    "install_depends": install_depends,
-    "ipfs_accelerate_py": ipfs_accelerate_py,
-    # Synchronized with the historical root export on first explicit access.
-    "worker": None if SKIP_CORE else _worker_snapshot,
-    "ipfs_multiformats_py": ipfs_multiformats_py,
-    "get_instance": get_instance,
-    "accelerate_with_browser": accelerate_with_browser,
-    "WebNNWebGPUAccelerator": WebNNWebGPUAccelerator,
-    "get_accelerator": get_accelerator,
-    "webnn_webgpu_available": webnn_webgpu_available,
-    "ModelManager": ModelManager,
-    "get_default_model_manager": get_default_model_manager,
-    "model_manager_available": model_manager_available,
-})
+    def copy(self) -> dict[str, Any]:
+        self.items()
+        return dict.copy(self)
 
 
-def __getattr__(name):
-    """Lazily expose optional legacy package-root components."""
+_BASE_EXPORT_NAMES = (
+    "backends",
+    "config",
+    "install_depends",
+    "ipfs_accelerate_py",
+    "worker",
+    "ipfs_multiformats_py",
+    "get_instance",
+    "accelerate_with_browser",
+    "WebNNWebGPUAccelerator",
+    "get_accelerator",
+    "webnn_webgpu_available",
+    "ModelManager",
+    "get_default_model_manager",
+    "model_manager_available",
+    "EndpointContract",
+    "SpaceRuntimeInfo",
+    "OutputBackend",
+    "LocalFileSystemBackend",
+    "HFBucketBackend",
+    "HFBucketBackendError",
+    "HFSpaceClient",
+    "RefreshableGradioFile",
+    "BatchState",
+    "BatchProcessor",
+    "is_hf_space_transport_error",
+    "is_retryable_hf_space_error",
+    "is_stale_gradio_file_error",
+    "normalize_api_name",
+)
 
+_CORE_EXPORT_NAMES = (
+    "cli_main",
+    "get_system_logs",
+    "SystemLogs",
+    "P2PWorkflowScheduler",
+    "P2PTask",
+    "WorkflowTag",
+    "MerkleClock",
+    "FibonacciHeap",
+    "calculate_hamming_distance",
+    "IPFSKitStorage",
+    "get_storage",
+    "reset_storage",
+    "StorageBackendConfig",
+    "InferenceBackendManager",
+    "get_backend_manager",
+    "register_backend_from_config",
+    "auto_patch_transformers",
+    "generate_text",
+    "get_llm_provider",
+    "register_llm_provider",
+    "clear_llm_router_caches",
+    "LLMProvider",
+    "MistralVibeInstallResult",
+    "ensure_mistral_vibe",
+    "RouterDeps",
+    "get_default_router_deps",
+    "set_default_router_deps",
+    "embed_texts",
+    "embed_texts_batched",
+    "embed_text",
+    "get_embeddings_provider",
+    "get_embedding_progress",
+    "get_last_embedding_trace",
+    "register_embeddings_provider",
+    "clear_embeddings_router_caches",
+    "EmbeddingsRouterError",
+    "EmbeddingsProvider",
+    "generate_multimodal",
+    "get_multimodal_provider",
+    "register_multimodal_provider",
+    "clear_multimodal_router_caches",
+    "MultimodalProvider",
+    "text_to_speech",
+    "speech_to_text",
+    "get_voice_provider",
+    "register_voice_provider",
+    "get_voice_provider_capabilities",
+    "clear_voice_router_caches",
+    "VoiceProvider",
+    "VoiceProviderCapabilities",
+    "ProviderInfo",
+    "VOICE_TURN_CONTRACT_VERSION",
+    "VOICE_STAGE_STATUSES",
+    "VOICE_TURN_STATUSES",
+    "DEFAULT_GROUNDED_FALLBACK",
+    "GroundingEvidence",
+    "VoiceGroundingSource",
+    "GroundedSlot",
+    "VoiceResponsePlan",
+    "VoiceTemplateProvider",
+    "GraphRAGVoiceTemplateProvider",
+    "buildVoiceGraphRagPromptParts",
+    "VoiceStageTrace",
+    "VoiceTurnRequest",
+    "VoiceTurnProvenance",
+    "VoiceTurnResult",
+    "voice_turn_cache_key",
+    "process_voice_turn",
+    "get_tts_provider",
+    "register_tts_provider",
+    "clear_tts_router_caches",
+    "TTSProvider",
+)
+
+
+def _initial_export_value(name: str) -> Any:
     if name == "worker":
-        return _load_legacy_worker()
-    if name in _HF_SPACE_EXPORT_NAMES:
-        return _load_hf_space_exports()[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        return None if SKIP_CORE else _worker_snapshot
+    if name in _PUBLIC_RESOLVED:
+        return _PUBLIC_VALUES[name]
+    # A falsey raw slot cannot masquerade as an available optional provider.
+    return None
 
-if not SKIP_CORE:
-    # Add CLI entry point for package access
-    def cli_main(*args, **kwargs):
-        from .cli_entry import main as _cli_main
 
-        return _cli_main(*args, **kwargs)
+_export_names = (
+    _BASE_EXPORT_NAMES
+    if SKIP_CORE
+    else _BASE_EXPORT_NAMES + _CORE_EXPORT_NAMES
+)
+export = _LazyRootExport(
+    {name: _initial_export_value(name) for name in _export_names}
+)
 
-    export["cli_main"] = cli_main
-
-    # Add system logs access
-    try:
-        from .logs import get_system_logs, SystemLogs
-
-        export["get_system_logs"] = get_system_logs
-        export["SystemLogs"] = SystemLogs
-    except ImportError:
-        get_system_logs = None
-        SystemLogs = None
-
-    # Add P2P workflow scheduler access
-    try:
-        from .p2p_workflow_scheduler import (
-            P2PWorkflowScheduler,
-            P2PTask,
-            WorkflowTag,
-            MerkleClock,
-            FibonacciHeap,
-            calculate_hamming_distance,
-        )
-
-        export["P2PWorkflowScheduler"] = P2PWorkflowScheduler
-        export["P2PTask"] = P2PTask
-        export["WorkflowTag"] = WorkflowTag
-        export["MerkleClock"] = MerkleClock
-        export["FibonacciHeap"] = FibonacciHeap
-        export["calculate_hamming_distance"] = calculate_hamming_distance
-    except ImportError:
-        P2PWorkflowScheduler = None
-        P2PTask = None
-        WorkflowTag = None
-        MerkleClock = None
-        FibonacciHeap = None
-        calculate_hamming_distance = None
-else:
-    cli_main = None
-    get_system_logs = None
-    SystemLogs = None
-    P2PWorkflowScheduler = None
-    P2PTask = None
-    WorkflowTag = None
-    MerkleClock = None
-    FibonacciHeap = None
-    calculate_hamming_distance = None
-
-# Add IPFS Kit integration
-if not SKIP_CORE:
-    try:
-        from .ipfs_kit_integration import (
-            IPFSKitStorage,
-            get_storage,
-            reset_storage,
-            StorageBackendConfig,
-        )
-
-        export["IPFSKitStorage"] = IPFSKitStorage
-        export["get_storage"] = get_storage
-        export["reset_storage"] = reset_storage
-        export["StorageBackendConfig"] = StorageBackendConfig
-    except ImportError:
-        IPFSKitStorage = None
-        get_storage = None
-        reset_storage = None
-        StorageBackendConfig = None
-else:
-    IPFSKitStorage = None
-    get_storage = None
-    reset_storage = None
-    StorageBackendConfig = None
-
-# Add inference backend manager
-if not SKIP_CORE:
-    try:
-        from .inference_backend_manager import (
-            InferenceBackendManager,
-            get_backend_manager,
-            register_backend_from_config,
-        )
-
-        export["InferenceBackendManager"] = InferenceBackendManager
-        export["get_backend_manager"] = get_backend_manager
-        export["register_backend_from_config"] = register_backend_from_config
-        inference_backend_manager_available = True
-    except ImportError:
-        InferenceBackendManager = None
-        get_backend_manager = None
-        register_backend_from_config = None
-        inference_backend_manager_available = False
-else:
-    InferenceBackendManager = None
-    get_backend_manager = None
-    register_backend_from_config = None
-    inference_backend_manager_available = False
-
-# Add auto-patching for transformers (applies automatically on import if enabled)
-if not SKIP_CORE:
-    try:
-        from . import auto_patch_transformers
-
-        export["auto_patch_transformers"] = auto_patch_transformers
-    except ImportError:
-        auto_patch_transformers = None
-else:
-    auto_patch_transformers = None
-
-# Add LLM router functionality
-if not SKIP_CORE:
-    try:
-        from .llm_router import (
-            generate_text,
-            get_llm_provider,
-            register_llm_provider,
-            clear_llm_router_caches,
-            LLMProvider,
-            MistralVibeInstallResult,
-            ensure_mistral_vibe,
-        )
-        from .router_deps import (
-            RouterDeps,
-            get_default_router_deps,
-            set_default_router_deps,
-        )
-
-        export["generate_text"] = generate_text
-        export["get_llm_provider"] = get_llm_provider
-        export["register_llm_provider"] = register_llm_provider
-        export["clear_llm_router_caches"] = clear_llm_router_caches
-        export["LLMProvider"] = LLMProvider
-        export["MistralVibeInstallResult"] = MistralVibeInstallResult
-        export["ensure_mistral_vibe"] = ensure_mistral_vibe
-        export["RouterDeps"] = RouterDeps
-        export["get_default_router_deps"] = get_default_router_deps
-        export["set_default_router_deps"] = set_default_router_deps
-        llm_router_available = True
-    except ImportError:
-        generate_text = None
-        get_llm_provider = None
-        register_llm_provider = None
-        clear_llm_router_caches = None
-        LLMProvider = None
-        MistralVibeInstallResult = None
-        ensure_mistral_vibe = None
-        RouterDeps = None
-        get_default_router_deps = None
-        set_default_router_deps = None
-        llm_router_available = False
-else:
-    generate_text = None
-    get_llm_provider = None
-    register_llm_provider = None
-    clear_llm_router_caches = None
-    LLMProvider = None
-    MistralVibeInstallResult = None
-    ensure_mistral_vibe = None
-    RouterDeps = None
-    get_default_router_deps = None
-    set_default_router_deps = None
-    llm_router_available = False
-
-# Add Embeddings router functionality
-if not SKIP_CORE:
-    try:
-        from .embeddings_router import (
-            embed_texts,
-            embed_texts_batched,
-            embed_text,
-            get_embeddings_provider,
-            get_embedding_progress,
-            get_last_embedding_trace,
-            register_embeddings_provider,
-            clear_embeddings_router_caches,
-            EmbeddingsRouterError,
-            EmbeddingsProvider,
-        )
-
-        export["embed_texts"] = embed_texts
-        export["embed_texts_batched"] = embed_texts_batched
-        export["embed_text"] = embed_text
-        export["get_embeddings_provider"] = get_embeddings_provider
-        export["get_embedding_progress"] = get_embedding_progress
-        export["get_last_embedding_trace"] = get_last_embedding_trace
-        export["register_embeddings_provider"] = register_embeddings_provider
-        export["clear_embeddings_router_caches"] = clear_embeddings_router_caches
-        export["EmbeddingsRouterError"] = EmbeddingsRouterError
-        export["EmbeddingsProvider"] = EmbeddingsProvider
-        embeddings_router_available = True
-    except ImportError:
-        embed_texts = None
-        embed_texts_batched = None
-        embed_text = None
-        get_embeddings_provider = None
-        get_embedding_progress = None
-        get_last_embedding_trace = None
-        register_embeddings_provider = None
-        clear_embeddings_router_caches = None
-        EmbeddingsRouterError = None
-        EmbeddingsProvider = None
-        embeddings_router_available = False
-else:
-    embed_texts = None
-    embed_texts_batched = None
-    embed_text = None
-    get_embeddings_provider = None
-    get_embedding_progress = None
-    get_last_embedding_trace = None
-    register_embeddings_provider = None
-    clear_embeddings_router_caches = None
-    EmbeddingsRouterError = None
-    EmbeddingsProvider = None
-    embeddings_router_available = False
-
-# Add Multimodal router functionality
-if not SKIP_CORE:
-    try:
-        from .multimodal_router import (
-            generate_multimodal,
-            get_multimodal_provider,
-            register_multimodal_provider,
-            clear_multimodal_router_caches,
-            MultimodalProvider,
-        )
-
-        export["generate_multimodal"] = generate_multimodal
-        export["get_multimodal_provider"] = get_multimodal_provider
-        export["register_multimodal_provider"] = register_multimodal_provider
-        export["clear_multimodal_router_caches"] = clear_multimodal_router_caches
-        export["MultimodalProvider"] = MultimodalProvider
-        multimodal_router_available = True
-    except ImportError:
-        generate_multimodal = None
-        get_multimodal_provider = None
-        register_multimodal_provider = None
-        clear_multimodal_router_caches = None
-        MultimodalProvider = None
-        multimodal_router_available = False
-else:
-    generate_multimodal = None
-    get_multimodal_provider = None
-    register_multimodal_provider = None
-    clear_multimodal_router_caches = None
-    MultimodalProvider = None
-    multimodal_router_available = False
-
-# Add Voice router functionality (TTS + STT); also provides backward-compat
-# aliases for the former tts_router (get_tts_provider, register_tts_provider,
-# clear_tts_router_caches, TTSProvider).
-if not SKIP_CORE:
-    try:
-        from .voice_router import (
-            text_to_speech,
-            speech_to_text,
-            get_voice_provider,
-            register_voice_provider,
-            get_voice_provider_capabilities,
-            clear_voice_router_caches,
-            VoiceProvider,
-            VoiceProviderCapabilities,
-            ProviderInfo,
-            VOICE_TURN_CONTRACT_VERSION,
-            VOICE_STAGE_STATUSES,
-            VOICE_TURN_STATUSES,
-            DEFAULT_GROUNDED_FALLBACK,
-            GroundingEvidence,
-            VoiceGroundingSource,
-            GroundedSlot,
-            VoiceResponsePlan,
-            VoiceTemplateProvider,
-            GraphRAGVoiceTemplateProvider,
-            buildVoiceGraphRagPromptParts,
-            VoiceStageTrace,
-            VoiceTurnRequest,
-            VoiceTurnProvenance,
-            VoiceTurnResult,
-            voice_turn_cache_key,
-            process_voice_turn,
-            # backward-compat TTS aliases
-            get_tts_provider,
-            register_tts_provider,
-            clear_tts_router_caches,
-            TTSProvider,
-        )
-
-        export["text_to_speech"] = text_to_speech
-        export["speech_to_text"] = speech_to_text
-        export["get_voice_provider"] = get_voice_provider
-        export["register_voice_provider"] = register_voice_provider
-        export["get_voice_provider_capabilities"] = get_voice_provider_capabilities
-        export["clear_voice_router_caches"] = clear_voice_router_caches
-        export["VoiceProvider"] = VoiceProvider
-        export["VoiceProviderCapabilities"] = VoiceProviderCapabilities
-        export["ProviderInfo"] = ProviderInfo
-        export["VOICE_TURN_CONTRACT_VERSION"] = VOICE_TURN_CONTRACT_VERSION
-        export["VOICE_STAGE_STATUSES"] = VOICE_STAGE_STATUSES
-        export["VOICE_TURN_STATUSES"] = VOICE_TURN_STATUSES
-        export["DEFAULT_GROUNDED_FALLBACK"] = DEFAULT_GROUNDED_FALLBACK
-        export["GroundingEvidence"] = GroundingEvidence
-        export["VoiceGroundingSource"] = VoiceGroundingSource
-        export["GroundedSlot"] = GroundedSlot
-        export["VoiceResponsePlan"] = VoiceResponsePlan
-        export["VoiceTemplateProvider"] = VoiceTemplateProvider
-        export["GraphRAGVoiceTemplateProvider"] = GraphRAGVoiceTemplateProvider
-        export["buildVoiceGraphRagPromptParts"] = buildVoiceGraphRagPromptParts
-        export["VoiceStageTrace"] = VoiceStageTrace
-        export["VoiceTurnRequest"] = VoiceTurnRequest
-        export["VoiceTurnProvenance"] = VoiceTurnProvenance
-        export["VoiceTurnResult"] = VoiceTurnResult
-        export["voice_turn_cache_key"] = voice_turn_cache_key
-        export["process_voice_turn"] = process_voice_turn
-        export["get_tts_provider"] = get_tts_provider
-        export["register_tts_provider"] = register_tts_provider
-        export["clear_tts_router_caches"] = clear_tts_router_caches
-        export["TTSProvider"] = TTSProvider
-        voice_router_available = True
-        tts_router_available = True
-    except ImportError:
-        text_to_speech = None
-        speech_to_text = None
-        get_voice_provider = None
-        register_voice_provider = None
-        get_voice_provider_capabilities = None
-        clear_voice_router_caches = None
-        VoiceProvider = None
-        VoiceProviderCapabilities = None
-        ProviderInfo = None
-        VOICE_TURN_CONTRACT_VERSION = None
-        VOICE_STAGE_STATUSES = None
-        VOICE_TURN_STATUSES = None
-        DEFAULT_GROUNDED_FALLBACK = None
-        GroundingEvidence = None
-        VoiceGroundingSource = None
-        GroundedSlot = None
-        VoiceResponsePlan = None
-        VoiceTemplateProvider = None
-        GraphRAGVoiceTemplateProvider = None
-        buildVoiceGraphRagPromptParts = None
-        VoiceStageTrace = None
-        VoiceTurnRequest = None
-        VoiceTurnProvenance = None
-        VoiceTurnResult = None
-        voice_turn_cache_key = None
-        process_voice_turn = None
-        get_tts_provider = None
-        register_tts_provider = None
-        clear_tts_router_caches = None
-        TTSProvider = None
-        voice_router_available = False
-        tts_router_available = False
-else:
-    text_to_speech = None
-    speech_to_text = None
-    get_voice_provider = None
-    register_voice_provider = None
-    get_voice_provider_capabilities = None
-    clear_voice_router_caches = None
-    VoiceProvider = None
-    VoiceProviderCapabilities = None
-    ProviderInfo = None
-    VOICE_TURN_CONTRACT_VERSION = None
-    VOICE_STAGE_STATUSES = None
-    VOICE_TURN_STATUSES = None
-    DEFAULT_GROUNDED_FALLBACK = None
-    GroundingEvidence = None
-    VoiceGroundingSource = None
-    GroundedSlot = None
-    VoiceResponsePlan = None
-    VoiceTemplateProvider = None
-    GraphRAGVoiceTemplateProvider = None
-    buildVoiceGraphRagPromptParts = None
-    VoiceStageTrace = None
-    VoiceTurnRequest = None
-    VoiceTurnProvenance = None
-    VoiceTurnResult = None
-    voice_turn_cache_key = None
-    process_voice_turn = None
-    get_tts_provider = None
-    register_tts_provider = None
-    clear_tts_router_caches = None
-    TTSProvider = None
-    voice_router_available = False
-    tts_router_available = False
 
 __all__ = [
-    'ipfs_accelerate_py', 'get_instance', 'backends', 'config',
-    'install_depends', 'worker', 'ipfs_multiformats_py',
-    'accelerate_with_browser', 'WebNNWebGPUAccelerator', 'get_accelerator',
-    'webnn_webgpu_available', 'ModelManager', 'get_default_model_manager',
-    'model_manager_available', 'SpaceRuntimeInfo', 'EndpointContract',
-    'OutputBackend', 'LocalFileSystemBackend', 'HFBucketBackend',
-    'HFBucketBackendError',
-    'HFSpaceClient', 'RefreshableGradioFile', 'BatchState', 'BatchProcessor',
-    'is_hf_space_transport_error', 'is_retryable_hf_space_error',
-    'is_stale_gradio_file_error', 'normalize_api_name',
-    'cli_main', 'get_system_logs', 'SystemLogs',
-    'P2PWorkflowScheduler', 'P2PTask', 'WorkflowTag', 'MerkleClock',
-    'FibonacciHeap', 'calculate_hamming_distance',
-    'IPFSKitStorage', 'get_storage', 'reset_storage', 'StorageBackendConfig',
-    'InferenceBackendManager', 'get_backend_manager', 'register_backend_from_config',
-    'inference_backend_manager_available',
-    'auto_patch_transformers',
-    'generate_text', 'get_llm_provider', 'register_llm_provider',
-    'clear_llm_router_caches', 'LLMProvider', 'RouterDeps',
-    'MistralVibeInstallResult', 'ensure_mistral_vibe',
-    'get_default_router_deps', 'set_default_router_deps', 'llm_router_available',
-    'embed_texts', 'embed_texts_batched', 'embed_text', 'get_embeddings_provider',
-    'get_embedding_progress', 'get_last_embedding_trace', 'register_embeddings_provider',
-    'clear_embeddings_router_caches', 'EmbeddingsRouterError', 'EmbeddingsProvider',
-    'embeddings_router_available',
-    'generate_multimodal', 'get_multimodal_provider', 'register_multimodal_provider',
-    'clear_multimodal_router_caches', 'MultimodalProvider', 'multimodal_router_available',
-    'text_to_speech', 'get_tts_provider', 'register_tts_provider',
-    'clear_tts_router_caches', 'TTSProvider', 'tts_router_available',
-    'speech_to_text', 'get_voice_provider', 'register_voice_provider',
-    'get_voice_provider_capabilities',
-    'clear_voice_router_caches', 'VoiceProvider', 'voice_router_available',
-    'VoiceProviderCapabilities', 'ProviderInfo', 'VOICE_TURN_CONTRACT_VERSION',
-    'VOICE_STAGE_STATUSES', 'VOICE_TURN_STATUSES', 'DEFAULT_GROUNDED_FALLBACK',
-    'GroundingEvidence', 'VoiceGroundingSource', 'GroundedSlot',
-    'VoiceResponsePlan', 'VoiceTemplateProvider', 'GraphRAGVoiceTemplateProvider',
-    'buildVoiceGraphRagPromptParts',
-    'VoiceStageTrace', 'VoiceTurnRequest', 'VoiceTurnProvenance',
-    'VoiceTurnResult', 'voice_turn_cache_key', 'process_voice_turn',
+    "ipfs_accelerate_py",
+    "get_instance",
+    "backends",
+    "config",
+    "install_depends",
+    "worker",
+    "ipfs_multiformats_py",
+    "accelerate_with_browser",
+    "WebNNWebGPUAccelerator",
+    "get_accelerator",
+    "webnn_webgpu_available",
+    "ModelManager",
+    "get_default_model_manager",
+    "model_manager_available",
+    "SpaceRuntimeInfo",
+    "EndpointContract",
+    "OutputBackend",
+    "LocalFileSystemBackend",
+    "HFBucketBackend",
+    "HFBucketBackendError",
+    "HFSpaceClient",
+    "RefreshableGradioFile",
+    "BatchState",
+    "BatchProcessor",
+    "is_hf_space_transport_error",
+    "is_retryable_hf_space_error",
+    "is_stale_gradio_file_error",
+    "normalize_api_name",
+    "cli_main",
+    "get_system_logs",
+    "SystemLogs",
+    "P2PWorkflowScheduler",
+    "P2PTask",
+    "WorkflowTag",
+    "MerkleClock",
+    "FibonacciHeap",
+    "calculate_hamming_distance",
+    "IPFSKitStorage",
+    "get_storage",
+    "reset_storage",
+    "StorageBackendConfig",
+    "InferenceBackendManager",
+    "get_backend_manager",
+    "register_backend_from_config",
+    "inference_backend_manager_available",
+    "auto_patch_transformers",
+    "generate_text",
+    "get_llm_provider",
+    "register_llm_provider",
+    "clear_llm_router_caches",
+    "LLMProvider",
+    "RouterDeps",
+    "MistralVibeInstallResult",
+    "ensure_mistral_vibe",
+    "get_default_router_deps",
+    "set_default_router_deps",
+    "llm_router_available",
+    "embed_texts",
+    "embed_texts_batched",
+    "embed_text",
+    "get_embeddings_provider",
+    "get_embedding_progress",
+    "get_last_embedding_trace",
+    "register_embeddings_provider",
+    "clear_embeddings_router_caches",
+    "EmbeddingsRouterError",
+    "EmbeddingsProvider",
+    "embeddings_router_available",
+    "generate_multimodal",
+    "get_multimodal_provider",
+    "register_multimodal_provider",
+    "clear_multimodal_router_caches",
+    "MultimodalProvider",
+    "multimodal_router_available",
+    "text_to_speech",
+    "get_tts_provider",
+    "register_tts_provider",
+    "clear_tts_router_caches",
+    "TTSProvider",
+    "tts_router_available",
+    "speech_to_text",
+    "get_voice_provider",
+    "register_voice_provider",
+    "get_voice_provider_capabilities",
+    "clear_voice_router_caches",
+    "VoiceProvider",
+    "voice_router_available",
+    "VoiceProviderCapabilities",
+    "ProviderInfo",
+    "VOICE_TURN_CONTRACT_VERSION",
+    "VOICE_STAGE_STATUSES",
+    "VOICE_TURN_STATUSES",
+    "DEFAULT_GROUNDED_FALLBACK",
+    "GroundingEvidence",
+    "VoiceGroundingSource",
+    "GroundedSlot",
+    "VoiceResponsePlan",
+    "VoiceTemplateProvider",
+    "GraphRAGVoiceTemplateProvider",
+    "buildVoiceGraphRagPromptParts",
+    "VoiceStageTrace",
+    "VoiceTurnRequest",
+    "VoiceTurnProvenance",
+    "VoiceTurnResult",
+    "voice_turn_cache_key",
+    "process_voice_turn",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "worker":
+        return _load_legacy_worker()
+    if name in _NAME_TO_GROUP:
+        return _resolve_public(name)
+    if name == "cli_main" and SKIP_CORE:
+        return None
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class _IPFSAccelerateModule(ModuleType):
     """Keep the lazy root worker canonical across subpackage import order."""
 
-    def __getattribute__(self, name):
+    def __getattribute__(self, name: str) -> Any:
         if name == "worker":
             namespace = ModuleType.__getattribute__(self, "__dict__")
             return namespace["_load_legacy_worker"]()
+        namespace = ModuleType.__getattribute__(self, "__dict__")
+        if name in namespace.get("_NAME_TO_GROUP", ()):
+            return namespace["_resolve_public"](name)
         return ModuleType.__getattribute__(self, name)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name != "worker":
             ModuleType.__setattr__(self, name, value)
             return
         namespace = ModuleType.__getattribute__(self, "__dict__")
-        # Importlib installs the worker package on its parent before the
-        # historical concrete ``worker.worker`` module is selected. Preserve
-        # that raw bookkeeping without turning it into the canonical export.
         if (
             isinstance(value, ModuleType)
             and value.__name__ == f"{namespace['__name__']}.worker"
@@ -962,7 +1012,8 @@ class _IPFSAccelerateModule(ModuleType):
         with condition:
             while (
                 namespace["_worker_loading"]
-                and namespace["_worker_loader_thread_id"] != threading.get_ident()
+                and namespace["_worker_loader_thread_id"]
+                != threading.get_ident()
             ):
                 condition.wait()
             namespace["_worker_export_value"] = value
@@ -972,7 +1023,7 @@ class _IPFSAccelerateModule(ModuleType):
                 dict.__setitem__(export_map, "worker", value)
             condition.notify_all()
 
-    def __delattr__(self, name):
+    def __delattr__(self, name: str) -> None:
         if name != "worker":
             ModuleType.__delattr__(self, name)
             return
@@ -982,7 +1033,9 @@ class _IPFSAccelerateModule(ModuleType):
             while namespace["_worker_loading"]:
                 condition.wait()
             namespace["_worker_export_value"] = (
-                None if namespace["SKIP_CORE"] else namespace["_WORKER_UNRESOLVED"]
+                None
+                if namespace["SKIP_CORE"]
+                else namespace["_WORKER_UNRESOLVED"]
             )
             namespace.pop("worker", None)
             export_map = namespace.get("export")
@@ -996,15 +1049,11 @@ class _IPFSAccelerateModule(ModuleType):
                 )
             condition.notify_all()
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         namespace = ModuleType.__getattribute__(self, "__dict__")
         return sorted(set(namespace).union(namespace.get("__all__", ())))
 
 
 sys.modules[__name__].__class__ = _IPFSAccelerateModule
 
-# Package version -- keep aligned with pyproject.toml / setup.py on every release.
-# A separate runtime string previously drifted to 0.4.0; packaging metadata is
-# the product pin (CHANGELOG, PyPI workflow).
-_PACKAGING_VERSION = "0.0.45"
-__version__ = _PACKAGING_VERSION
+__version__ = "0.4.0"

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/__init__.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/__init__.py
@@ -1,5 +1,7 @@
 """Reusable lifecycle helpers for unattended optimizer todo daemons."""
 
+import importlib
+
 from .core import (
     DaemonHealth,
     EnsureResult,
@@ -853,28 +855,29 @@ _IMPLEMENTATION_SUPERVISOR_EXPORTS = {
     "supervisor_config_from_args",
 }
 
-_LAZY_IMPLEMENTATION_SUBMODULES = {
-    "implementation_daemon",
-    "implementation_supervisor",
+_LAZY_IMPLEMENTATION_MODULES = {
+    "implementation_daemon": _IMPLEMENTATION_DAEMON_EXPORTS,
+    "implementation_supervisor": _IMPLEMENTATION_SUPERVISOR_EXPORTS,
 }
 
 
-def _load_lazy_export(module_name, name):
-    from importlib import import_module
+def _load_implementation_module(module_name):
+    """Load and cache one implementation surface on explicit access."""
 
-    module = import_module(f"{__name__}.{module_name}")
-    value = module if name == module_name else getattr(module, name)
-    globals()[name] = value
-    return value
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    globals()[module_name] = module
+    for export_name in _LAZY_IMPLEMENTATION_MODULES[module_name]:
+        globals()[export_name] = getattr(module, export_name)
+    return module
 
 
 def __getattr__(name):
-    if name in _IMPLEMENTATION_DAEMON_EXPORTS:
-        return _load_lazy_export("implementation_daemon", name)
-    if name in _IMPLEMENTATION_SUPERVISOR_EXPORTS:
-        return _load_lazy_export("implementation_supervisor", name)
-    if name in _LAZY_IMPLEMENTATION_SUBMODULES:
-        return _load_lazy_export(name, name)
+    if name in _LAZY_IMPLEMENTATION_MODULES:
+        return _load_implementation_module(name)
+    for module_name, export_names in _LAZY_IMPLEMENTATION_MODULES.items():
+        if name in export_names:
+            module = _load_implementation_module(module_name)
+            return getattr(module, name)
     if name in _LEGAL_PARSER_EXPORTS:
         from . import legal_parser
 
@@ -884,3 +887,11 @@ def __getattr__(name):
 
         return getattr(logic_port, name)
     raise AttributeError(name)
+
+
+def __dir__():
+    return sorted(
+        set(globals())
+        .union(__all__)
+        .union(_LAZY_IMPLEMENTATION_MODULES)
+    )

--- a/ipfs_accelerate_py/config/config.py
+++ b/ipfs_accelerate_py/config/config.py
@@ -12,25 +12,6 @@ try:
 except ImportError:  # pragma: no cover
     toml = importlib.import_module("toml")  # type: ignore[assignment]
 
-try:
-    from ...common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-except ImportError:
-    try:
-        from ..common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-    except ImportError:
-        try:
-            from test.common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-        except ImportError:
-            HAVE_STORAGE_WRAPPER = False
-
-if HAVE_STORAGE_WRAPPER:
-    try:
-        _storage = get_storage_wrapper(auto_detect_ci=True)
-    except Exception:
-        _storage = None
-else:
-    _storage = None
-
 class config():
     def __init__(self, collection=None, meta=None):
         this_dir = os.path.dirname(os.path.realpath(__file__))

--- a/ipfs_accelerate_py/github_cli/__init__.py
+++ b/ipfs_accelerate_py/github_cli/__init__.py
@@ -1,12 +1,22 @@
-"""GitHub CLI integration for IPFS Accelerate."""
+"""GitHub CLI integration with a scoped, lazy package surface."""
 
-from .wrapper import GitHubCLI, RunnerManager, WorkflowQueue
-from .cache import GitHubAPICache, get_global_cache, configure_cache
-from .graphql_wrapper import GitHubGraphQL
+from __future__ import annotations
 
-# Backwards compatibility: older callers imported WorkflowManager from this
-# package even though the concrete implementation class is WorkflowQueue.
-WorkflowManager = WorkflowQueue
+import importlib
+from typing import Any
+
+
+_EXPORTS = {
+    "GitHubCLI": (".wrapper", "GitHubCLI"),
+    "RunnerManager": (".wrapper", "RunnerManager"),
+    "WorkflowQueue": (".wrapper", "WorkflowQueue"),
+    # Historical alias of WorkflowQueue.
+    "WorkflowManager": (".wrapper", "WorkflowQueue"),
+    "GitHubAPICache": (".cache", "GitHubAPICache"),
+    "get_global_cache": (".cache", "get_global_cache"),
+    "configure_cache": (".cache", "configure_cache"),
+    "GitHubGraphQL": (".graphql_wrapper", "GitHubGraphQL"),
+}
 
 __all__ = [
     "GitHubCLI",
@@ -16,5 +26,23 @@ __all__ = [
     "GitHubAPICache",
     "get_global_cache",
     "configure_cache",
-    "GitHubGraphQL"
+    "GitHubGraphQL",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    spec = _EXPORTS.get(name)
+    if spec is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attribute_name = spec
+    module = importlib.import_module(f"{__name__}{module_name}")
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    if name in {"WorkflowQueue", "WorkflowManager"}:
+        globals()["WorkflowQueue"] = value
+        globals()["WorkflowManager"] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()).union(__all__))

--- a/ipfs_accelerate_py/github_cli/cache.py
+++ b/ipfs_accelerate_py/github_cli/cache.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import socket
+import sys
 import time
 import hashlib
 import base64
@@ -23,26 +24,45 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Set
 from threading import Lock
 
-try:
-    from ...common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-except ImportError:
-    try:
-        from ..common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-    except ImportError:
+
+# Compatibility injection point.  The production storage implementation is
+# imported only when a GitHubAPICache instance is explicitly constructed.
+storage_wrapper = None
+HAVE_STORAGE_WRAPPER = False
+_STORAGE_WRAPPER_IMPORT_ATTEMPTED = False
+_STORAGE_WRAPPER_IMPORT_LOCK = Lock()
+
+
+def _resolve_storage_wrapper():
+    global HAVE_STORAGE_WRAPPER
+    global _STORAGE_WRAPPER_IMPORT_ATTEMPTED
+    global storage_wrapper
+
+    if callable(storage_wrapper):
+        HAVE_STORAGE_WRAPPER = True
+        return storage_wrapper
+    if _STORAGE_WRAPPER_IMPORT_ATTEMPTED:
+        return None
+    with _STORAGE_WRAPPER_IMPORT_LOCK:
+        if callable(storage_wrapper):
+            HAVE_STORAGE_WRAPPER = True
+            return storage_wrapper
+        if _STORAGE_WRAPPER_IMPORT_ATTEMPTED:
+            return None
         try:
-            from test.common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
+            from ..common.storage_wrapper import (
+                HAVE_STORAGE_WRAPPER as available,
+                get_storage_wrapper,
+            )
         except ImportError:
-            HAVE_STORAGE_WRAPPER = False
-
-storage_wrapper = get_storage_wrapper if HAVE_STORAGE_WRAPPER else None
-
-if HAVE_STORAGE_WRAPPER:
-    try:
-        _storage = get_storage_wrapper(auto_detect_ci=True)
-    except Exception:
-        _storage = None
-else:
-    _storage = None
+            available = False
+            get_storage_wrapper = None
+        _STORAGE_WRAPPER_IMPORT_ATTEMPTED = True
+        HAVE_STORAGE_WRAPPER = bool(available and get_storage_wrapper)
+        storage_wrapper = (
+            get_storage_wrapper if HAVE_STORAGE_WRAPPER else None
+        )
+        return storage_wrapper
 
 # Try to import cryptography for message encryption
 try:
@@ -58,16 +78,76 @@ except ImportError:
     hashes = None
     default_backend = None
 
-# Try to import multiformats for content-addressed caching
-# Note: multiformats provides its own multihash submodule, separate from pymultihash
-try:
-    from multiformats import CID
-    from multiformats import multihash as multiformats_multihash
+# Resolve multiformats only when content addressing is actually requested.
+#
+# Importing ``ipfs_accelerate_py.testing.proof_reuse.plugin`` first imports the
+# package root, which reaches this module through optional GitHub/voice
+# integrations.  A module-level multiformats probe therefore made the otherwise
+# cold pytest bootstrap depend on an unrelated optional cache dependency.
+# Keep that bootstrap side-effect free while preserving the SHA-256 fallback
+# when multiformats is genuinely unavailable.
+_loaded_multiformats = sys.modules.get("multiformats")
+CID = getattr(_loaded_multiformats, "CID", None)
+multiformats_multihash = getattr(_loaded_multiformats, "multihash", None)
+HAVE_MULTIFORMATS = CID is not None and multiformats_multihash is not None
+_MULTIFORMATS_IMPORT_ATTEMPTED = HAVE_MULTIFORMATS
+_MULTIFORMATS_IMPORT_LOCK = Lock()
+
+
+def _adopt_loaded_multiformats() -> bool:
+    """Adopt a provider loaded by an authorized installer in this process."""
+
+    global CID
+    global HAVE_MULTIFORMATS
+    global multiformats_multihash
+
+    loaded = sys.modules.get("multiformats")
+    cid_type = getattr(loaded, "CID", None)
+    multihash_module = getattr(loaded, "multihash", None)
+    if cid_type is None or multihash_module is None:
+        return False
+    CID = cid_type
+    multiformats_multihash = multihash_module
     HAVE_MULTIFORMATS = True
-except ImportError:
-    HAVE_MULTIFORMATS = False
-    CID = None
-    multiformats_multihash = None
+    return True
+
+
+def _ensure_multiformats() -> bool:
+    """Load the optional content-addressing provider at first real use."""
+
+    global CID
+    global HAVE_MULTIFORMATS
+    global multiformats_multihash
+    global _MULTIFORMATS_IMPORT_ATTEMPTED
+
+    if HAVE_MULTIFORMATS:
+        return True
+    # A controlled proof-reuse installer may make the provider available after
+    # an earlier negative probe. Positive capability is stable, while cached
+    # absence must not mask that explicit in-process transition.
+    if _adopt_loaded_multiformats():
+        return True
+    if _MULTIFORMATS_IMPORT_ATTEMPTED:
+        return HAVE_MULTIFORMATS
+
+    with _MULTIFORMATS_IMPORT_LOCK:
+        if HAVE_MULTIFORMATS or _adopt_loaded_multiformats():
+            return True
+        if _MULTIFORMATS_IMPORT_ATTEMPTED:
+            return HAVE_MULTIFORMATS
+        try:
+            from multiformats import CID as cid_type
+            from multiformats import multihash as multihash_module
+        except ImportError:
+            HAVE_MULTIFORMATS = False
+        else:
+            CID = cid_type
+            multiformats_multihash = multihash_module
+            HAVE_MULTIFORMATS = True
+        finally:
+            _MULTIFORMATS_IMPORT_ATTEMPTED = True
+
+    return HAVE_MULTIFORMATS
 
 # Legacy raw cache P2P is disabled. Distributed cache sharing is handled by
 # ipfs_accelerate_py.p2p_tasks through the MCP++ TaskQueue cache tools.
@@ -154,9 +234,10 @@ class GitHubAPICache:
             enable_universal_connectivity: Whether to enable universal connectivity patterns
         """
         # Initialize storage wrapper
-        if storage_wrapper:
+        storage_factory = _resolve_storage_wrapper()
+        if storage_factory:
             try:
-                self.storage = storage_wrapper()
+                self.storage = storage_factory()
             except:
                 self.storage = None
         else:
@@ -459,7 +540,7 @@ class GitHubAPICache:
         # Sort fields for deterministic hashing
         sorted_fields = json.dumps(validation_fields, sort_keys=True)
 
-        if HAVE_MULTIFORMATS:
+        if _ensure_multiformats():
             # Use multiformats for content-addressed hashing
             content_bytes = sorted_fields.encode('utf-8')
             hasher = hashlib.sha256()
@@ -1142,7 +1223,7 @@ class GitHubAPICache:
                 "raw_p2p_cache_requested": bool(getattr(self, "raw_p2p_cache_requested", False)),
                 "p2p_transport": "mcpplusplus-taskqueue-cache" if getattr(self, "enable_task_p2p_cache", False) else "local-only",
                 "task_p2p_cache_enabled": bool(getattr(self, "enable_task_p2p_cache", False)),
-                "content_addressing_available": HAVE_MULTIFORMATS,
+                "content_addressing_available": _ensure_multiformats(),
                 "cache_dir": str(self.cache_dir) if self.enable_persistence else "",
             }
 

--- a/ipfs_accelerate_py/install_depends/install_depends.py
+++ b/ipfs_accelerate_py/install_depends/install_depends.py
@@ -9,24 +9,43 @@ import re
 from pathlib import Path
 from typing import Optional, Tuple, List, Dict, Any
 
-try:
-    from ...common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-except ImportError:
-    try:
-        from ..common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-    except ImportError:
-        try:
-            from test.common.storage_wrapper import get_storage_wrapper, HAVE_STORAGE_WRAPPER
-        except ImportError:
-            HAVE_STORAGE_WRAPPER = False
 
-if HAVE_STORAGE_WRAPPER:
+def _resolve_storage(resources: Any) -> Any:
+    """Resolve optional storage only for an installer instance.
+
+    Importing the dependency installer is a capability-discovery operation and
+    must not initialize IPFS storage.  Callers can inject either an existing
+    ``storage``/``storage_wrapper`` object or a ``get_storage_wrapper`` factory.
+    """
+
+    if isinstance(resources, dict):
+        injected = resources.get("storage")
+        if injected is None:
+            injected = resources.get("storage_wrapper")
+        if injected is not None and not callable(injected):
+            return injected
+        factory = resources.get("get_storage_wrapper")
+        if factory is None and callable(injected):
+            factory = injected
+    else:
+        factory = None
+
+    if factory is None:
+        try:
+            from ..common.storage_wrapper import (
+                HAVE_STORAGE_WRAPPER,
+                get_storage_wrapper,
+            )
+        except ImportError:
+            return None
+        if not HAVE_STORAGE_WRAPPER:
+            return None
+        factory = get_storage_wrapper
+
     try:
-        _storage = get_storage_wrapper(auto_detect_ci=True)
+        return factory(auto_detect_ci=True)
     except Exception:
-        _storage = None
-else:
-    _storage = None
+        return None
 
 class install_depends_py():
     def __init__(self, resources, metadata):
@@ -38,7 +57,7 @@ class install_depends_py():
         self.install_results = {}
 
         # Optional distributed storage integration
-        self.storage = _storage
+        self.storage = _resolve_storage(resources)
 
         # Optional test harness callback (only if the caller provides it).
         # Importing `test.test_ipfs_accelerate` at init-time is expensive and brittle,

--- a/ipfs_accelerate_py/p2p_tasks/__init__.py
+++ b/ipfs_accelerate_py/p2p_tasks/__init__.py
@@ -1,87 +1,89 @@
-"""Peer-to-peer TaskQueue transport + worker helpers.
+"""Lazy public surface for peer-to-peer TaskQueue helpers.
 
-This package is intended to be reusable by long-running services (e.g. systemd)
-that want to participate in the distributed TaskQueue network.
-
-It is intentionally dependency-minimal and uses py-libp2p for transport.
+Importing a dependency-light leaf such as :mod:`p2p_tasks.task_types` must not
+initialize the network service, worker, MCP bridge, or GitHub cache.  Public
+compatibility exports are therefore resolved only when explicitly requested.
 """
 
-from .protocol import PROTOCOL_V1, auth_ok, get_shared_token
-from .peer_trust import PeerTrustLevel, baseline_max_claim_priority, resolve_peer_trust_level, trust_tiers_enabled
-from .task_queue import TaskQueue, default_queue_path
-from .service import serve_task_queue
-from .client import (
-    RemoteQueue,
-    submit_task,
-    submit_task_with_info,
-    submit_task_sync,
-    submit_task_with_info_sync,
-    submit_docker_hub_task,
-    submit_docker_hub_task_sync,
-    submit_docker_github_task,
-    submit_docker_github_task_sync,
-    claim_next,
-    claim_next_sync,
-    heartbeat,
-    heartbeat_sync,
-    list_tasks,
-    list_tasks_sync,
-    complete_task,
-    complete_task_sync,
-    get_task,
-    wait_task,
-    get_capabilities,
-    get_capabilities_sync,
-    call_tool,
-    call_tool_sync,
-    cache_get,
-    cache_get_sync,
-    cache_has,
-    cache_has_sync,
-    cache_set,
-    cache_set_sync,
-)
-from .worker import run_worker
+from __future__ import annotations
 
-__all__ = [
-    "PROTOCOL_V1",
-    "auth_ok",
-    "get_shared_token",
-    "PeerTrustLevel",
-    "baseline_max_claim_priority",
-    "resolve_peer_trust_level",
-    "trust_tiers_enabled",
-    "TaskQueue",
-    "default_queue_path",
-    "serve_task_queue",
-    "RemoteQueue",
-    "submit_task",
-    "submit_task_with_info",
-    "submit_task_sync",
-    "submit_task_with_info_sync",
-    "submit_docker_hub_task",
-    "submit_docker_hub_task_sync",
-    "submit_docker_github_task",
-    "submit_docker_github_task_sync",
-    "claim_next",
-    "claim_next_sync",
-    "heartbeat",
-    "heartbeat_sync",
-    "list_tasks",
-    "list_tasks_sync",
-    "complete_task",
-    "complete_task_sync",
-    "get_task",
-    "wait_task",
-    "get_capabilities",
-    "get_capabilities_sync",
-    "call_tool",
-    "call_tool_sync",
-    "cache_get",
-    "cache_get_sync",
-    "cache_has",
-    "cache_has_sync",
-    "cache_set",
-    "cache_set_sync",
-    "run_worker",
-]
+import importlib
+from typing import Final
+
+_EXPORTS: Final[dict[str, tuple[str, str]]] = {
+    "PROTOCOL_V1": ("protocol", "PROTOCOL_V1"),
+    "auth_ok": ("protocol", "auth_ok"),
+    "get_shared_token": ("protocol", "get_shared_token"),
+    "PeerTrustLevel": ("peer_trust", "PeerTrustLevel"),
+    "baseline_max_claim_priority": (
+        "peer_trust",
+        "baseline_max_claim_priority",
+    ),
+    "resolve_peer_trust_level": ("peer_trust", "resolve_peer_trust_level"),
+    "trust_tiers_enabled": ("peer_trust", "trust_tiers_enabled"),
+    "TaskQueue": ("task_queue", "TaskQueue"),
+    "default_queue_path": ("task_queue", "default_queue_path"),
+    "serve_task_queue": ("service", "serve_task_queue"),
+    "RemoteQueue": ("client", "RemoteQueue"),
+    "submit_task": ("client", "submit_task"),
+    "submit_task_with_info": ("client", "submit_task_with_info"),
+    "submit_task_sync": ("client", "submit_task_sync"),
+    "submit_task_with_info_sync": ("client", "submit_task_with_info_sync"),
+    "submit_docker_hub_task": ("client", "submit_docker_hub_task"),
+    "submit_docker_hub_task_sync": (
+        "client",
+        "submit_docker_hub_task_sync",
+    ),
+    "submit_docker_github_task": ("client", "submit_docker_github_task"),
+    "submit_docker_github_task_sync": (
+        "client",
+        "submit_docker_github_task_sync",
+    ),
+    "claim_next": ("client", "claim_next"),
+    "claim_next_sync": ("client", "claim_next_sync"),
+    "heartbeat": ("client", "heartbeat"),
+    "heartbeat_sync": ("client", "heartbeat_sync"),
+    "list_tasks": ("client", "list_tasks"),
+    "list_tasks_sync": ("client", "list_tasks_sync"),
+    "complete_task": ("client", "complete_task"),
+    "complete_task_sync": ("client", "complete_task_sync"),
+    "get_task": ("client", "get_task"),
+    "wait_task": ("client", "wait_task"),
+    "get_capabilities": ("client", "get_capabilities"),
+    "get_capabilities_sync": ("client", "get_capabilities_sync"),
+    "call_tool": ("client", "call_tool"),
+    "call_tool_sync": ("client", "call_tool_sync"),
+    "cache_get": ("client", "cache_get"),
+    "cache_get_sync": ("client", "cache_get_sync"),
+    "cache_has": ("client", "cache_has"),
+    "cache_has_sync": ("client", "cache_has_sync"),
+    "cache_set": ("client", "cache_set"),
+    "cache_set_sync": ("client", "cache_set_sync"),
+    "run_worker": ("worker", "run_worker"),
+}
+_MODULE_EXPORTS: Final = frozenset(
+    {"client", "peer_trust", "protocol", "service", "task_queue", "worker"}
+)
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str):
+    """Resolve one compatibility export without importing unrelated stacks."""
+
+    if name in _MODULE_EXPORTS:
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    try:
+        module_name, attribute_name = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()).union(__all__).union(_MODULE_EXPORTS))

--- a/test/api/test_github_cache_lazy_multiformats.py
+++ b/test/api/test_github_cache_lazy_multiformats.py
@@ -1,0 +1,99 @@
+"""Regression tests for the GitHub cache's lazy CID provider."""
+
+from __future__ import annotations
+
+import builtins
+import hashlib
+import json
+import sys
+from types import ModuleType
+
+from ipfs_accelerate_py.github_cli import cache as cache_module
+
+
+def _reset_lazy_state(monkeypatch) -> None:
+    monkeypatch.setattr(cache_module, "CID", None)
+    monkeypatch.setattr(cache_module, "multiformats_multihash", None)
+    monkeypatch.setattr(cache_module, "HAVE_MULTIFORMATS", False)
+    monkeypatch.setattr(
+        cache_module,
+        "_MULTIFORMATS_IMPORT_ATTEMPTED",
+        False,
+    )
+
+
+def test_missing_multiformats_falls_back_once(monkeypatch) -> None:
+    _reset_lazy_state(monkeypatch)
+    monkeypatch.delitem(sys.modules, "multiformats", raising=False)
+    attempts: list[str] = []
+    real_import = builtins.__import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "multiformats" or name.startswith("multiformats."):
+            attempts.append(name)
+            raise ModuleNotFoundError(
+                "optional CID provider unavailable",
+                name="multiformats",
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    fields = {"updatedAt": "2026-08-01T00:00:00Z", "revision": 7}
+    canonical = json.dumps(fields, sort_keys=True).encode("utf-8")
+    expected = hashlib.sha256(canonical).hexdigest()
+
+    assert cache_module.GitHubAPICache._compute_validation_hash(fields) == expected
+    assert cache_module.GitHubAPICache._compute_validation_hash(fields) == expected
+    assert attempts == ["multiformats"]
+    assert cache_module.HAVE_MULTIFORMATS is False
+
+
+def test_preloaded_multiformats_preserves_capability_contract(monkeypatch) -> None:
+    _reset_lazy_state(monkeypatch)
+    provider = ModuleType("multiformats")
+
+    class FakeCID:
+        pass
+
+    fake_multihash = object()
+    provider.CID = FakeCID
+    provider.multihash = fake_multihash
+    monkeypatch.setitem(sys.modules, "multiformats", provider)
+
+    assert cache_module._ensure_multiformats() is True
+    assert cache_module.HAVE_MULTIFORMATS is True
+    assert cache_module.CID is FakeCID
+    assert cache_module.multiformats_multihash is fake_multihash
+
+
+def test_negative_probe_recovers_after_authorized_provider_load(monkeypatch) -> None:
+    _reset_lazy_state(monkeypatch)
+    monkeypatch.delitem(sys.modules, "multiformats", raising=False)
+    real_import = builtins.__import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "multiformats" or name.startswith("multiformats."):
+            raise ModuleNotFoundError(
+                "optional CID provider unavailable",
+                name="multiformats",
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    assert cache_module._ensure_multiformats() is False
+    assert cache_module._MULTIFORMATS_IMPORT_ATTEMPTED is True
+
+    provider = ModuleType("multiformats")
+
+    class InstalledCID:
+        pass
+
+    installed_multihash = object()
+    provider.CID = InstalledCID
+    provider.multihash = installed_multihash
+    monkeypatch.setitem(sys.modules, "multiformats", provider)
+
+    assert cache_module._ensure_multiformats() is True
+    assert cache_module.CID is InstalledCID
+    assert cache_module.multiformats_multihash is installed_multihash
+    assert cache_module.HAVE_MULTIFORMATS is True

--- a/test/api/test_p2p_tasks_lazy_package.py
+++ b/test/api/test_p2p_tasks_lazy_package.py
@@ -1,0 +1,62 @@
+"""Compatibility checks for the lazy :mod:`p2p_tasks` package surface."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ACCELERATE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_historical_module_aliases_resolve_only_on_access() -> None:
+    environment = dict(os.environ)
+    environment["IPFS_ACCEL_SKIP_CORE"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (
+            str(ACCELERATE_ROOT),
+            environment.get("PYTHONPATH", ""),
+        )
+        if part
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import sys
+                import ipfs_accelerate_py.p2p_tasks as package
+
+                aliases = (
+                    "client",
+                    "peer_trust",
+                    "protocol",
+                    "service",
+                    "task_queue",
+                    "worker",
+                )
+                assert all(
+                    f"{package.__name__}.{name}" not in sys.modules
+                    for name in aliases
+                )
+                assert all(name not in package.__all__ for name in aliases)
+                for name in aliases:
+                    module = getattr(package, name)
+                    assert module.__name__ == f"{package.__name__}.{name}"
+                    assert getattr(package, name) is module
+                """
+            ),
+        ],
+        cwd=ACCELERATE_ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/test/api/test_package_root_cold_surface.py
+++ b/test/api/test_package_root_cold_surface.py
@@ -1,0 +1,389 @@
+"""Cold-import and exact-object contracts for the accelerator package root."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ACCELERATE_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(script: str, *, skip_core: bool = False) -> None:
+    environment = dict(os.environ)
+    environment["IPFS_ACCEL_SKIP_CORE"] = "1" if skip_core else "0"
+    environment["IPFS_ACCEL_IMPORT_EAGER"] = "0"
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (
+            str(ACCELERATE_ROOT),
+            environment.get("PYTHONPATH", ""),
+        )
+        if part
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=ACCELERATE_ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_proof_plugin_import_has_no_root_initialization_side_effects() -> None:
+    _run(
+        """
+        import builtins
+        import os
+        import pathlib
+        import socket
+        import subprocess
+        import sys
+        import tempfile
+        import threading
+
+        path_before = list(sys.path)
+        meta_path_before = list(sys.meta_path)
+
+        def forbidden(operation):
+            def fail(*args, **kwargs):
+                raise AssertionError(f"{operation} during cold plugin import")
+            return fail
+
+        original_open = builtins.open
+        def guarded_open(file, mode="r", *args, **kwargs):
+            if any(flag in mode for flag in ("w", "a", "x", "+")):
+                raise AssertionError(f"write-open during cold import: {file!r}")
+            return original_open(file, mode, *args, **kwargs)
+        builtins.open = guarded_open
+
+        os.mkdir = forbidden("os.mkdir")
+        os.makedirs = forbidden("os.makedirs")
+        os.remove = forbidden("os.remove")
+        os.unlink = forbidden("os.unlink")
+        os.rename = forbidden("os.rename")
+        os.replace = forbidden("os.replace")
+        pathlib.Path.mkdir = forbidden("Path.mkdir")
+        pathlib.Path.touch = forbidden("Path.touch")
+        pathlib.Path.unlink = forbidden("Path.unlink")
+        pathlib.Path.write_bytes = forbidden("Path.write_bytes")
+        pathlib.Path.write_text = forbidden("Path.write_text")
+        tempfile.mkstemp = forbidden("tempfile.mkstemp")
+        tempfile.mkdtemp = forbidden("tempfile.mkdtemp")
+        tempfile.NamedTemporaryFile = forbidden("NamedTemporaryFile")
+
+        socket.create_connection = forbidden("socket.create_connection")
+        original_socket = socket.socket
+        class GuardedSocket(original_socket):
+            connect = forbidden("socket.connect")
+            connect_ex = forbidden("socket.connect_ex")
+        socket.socket = GuardedSocket
+
+        subprocess.Popen = forbidden("subprocess.Popen")
+        subprocess.run = forbidden("subprocess.run")
+        subprocess.call = forbidden("subprocess.call")
+        subprocess.check_call = forbidden("subprocess.check_call")
+        subprocess.check_output = forbidden("subprocess.check_output")
+        threading.Thread.start = forbidden("threading.Thread.start")
+
+        import ipfs_accelerate_py.testing.proof_reuse.plugin as plugin
+        import ipfs_accelerate_py as package
+
+        assert plugin.PLUGIN_NAME == "ipfs-proof-reuse"
+        assert sys.path == path_before
+        assert sys.meta_path == meta_path_before
+        assert len(package.__all__) == 106
+        assert len(package.export) == 100
+        availability_only = {
+            "inference_backend_manager_available",
+            "llm_router_available",
+            "embeddings_router_available",
+            "multimodal_router_available",
+            "tts_router_available",
+            "voice_router_available",
+        }
+        assert set(package.export) == set(package.__all__) - availability_only
+
+        forbidden_prefixes = (
+            "ipfs_kit_py",
+            "ipfs_datasets_py",
+            "test",
+            "multiformats",
+            "ipfs_accelerate_py.ipfs_accelerate",
+            "ipfs_accelerate_py.ipfs_multiformats",
+            "ipfs_accelerate_py.container_backends",
+            "ipfs_accelerate_py.inference_backend_manager",
+            "ipfs_accelerate_py.github_cli",
+            "ipfs_accelerate_py.llm_router",
+            "ipfs_accelerate_py.embeddings_router",
+            "ipfs_accelerate_py.multimodal_router",
+            "ipfs_accelerate_py.voice_router",
+            "ipfs_accelerate_py.worker",
+        )
+        loaded = [
+            name
+            for name in sys.modules
+            if any(
+                name == prefix or name.startswith(prefix + ".")
+                for prefix in forbidden_prefixes
+            )
+        ]
+        assert loaded == [], loaded
+
+        raw_export = dict(package.export)
+        assert raw_export["ipfs_multiformats_py"] is None
+        assert raw_export["ModelManager"] is None
+        """
+    )
+
+
+def test_scoped_support_module_imports_do_not_acquire_storage_or_tests() -> None:
+    _run(
+        """
+        import importlib
+        import sys
+
+        storage_name = "ipfs_accelerate_py.common.storage_wrapper"
+        assert storage_name not in sys.modules
+        for module_name in (
+            "ipfs_accelerate_py.config.config",
+            "ipfs_accelerate_py.install_depends.install_depends",
+            "ipfs_accelerate_py.github_cli.cache",
+        ):
+            importlib.import_module(module_name)
+            assert storage_name not in sys.modules, module_name
+            assert not any(
+                name == "test" or name.startswith("test.")
+                for name in sys.modules
+            ), module_name
+        """
+    )
+
+
+def test_lazy_root_access_returns_and_caches_exact_objects() -> None:
+    _run(
+        """
+        import inspect
+        import ipfs_accelerate_py as package
+
+        assert "ipfs_accelerate_py.ipfs_multiformats" not in __import__(
+            "sys"
+        ).modules
+        via_getattr = package.ipfs_multiformats_py
+        from ipfs_accelerate_py import ipfs_multiformats_py as via_from
+        from ipfs_accelerate_py.ipfs_multiformats import (
+            ipfs_multiformats_py as real_multiformats,
+        )
+        assert via_getattr is real_multiformats
+        assert via_from is real_multiformats
+        assert package.export["ipfs_multiformats_py"] is real_multiformats
+        assert package.ipfs_multiformats_py is real_multiformats
+        assert via_getattr.__module__ == real_multiformats.__module__
+        assert via_getattr.__name__ == real_multiformats.__name__
+        assert via_getattr.__qualname__ == real_multiformats.__qualname__
+        assert inspect.signature(via_getattr) == inspect.signature(
+            real_multiformats
+        )
+        assert issubclass(via_getattr, real_multiformats)
+
+        from ipfs_accelerate_py import config as via_config_from
+        from ipfs_accelerate_py.config.config import config as real_config
+        assert via_config_from is real_config
+        assert package.config is real_config
+        assert package.export["config"] is real_config
+
+        from ipfs_accelerate_py import install_depends as via_install_from
+        real_install = __import__("importlib").import_module(
+            "ipfs_accelerate_py.install_depends.install_depends"
+        )
+        assert via_install_from is real_install
+        assert package.install_depends is real_install
+        assert package.export["install_depends"] is real_install
+
+        from ipfs_accelerate_py import backends as via_backends_from
+        from ipfs_accelerate_py.container_backends import backends as real_backends
+        assert via_backends_from is real_backends
+        assert package.backends is real_backends
+        assert package.export["backends"] is real_backends
+        """
+    )
+
+
+def test_missing_multiformats_is_bounded_then_recovers_after_install() -> None:
+    _run(
+        """
+        import importlib.abc
+        import importlib
+        import sys
+
+        class BlockMultiformats(importlib.abc.MetaPathFinder):
+            enabled = True
+            attempts = 0
+
+            def find_spec(self, fullname, path=None, target=None):
+                if self.enabled and (
+                    fullname == "multiformats"
+                    or fullname.startswith("multiformats.")
+                    or fullname == "ipfs_accelerate_py.ipfs_multiformats"
+                ):
+                    self.attempts += 1
+                    raise ModuleNotFoundError(
+                        f"blocked optional provider: {fullname}",
+                        name=fullname,
+                    )
+                return None
+
+        blocker = BlockMultiformats()
+        sys.meta_path.insert(0, blocker)
+        import ipfs_accelerate_py as package
+        from ipfs_accelerate_py import ipfs_multiformats_py
+
+        assert ipfs_multiformats_py is None
+        assert package.ipfs_multiformats_py is None
+        assert package.export["ipfs_multiformats_py"] is None
+        assert dict(package.export)["ipfs_multiformats_py"] is None
+        first_attempts = blocker.attempts
+        assert first_attempts > 0
+
+        # Immediate repeated reads use the bounded negative result.
+        assert package.ipfs_multiformats_py is None
+        assert blocker.attempts == first_attempts
+
+        # A controlled installer/import changes the in-process capability
+        # state. The next explicit read retries immediately and caches the
+        # exact real class.
+        blocker.enabled = False
+        importlib.import_module("multiformats")
+        recovered = package.ipfs_multiformats_py
+        real = importlib.import_module(
+            "ipfs_accelerate_py.ipfs_multiformats"
+        ).ipfs_multiformats_py
+        assert recovered is real
+        assert package.export["ipfs_multiformats_py"] is real
+        """
+    )
+
+
+def test_install_depends_exact_module_and_injected_first_use() -> None:
+    _run(
+        """
+        import importlib
+        import sys
+        import ipfs_accelerate_py as package
+
+        implementation_name = (
+            "ipfs_accelerate_py.install_depends.install_depends"
+        )
+        storage_name = "ipfs_accelerate_py.common.storage_wrapper"
+        assert implementation_name not in sys.modules
+        assert storage_name not in sys.modules
+
+        from ipfs_accelerate_py import install_depends as root_value
+        implementation = importlib.import_module(implementation_name)
+        package_surface = importlib.import_module(
+            "ipfs_accelerate_py.install_depends"
+        )
+        assert root_value is implementation
+        assert package.install_depends is implementation
+        assert package.export["install_depends"] is implementation
+        assert (
+            package_surface.install_depends_py
+            is implementation.install_depends_py
+        )
+        assert storage_name not in sys.modules
+
+        injected_storage = object()
+        instance = package_surface.install_depends_py(
+            {"storage": injected_storage},
+            {},
+        )
+        assert instance.storage is injected_storage
+        assert storage_name not in sys.modules
+        """
+    )
+
+
+def test_skip_core_preserves_root_manifests_without_core_imports() -> None:
+    _run(
+        """
+        import sys
+        import ipfs_accelerate_py as package
+
+        expected_export = {
+            "backends",
+            "config",
+            "install_depends",
+            "ipfs_accelerate_py",
+            "worker",
+            "ipfs_multiformats_py",
+            "get_instance",
+            "accelerate_with_browser",
+            "WebNNWebGPUAccelerator",
+            "get_accelerator",
+            "webnn_webgpu_available",
+            "ModelManager",
+            "get_default_model_manager",
+            "model_manager_available",
+            "EndpointContract",
+            "SpaceRuntimeInfo",
+            "OutputBackend",
+            "LocalFileSystemBackend",
+            "HFBucketBackend",
+            "HFBucketBackendError",
+            "HFSpaceClient",
+            "RefreshableGradioFile",
+            "BatchState",
+            "BatchProcessor",
+            "is_hf_space_transport_error",
+            "is_retryable_hf_space_error",
+            "is_stale_gradio_file_error",
+            "normalize_api_name",
+        }
+        assert set(package.export) == expected_export
+        assert len(package.__all__) == 106
+        assert len(package.__all__) == len(set(package.__all__))
+        assert package.worker is None
+        assert package.config is None
+        assert package.install_depends is None
+        assert package.ipfs_multiformats_py is None
+        assert package.accelerate_with_browser is None
+        assert package.WebNNWebGPUAccelerator is None
+        assert package.get_accelerator is None
+        assert package.webnn_webgpu_available is False
+        assert not any(
+            name == "ipfs_accelerate_py.ipfs_multiformats"
+            or name.startswith("ipfs_accelerate_py.ipfs_multiformats.")
+            for name in sys.modules
+        )
+        """,
+        skip_core=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "availability_name",
+    [
+        "inference_backend_manager_available",
+        "llm_router_available",
+        "embeddings_router_available",
+        "multimodal_router_available",
+        "tts_router_available",
+        "voice_router_available",
+    ],
+)
+def test_non_exported_availability_names_remain_in_all(
+    availability_name: str,
+) -> None:
+    import ipfs_accelerate_py as package
+
+    assert availability_name in package.__all__
+    assert availability_name not in package.export

--- a/test/api/test_todo_daemon_lazy_package.py
+++ b/test/api/test_todo_daemon_lazy_package.py
@@ -1,0 +1,133 @@
+"""Lazy package and runpy contracts for todo implementation entry points."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ACCELERATE_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE = "ipfs_accelerate_py.agent_supervisor.todo_daemon"
+DAEMON_MODULE = f"{PACKAGE}.implementation_daemon"
+SUPERVISOR_MODULE = f"{PACKAGE}.implementation_supervisor"
+
+
+def _environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONWARNINGS"] = "default"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (
+            str(ACCELERATE_ROOT),
+            environment.get("PYTHONPATH", ""),
+        )
+        if part
+    )
+    return environment
+
+
+def _run_script(script: str) -> None:
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=ACCELERATE_ROOT,
+        env=_environment(),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_package_import_does_not_load_implementation_entrypoints() -> None:
+    _run_script(
+        f"""
+        import sys
+        import {PACKAGE} as package
+
+        assert {DAEMON_MODULE!r} not in sys.modules
+        assert {SUPERVISOR_MODULE!r} not in sys.modules
+        assert "TodoImplementationDaemon" in package.__all__
+        assert "TodoImplementationSupervisor" in package.__all__
+        assert "implementation_daemon" in dir(package)
+        assert "implementation_supervisor" in dir(package)
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "other_module", "export_names"),
+    [
+        (
+            DAEMON_MODULE,
+            SUPERVISOR_MODULE,
+            (
+                "DEFAULT_WORKTREE_SUBMODULE_PATHS",
+                "TodoImplementationDaemon",
+                "TodoTask",
+                "TodoTaskState",
+                "WORKTREE_SUBMODULE_PATHS",
+                "normalize_relative_path_list",
+                "parse_task_file",
+            ),
+        ),
+        (
+            SUPERVISOR_MODULE,
+            "",
+            (
+                "TodoImplementationSupervisor",
+                "TodoSupervisorConfig",
+                "supervisor_config_from_args",
+            ),
+        ),
+    ],
+)
+def test_lazy_exports_cache_exact_implementation_objects(
+    module_name: str,
+    other_module: str,
+    export_names: tuple[str, ...],
+) -> None:
+    _run_script(
+        f"""
+        import importlib
+        import sys
+        import {PACKAGE} as package
+
+        module_alias = {module_name!r}.rsplit(".", 1)[-1]
+        first_name = {export_names[0]!r}
+        first_value = getattr(package, first_name)
+        module = importlib.import_module({module_name!r})
+        assert getattr(package, module_alias) is module
+        assert first_value is getattr(module, first_name)
+        for export_name in {export_names!r}:
+            root_value = getattr(package, export_name)
+            assert root_value is getattr(module, export_name)
+            assert package.__dict__[export_name] is root_value
+        if {other_module!r}:
+            assert {other_module!r} not in sys.modules
+        """
+    )
+
+
+@pytest.mark.parametrize("module_name", [DAEMON_MODULE, SUPERVISOR_MODULE])
+def test_module_help_has_no_preloaded_module_runpy_warning(
+    module_name: str,
+) -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", module_name, "--help"],
+        cwd=ACCELERATE_ROOT,
+        env=_environment(),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "usage:" in completed.stdout.lower()
+    assert "found in sys.modules after import of package" not in completed.stderr


### PR DESCRIPTION
## Summary
Manual Wave 3a file port of the **package-root cold surface** (not a bulk PTR history replay).

Makes the accelerator package root and key support modules safe for proof-reuse plugin / light imports:

- Lazy package root (`__getattr__` group exports, no eager core init)
- Cold `github_cli` package surface + deferred multiformats/storage
- Cold `install_depends` / `config` imports (no storage/test acquisition)
- Lazy `todo_daemon` implementation entrypoints
- Lazy `p2p_tasks` historical aliases
- New unit contracts under `test/api/test_package_root_cold_surface.py` and related lazy-package tests

## Test plan
- [x] Local: 21/21 cold-surface + lazy package tests pass
- [ ] CI green
- [ ] Spot-check: `import ipfs_accelerate_py.testing.proof_reuse.plugin` does not load multiformats/core

## Notes
Bulk cherry-pick of PTR cold-import worktree commits conflicts on every shared surface because main already carries alternate PTR implementations. This PR ports the cold-import *behavior* by file.