### PR TITLE
fix(agent-supervisor): reuse clean external merge-target checkouts (SCA-632)

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -34651,11 +34651,35 @@ class PortalImplementationDaemon:
                     return result
                 self._run_git(["worktree", "remove", "--force", str(checked_out_path)], cwd=self.repo_root)
                 continue
+            # Target is checked out outside the managed merge-worktree root
+            # (common for shared agent/main worktrees). Reuse a clean checkout
+            # so parallel lanes can merge instead of looping on
+            # main_branch_checked_out_elsewhere (SCA-615 / SCA-632).
+            dirty_paths = sorted(self._dirty_worktree_paths(checked_out_path))
+            generated_restore = self._restore_generated_dirty_paths(
+                checked_out_path,
+                dirty_paths,
+                reason="main_external_checkout_dirty",
+            )
+            if generated_restore:
+                dirty_paths = sorted(self._dirty_worktree_paths(checked_out_path))
+            if dirty_paths:
+                result = {
+                    "available": False,
+                    "reason": "main_branch_checked_out_elsewhere",
+                    "target_branch": target_branch,
+                    "worktree_path": str(checked_out_path),
+                    "dirty_paths": dirty_paths,
+                }
+                if generated_restore:
+                    result["generated_dirty_restore"] = generated_restore
+                return result
             return {
-                "available": False,
-                "reason": "main_branch_checked_out_elsewhere",
+                "available": True,
+                "path": str(checked_out_path),
+                "ephemeral": False,
                 "target_branch": target_branch,
-                "worktree_path": str(checked_out_path),
+                "reused_external_checkout": True,
             }
 
         merge_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
Land the only clean cherry-pick from the UIIR quota-recovery worktree onto current main:

**SCA-632**: when the merge target branch is checked out outside managed `.main-merge-worktrees` (shared agent/main worktrees), reuse that checkout **if clean** instead of failing closed with `main_branch_checked_out_elsewhere`.

## Context
Attempted to port the full UIIR quota/recovery stack (42 unique commits): **1 applied cleanly, 41 conflicted**. Main has already evolved past the worktree baseline (e.g. `post_merge_review` → `post_merge_validation`, expanded `grok_cli_runner` / FVT auto-finish). Remaining UIIR quota/Terra/composite-recovery work needs dedicated file-level ports, not history replay.

## Test plan
- [ ] CI green
- [ ] Manual: merge with target branch checked out cleanly in a non-managed worktree should set `reused_external_checkout: true`