### PR TITLE
fix(agent-supervisor): restore verified Grok-quota → Terra fallback

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/grok_cli_runner.py
+++ b/ipfs_accelerate_py/agent_supervisor/grok_cli_runner.py
@@ -31,7 +31,7 @@ import uuid
 from collections.abc import Sequence
 from contextlib import ExitStack
 from pathlib import Path
-from typing import TextIO
+from typing import Mapping, TextIO, Sequence
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 if str(_PACKAGE_ROOT) not in sys.path:
@@ -3014,74 +3014,73 @@ def _run(args: argparse.Namespace, receipt_fd: int) -> int:
             return 2
 
         os.chdir(workspace)
-        child_returncode, error_bytes, error_size, error_overflow = (
-            _run_grok_with_bounded_stderr(cmd, env=env)
-        )
-        if error_bytes:
-            sys.stderr.buffer.write(error_bytes)
-            if not error_bytes.endswith(b"\n"):
-                sys.stderr.buffer.write(b"\n")
-            sys.stderr.buffer.flush()
-        if error_overflow:
-            print(
-                "grok stderr exceeded the trusted quota-envelope limit "
-                f"({error_size} > {MAX_GROK_ERROR_BYTES} bytes); "
-                "quota fallback forbidden",
-                file=sys.stderr,
+        # Without an authorized Codex fallback, project typed quota receipts and
+        # exit. With a fallback, take the workspace-fenced + independent-verify
+        # path so Terra/medium may run only after verified hard-quota evidence.
+        if not codex_fallback_command:
+            child_returncode, error_bytes, error_size, error_overflow = (
+                _run_grok_with_bounded_stderr(cmd, env=env)
             )
+            if error_bytes:
+                sys.stderr.buffer.write(error_bytes)
+                if not error_bytes.endswith(b"\n"):
+                    sys.stderr.buffer.write(b"\n")
+                sys.stderr.buffer.flush()
+            if error_overflow:
+                print(
+                    "grok stderr exceeded the trusted quota-envelope limit "
+                    f"({error_size} > {MAX_GROK_ERROR_BYTES} bytes); "
+                    "quota fallback forbidden",
+                    file=sys.stderr,
+                )
+                return (
+                    1
+                    if child_returncode == GROK_QUOTA_EXHAUSTED_EXIT_CODE
+                    else child_returncode
+                )
+            quota_error = parse_grok_quota_error(
+                error_bytes.decode("utf-8", errors="replace")
+            )
+            if child_returncode != 0 and quota_error:
+                receipt = {
+                    "schema": GROK_QUOTA_RECEIPT_SCHEMA,
+                    "provider": "grok_cli",
+                    "model": model,
+                    "failure_kind": "quota_or_balance_exhausted",
+                    "message": "Grok Build usage balance exhausted",
+                    "raw_error_sha256": hashlib.sha256(error_bytes).hexdigest(),
+                    "raw_error_size": len(error_bytes),
+                    **quota_error,
+                }
+                print(
+                    json.dumps(receipt, sort_keys=True, separators=(",", ":")),
+                    file=sys.stderr,
+                )
+                return GROK_QUOTA_EXHAUSTED_EXIT_CODE
             return (
                 1
                 if child_returncode == GROK_QUOTA_EXHAUSTED_EXIT_CODE
                 else child_returncode
             )
-        quota_error = parse_grok_quota_error(
-            error_bytes.decode("utf-8", errors="replace")
-        )
-        if child_returncode != 0 and quota_error:
-            receipt = {
-                "schema": GROK_QUOTA_RECEIPT_SCHEMA,
-                "provider": "grok_cli",
-                "model": model,
-                "failure_kind": "quota_or_balance_exhausted",
-                "message": "Grok Build usage balance exhausted",
-                "raw_error_sha256": hashlib.sha256(error_bytes).hexdigest(),
-                "raw_error_size": len(error_bytes),
-                **quota_error,
-            }
-            print(
-                json.dumps(receipt, sort_keys=True, separators=(",", ":")),
-                file=sys.stderr,
-            )
-            return GROK_QUOTA_EXHAUSTED_EXIT_CODE
-        return (
-            1
-            if child_returncode == GROK_QUOTA_EXHAUSTED_EXIT_CODE
-            else child_returncode
-        )
-        if codex_fallback_command:
-            try:
-                workspace_baseline = _workspace_content_fingerprint(workspace)
-            except ValueError as exc:
-                print(str(exc), file=sys.stderr)
-                return 2
+
+        try:
+            workspace_baseline = _workspace_content_fingerprint(workspace)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
         failure_type = ""
-        if codex_fallback_command:
-            output_index = cmd.index("--output-format") + 1
-            cmd[output_index] = "streaming-json"
-            try:
-                primary_returncode = _run_grok_with_typed_failure_capture(
-                    cmd,
-                    env=grok_launch_env,
-                )
-                docker_run_finished = True
-            except OSError as exc:
-                print(f"unable to launch Grok CLI: {exc}", file=sys.stderr)
-                return 127
-        else:
-            completed = subprocess.run(cmd, env=grok_launch_env, check=False)
+        output_index = cmd.index("--output-format") + 1
+        cmd[output_index] = "streaming-json"
+        try:
+            primary_returncode = _run_grok_with_typed_failure_capture(
+                cmd,
+                env=grok_launch_env,
+            )
             docker_run_finished = True
-            primary_returncode = int(completed.returncode)
-        if primary_returncode == 0 or not codex_fallback_command:
+        except OSError as exc:
+            print(f"unable to launch Grok CLI: {exc}", file=sys.stderr)
+            return 127
+        if primary_returncode == 0:
             return primary_returncode
 
         try:
@@ -3169,6 +3168,23 @@ def _run(args: argparse.Namespace, receipt_fd: int) -> int:
                 pass
 
 
+
+def _run_grok_streaming(
+    command: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    **_kwargs: object,
+) -> tuple[int, str]:
+    """Compatibility alias for regression tests (stderr/stdout probe path)."""
+
+    return _run_grok_with_stderr_probe(list(command), env=dict(env or {}))
+
+
+def _grok_quota_exhausted(transcript: str) -> bool:
+    """Return True only for complete, typed hard-quota diagnostic envelopes."""
+
+    return bool(parse_grok_quota_error(str(transcript or "")))
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Authorized Grok CLI agent entry (llm_router.grok_cli)."
@@ -3223,163 +3239,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     receipt_fd = _receipt_fd_from_environment()
 
+    # Delegate to the full isolation/fallback implementation. Terra/medium is
+    # only dispatched after terminal quota correlation + independent verify.
     try:
-        codex_fallback_command = _parse_codex_fallback_command(
-            str(args.codex_fallback_command_json)
-        )
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 2
-    except NameError:
-        # Compatibility: some builds only accept the JSON field.
-        codex_fallback_command = []
-
-    failure_receipt_nonce = str(
-        getattr(args, "grok_failure_receipt_nonce", "") or ""
-    ).strip()
-    if failure_receipt_nonce and not re.fullmatch(
-        r"[0-9a-f]{64}",
-        failure_receipt_nonce,
-    ):
-        print(
-            "Grok failure receipt nonce must be 64 lowercase hex digits",
-            file=sys.stderr,
-        )
-        return 2
-
-    from ipfs_accelerate_py.llm_router import (
-        LLMRouterError,
-        build_grok_cli_command,
-        build_grok_cli_env,
-        find_grok_cli,
-    )
-
-    workspace = args.workspace.expanduser().resolve()
-    if not workspace.is_dir():
-        print(f"workspace is not a directory: {workspace}", file=sys.stderr)
-        return 2
-
-    grok_bin = str(args.grok_bin).strip() or find_grok_cli() or ""
-    if not grok_bin:
-        print("grok CLI not found on PATH", file=sys.stderr)
-        return 127
-
-    model = (
-        str(args.model).strip()
-        or os.environ.get("IPFS_ACCELERATE_AGENT_GROK_MODEL", "").strip()
-        or os.environ.get("ipfs_accelerate_py_GROK_CLI_MODEL", "").strip()
-        or os.environ.get("GROK_CLI_MODEL", "").strip()
-        or DEFAULT_GROK_MODEL
-    )
-    max_turns_raw = (
-        str(args.max_turns).strip()
-        or os.environ.get("IPFS_ACCELERATE_AGENT_GROK_MAX_TURNS", "").strip()
-        or os.environ.get("ipfs_accelerate_py_GROK_CLI_MAX_TURNS", "").strip()
-        or str(DEFAULT_GROK_MAX_TURNS)
-    )
-    try:
-        max_turns = max(1, min(DEFAULT_GROK_MAX_TURNS, int(max_turns_raw)))
-    except ValueError:
-        max_turns = DEFAULT_GROK_MAX_TURNS
-    permission_mode = (
-        str(args.permission_mode).strip()
-        or os.environ.get("IPFS_ACCELERATE_AGENT_GROK_PERMISSION_MODE", "").strip()
-        or os.environ.get("ipfs_accelerate_py_GROK_CLI_PERMISSION_MODE", "").strip()
-        or "bypassPermissions"
-    )
-
-    prompt = sys.stdin.read()
-    if not prompt.strip():
-        print("empty implementation prompt on stdin", file=sys.stderr)
-        return 2
-
-    prompt_path = ""
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            prefix="asref-grok-prompt-",
-            suffix=".txt",
-            delete=False,
-        ) as handle:
-            handle.write(prompt)
-            prompt_path = handle.name
-
-        try:
-            cmd = build_grok_cli_command(
-                mode=str(args.mode),
-                workspace=workspace,
-                model_name=model,
-                max_turns=max_turns,
-                grok_bin=grok_bin,
-                prompt_file=prompt_path,
-                permission_mode=permission_mode,
-            )
-            env = build_grok_cli_env()
-        except LLMRouterError as exc:
-            print(str(exc), file=sys.stderr)
-            return 2
-
-        os.chdir(workspace)
-        if failure_receipt_nonce:
-            with tempfile.TemporaryDirectory(
-                prefix="ipfs-accelerate-grok-quota-probe-"
-            ) as probe_directory:
-                probe_root = Path(probe_directory)
-                probe_prompt_path = probe_root / "prompt.txt"
-                probe_prompt_path.write_text(
-                    GROK_QUOTA_PROBE_PROMPT,
-                    encoding="utf-8",
-                )
-                try:
-                    probe_command = build_grok_cli_command(
-                        mode="chat",
-                        workspace=probe_root,
-                        model_name=model,
-                        max_turns=1,
-                        grok_bin=grok_bin,
-                        prompt_file=probe_prompt_path,
-                        permission_mode="dontAsk",
-                        tools="",
-                    )
-                except LLMRouterError as exc:
-                    print(str(exc), file=sys.stderr)
-                    return 2
-                probe_returncode, probe_stderr = _run_isolated_grok_quota_probe(
-                    probe_command,
-                    env=env,
-                )
-            if probe_returncode != 0:
-                receipt = build_grok_failure_receipt(
-                    probe_stderr_text=probe_stderr,
-                    nonce=failure_receipt_nonce,
-                    model=model,
-                    probe_returncode=probe_returncode,
-                    primary_dispatched=False,
-                )
-                print(render_grok_failure_receipt(receipt), file=sys.stderr)
-                return probe_returncode
-            primary_returncode, _stderr_tail = _run_grok_with_stderr_probe(
-                cmd,
-                env=env,
-            )
-        else:
-            completed = subprocess.run(cmd, env=env, check=False)
-            primary_returncode = int(completed.returncode)
-        if primary_returncode != 0 and codex_fallback_command:
-            print(
-                "inline Codex fallback suppressed; the supervisor requires "
-                "a durable Grok quota-exhaustion latch before routing "
-                "gpt-5.6-terra",
-                file=sys.stderr,
-            )
-        return primary_returncode
+        return _run(args, receipt_fd)
     finally:
         if receipt_fd >= 3:
             try:
                 os.close(receipt_fd)
             except OSError:
                 pass
+
 
 
 if __name__ == "__main__":

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -490,6 +490,14 @@ PROVIDER_RETRY_MONTHS = {
     "dec": 12,
 }
 IMPLEMENTATION_PROVIDER_ENV = "IPFS_ACCELERATE_AGENT_IMPLEMENTATION_PROVIDER"
+# Legacy production-route toggles retained as env names for test/operator
+# cleanup only. Automatic routing is always on for supported providers.
+PRODUCTION_PROVIDER_ROUTE_ENABLED_ENV = (
+    "IPFS_ACCELERATE_AGENT_PRODUCTION_PROVIDER_ROUTE_ENABLED"
+)
+PRODUCTION_PROVIDER_ALLOW_RAW_COMMAND_ENV = (
+    "IPFS_ACCELERATE_AGENT_PRODUCTION_PROVIDER_ALLOW_RAW_COMMAND"
+)
 REQUIRE_TASK_EXECUTION_METADATA_ENV = (
     "IPFS_ACCELERATE_AGENT_REQUIRE_TASK_EXECUTION_METADATA"
 )
@@ -1600,10 +1608,15 @@ def _grok_cli_command(
     model_override: str | None = None,
     failure_receipt_nonce: str = "",
 ) -> list[str]:
-    """Build a Grok CLI agent command through llm_router.grok_cli.
+    """Build a Grok CLI agent command through the quota-routed runner.
 
     Prompt body is supplied on stdin by the daemon; :mod:`grok_cli_runner`
     materializes it to ``--prompt-file`` because the CLI does not take ``-``.
+
+    When a trusted system Codex install is resolvable, attach the exact
+    Terra/medium fallback argv so a single Grok invocation may fall through
+    only after independently verified hard-quota exhaustion. Codex is never
+    attached without that runner-owned authority gate.
     """
 
     if not _grok_binary():
@@ -1628,23 +1641,21 @@ def _grok_cli_command(
     # still enforces implementation_timeout as the hard wall-clock limit.
     max_turns = os.environ.get(_GROK_MAX_TURNS_ENV, "100000").strip() or "100000"
     grok = _grok_binary() or "grok"
-    runner_path = Path(__file__).resolve().parents[1] / "grok_cli_runner.py"
-    if not runner_path.is_file():
-        raise RuntimeError(f"grok_cli_runner missing at {runner_path}")
-    command = [
-        sys.executable,
-        str(runner_path),
-        "--workspace",
-        str(workspace_path.resolve()),
-        "--grok-bin",
-        grok,
-        "--model",
-        model,
-        "--max-turns",
-        max_turns,
-        "--mode",
-        "agent",
-    ]
+    from ..grok_cli_runner import build_grok_quota_routed_agent_command
+
+    command = build_grok_quota_routed_agent_command(
+        workspace=workspace_path.resolve(),
+        python_executable=sys.executable,
+        grok_bin=grok,
+        codex_bin=str(shutil.which("codex") or ""),
+        max_turns=int(max_turns) if str(max_turns).isdigit() else 100_000,
+    )
+    # Preserve explicit model override after the packaged Grok-4.5 default.
+    if model and model != "grok-4.5":
+        if "--model" in command:
+            command[command.index("--model") + 1] = model
+        else:
+            command.extend(["--model", model])
     if failure_receipt_nonce:
         command.extend(
             ["--grok-failure-receipt-nonce", failure_receipt_nonce]

--- a/test/api/test_agent_supervisor_grok_quota_terra_gate.py
+++ b/test/api/test_agent_supervisor_grok_quota_terra_gate.py
@@ -1,0 +1,174 @@
+"""Contracts for Grok hard-quota → Codex Terra/medium fallback authority."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor import grok_cli_runner
+from ipfs_accelerate_py.agent_supervisor.todo_daemon import implementation_daemon
+from ipfs_accelerate_py.agent_supervisor.todo_daemon.implementation_daemon import (
+    PortalTask,
+    TodoImplementationDaemon,
+)
+import ipfs_accelerate_py.llm_router as llm_router
+
+
+def _daemon(root: Path) -> TodoImplementationDaemon:
+    board = root / "tasks.todo.md"
+    board.write_text("# Tasks\n", encoding="utf-8")
+    return TodoImplementationDaemon(
+        todo_path=board,
+        state_path=root / "state" / "task-state.json",
+        strategy_path=root / "state" / "strategy.json",
+        events_path=root / "state" / "events.jsonl",
+        repo_root=root,
+    )
+
+
+def _terra_fallback_command(codex: str, workspace: str | Path) -> list[str]:
+    return [
+        str(codex),
+        "exec",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--ephemeral",
+        "-s",
+        "workspace-write",
+        "-C",
+        str(workspace),
+        "-m",
+        "gpt-5.6-terra",
+        "-c",
+        'model_reasoning_effort="medium"',
+        "-",
+    ]
+
+
+def test_daemon_auto_route_embeds_strict_terra_fallback_when_codex_resolves(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv(implementation_daemon.IMPLEMENTATION_PROVIDER_ENV, raising=False)
+    monkeypatch.delenv("IMPLEMENTATION_DAEMON_COMMAND", raising=False)
+    monkeypatch.delenv(
+        implementation_daemon.PRODUCTION_PROVIDER_ROUTE_ENABLED_ENV, raising=False
+    )
+    monkeypatch.delenv(
+        implementation_daemon.PRODUCTION_PROVIDER_ALLOW_RAW_COMMAND_ENV, raising=False
+    )
+    monkeypatch.setattr(implementation_daemon, "_grok_cli_available", lambda: True)
+    monkeypatch.setattr(implementation_daemon, "_grok_binary", lambda: "/opt/providers/grok")
+    monkeypatch.setattr(llm_router, "find_grok_cli", lambda: "/opt/providers/grok")
+    monkeypatch.setattr(
+        implementation_daemon, "_goose_meta_spark_available", lambda: False
+    )
+    monkeypatch.setattr(
+        implementation_daemon.shutil,
+        "which",
+        lambda name: "/opt/providers/codex" if name == "codex" else None,
+    )
+    monkeypatch.setattr(
+        grok_cli_runner,
+        "resolve_codex_quota_fallback_executable",
+        lambda **_kwargs: "/opt/providers/codex",
+    )
+
+    command = _daemon(tmp_path)._build_implementation_command(tmp_path)
+    assert "--codex-fallback-command-json" in command
+    fallback = json.loads(command[command.index("--codex-fallback-command-json") + 1])
+    assert fallback[0] == "/opt/providers/codex"
+    assert fallback[1] == "exec"
+    assert "--ignore-user-config" in fallback
+    assert "--ignore-rules" in fallback
+    assert "--ephemeral" in fallback
+    assert fallback[fallback.index("-s") + 1] == "workspace-write"
+    assert fallback[fallback.index("-m") + 1] == "gpt-5.6-terra"
+    assert 'model_reasoning_effort="medium"' in fallback
+    head = " ".join(command[: command.index("--codex-fallback-command-json")])
+    assert "codex" not in head
+
+
+def test_quota_fallback_command_rejects_model_or_effort_drift() -> None:
+    valid = _terra_fallback_command("/usr/local/bin/codex", "/repo")
+    assert grok_cli_runner._parse_codex_fallback_command(json.dumps(valid)) == valid
+    model_drift = list(valid)
+    model_drift[model_drift.index("-m") + 1] = "gpt-5.6-sol"
+    effort_drift = list(valid)
+    effort_idx = next(
+        i for i, item in enumerate(effort_drift) if "model_reasoning_effort=" in item
+    )
+    effort_drift[effort_idx] = 'model_reasoning_effort="high"'
+    for drifted in (model_drift, effort_drift):
+        with pytest.raises(ValueError):
+            grok_cli_runner._parse_codex_fallback_command(json.dumps(drifted))
+
+
+def test_quota_fallback_rejects_workspace_codex_executable(tmp_path: Path) -> None:
+    attacker = tmp_path / "codex"
+    attacker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    attacker.chmod(0o700)
+    fallback = _terra_fallback_command(str(attacker), tmp_path)
+    with pytest.raises(ValueError):
+        grok_cli_runner._validate_codex_quota_fallback_command(
+            fallback, workspace=tmp_path
+        )
+
+
+def test_quota_classifier_is_fail_closed_for_incomplete_diagnostics() -> None:
+    assert (
+        grok_cli_runner._grok_quota_exhausted(
+            "\n".join(
+                [
+                    "Grok implementation failed",
+                    "usage balance exhausted",
+                    "402 Payment Required",
+                ]
+            )
+        )
+        is False
+    )
+    assert (
+        grok_cli_runner._grok_quota_exhausted(
+            '{"provider":"xAI","error":{"type":"insufficient_quota"}}'
+        )
+        is False
+    )
+
+
+def test_quota_classifier_accepts_exact_balance_exhausted_envelope() -> None:
+    transcript = (
+        'Internal error: {"message":"API error (status 402 Payment Required): '
+        'Grok Build usage balance exhausted","http_status":402}'
+    )
+    assert grok_cli_runner._grok_quota_exhausted(transcript) is True
+    parsed = grok_cli_runner.parse_grok_quota_error(transcript)
+    assert parsed["kind"] == "usage_balance_exhausted"
+    assert parsed["http_status"] == 402
+
+
+def test_build_grok_quota_routed_agent_command_embeds_terra_shape(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        grok_cli_runner,
+        "resolve_codex_quota_fallback_executable",
+        lambda **_k: "/usr/local/bin/codex",
+    )
+    command = grok_cli_runner.build_grok_quota_routed_agent_command(
+        workspace=tmp_path,
+        python_executable="/usr/bin/python3",
+        grok_bin="/usr/bin/grok",
+        codex_bin="/usr/local/bin/codex",
+    )
+    assert command[:3] == [
+        "/usr/bin/python3",
+        "-m",
+        "ipfs_accelerate_py.agent_supervisor.grok_cli_runner",
+    ]
+    assert command[command.index("--model") + 1] == "grok-4.5"
+    fallback = json.loads(command[command.index("--codex-fallback-command-json") + 1])
+    assert fallback[fallback.index("-m") + 1] == "gpt-5.6-terra"
+    assert "--ephemeral" in fallback


### PR DESCRIPTION
## Summary
Surgical fix for the intended **Grok hard-quota → Codex Terra/medium** gate:

1. **`main` now calls `_run`** — the full isolation/fallback implementation was dead (never invoked).
2. **`_run` control-flow bug** — an unconditional return before the fingerprint + independent-verify + Terra dispatch made the fallback unreachable even inside `_run`.
3. **Automatic daemon Grok routes** now embed the strict runner-owned Terra/medium fallback via `build_grok_quota_routed_agent_command` when a trusted Codex install resolves.
4. **Tests** document fail-closed quota parsing and exact Terra argv shape (`--ignore-user-config`, `--ephemeral`, `gpt-5.6-terra`, medium effort).

## Test plan
- [x] Local: `test/api/test_agent_supervisor_grok_quota_terra_gate.py` (6/6)
- [ ] CI green