### PR TITLE
feat(action_runtime): surface exposure gates for pilot policy and catalog

### DIFF
--- a/ipfs_accelerate_py/action_runtime/catalog_211ai.py
+++ b/ipfs_accelerate_py/action_runtime/catalog_211ai.py
@@ -17,11 +17,12 @@ from typing import Any, Mapping
 
 from .catalog import ActionCatalog, ActionDescriptor
 from .contracts import RiskClass, SideEffectClass, content_digest
+from .surface_exposure import SURFACE_EXPOSURE_CLASS, VOICE_CLIENT_SURFACE_ACTIONS
 
 CATALOG_ID: str = "211ai-pilot-v1"
-CATALOG_VERSION: str = "1"
+CATALOG_VERSION: str = "1.1"
 CATALOG_SCHEMA: str = "voice-action/catalog@1"
-POLICY_REVISION: str = "pilot-v1"
+POLICY_REVISION: str = "pilot-v1.1-surface-coverage"
 
 # Stable pilot logical actions (board namespace voice-action-dag-abby-v1).
 PILOT_LOGICAL_ACTIONS: tuple[str, ...] = (
@@ -110,6 +111,9 @@ def pilot_descriptors() -> tuple[ActionDescriptor, ...]:
                 family="app_surface",
                 auth_required="false",
                 confirmation_mode="explicit",
+                # Authority plane enforces exposure classes; content never embeds allowlists.
+                surface_gate="voice_navigable_or_voice_actionable",
+                surface_arg="surface_id",
             ),
         ),
         ActionDescriptor(
@@ -125,6 +129,8 @@ def pilot_descriptors() -> tuple[ActionDescriptor, ...]:
                 family="wallet_documents",
                 auth_required="false",
                 confirmation_mode="explicit",
+                surface_gate="voice_actionable_uploads",
+                default_surface_id="uploads",
             ),
         ),
         ActionDescriptor(
@@ -341,6 +347,32 @@ def catalog_digest(descriptors: tuple[ActionDescriptor, ...] | None = None) -> s
     )
 
 
+def export_surface_action_matrix() -> dict[str, Any]:
+    """Export surface → exposure_class → logical actions (content-safe)."""
+
+    surfaces: list[dict[str, Any]] = []
+    for surface_id in sorted(SURFACE_EXPOSURE_CLASS):
+        klass = SURFACE_EXPOSURE_CLASS[surface_id]
+        actions = list(VOICE_CLIENT_SURFACE_ACTIONS.get(surface_id, ()))
+        surfaces.append(
+            {
+                "surface_id": surface_id,
+                "exposure_class": klass,
+                "logical_actions": actions,
+                "client_voice_open": klass in {"voice_navigable", "voice_actionable"},
+            }
+        )
+    payload = {
+        "schema": "voice-action/surface-action-matrix@1",
+        "catalog_id": CATALOG_ID,
+        "catalog_version": CATALOG_VERSION,
+        "policy_revision": POLICY_REVISION,
+        "surfaces": surfaces,
+    }
+    assert_no_executable_locators(payload)
+    return payload
+
+
 def export_pilot_catalog_dict(
     descriptors: tuple[ActionDescriptor, ...] | None = None,
     *,
@@ -359,6 +391,7 @@ def export_pilot_catalog_dict(
         "logical_actions": sorted(d.logical_action for d in rows),
         "policy_revision": POLICY_REVISION,
         "schema": CATALOG_SCHEMA,
+        "surface_action_matrix": export_surface_action_matrix(),
         "version": CATALOG_VERSION,
     }
     if include_digests:
@@ -474,6 +507,7 @@ def write_pilot_catalog_json(
 __all__ = [
     "CATALOG_ID",
     "CATALOG_SCHEMA",
+    "export_surface_action_matrix",
     "CATALOG_VERSION",
     "FORBIDDEN_LOCATOR_KEYS",
     "PILOT_LOGICAL_ACTIONS",

--- a/ipfs_accelerate_py/action_runtime/policy_pilot.py
+++ b/ipfs_accelerate_py/action_runtime/policy_pilot.py
@@ -28,8 +28,13 @@ from .contracts import (
     ActionProposal,
     RiskClass,
 )
+from .surface_exposure import (
+    SURFACE_TARGETING_ACTIONS,
+    resolve_target_surface_id,
+    surface_exposure_deny_reason,
+)
 
-POLICY_REVISION: str = "pilot-policy-matrix-v1"
+POLICY_REVISION: str = "pilot-policy-matrix-v2"
 SAFETY_LOGICAL_ACTION: str = "escalate_safety"
 HANDOFF_LOGICAL_ACTION: str = "handoff_live_agent"
 
@@ -168,6 +173,33 @@ class PilotPolicy:
                 reason="tenant_not_allowed",
                 descriptor=descriptor,
             )
+
+        # Surface exposure gate (client voice/phone): when a target surface is
+        # known, never_voice / staff_only / voice_read_only cannot open.
+        # Missing surface_id is left to binding/clarify (not policy DENY here).
+        if descriptor.logical_action in SURFACE_TARGETING_ACTIONS:
+            target = resolve_target_surface_id(
+                descriptor.logical_action,
+                proposal.arguments,
+            )
+            if target is not None:
+                role = str(
+                    (proposal.metadata or {}).get("role")
+                    or (proposal.arguments or {}).get("role")
+                    or "client"
+                )
+                surface_deny = surface_exposure_deny_reason(
+                    target,
+                    channel=proposal.channel or "voice",
+                    role=role,
+                )
+                if surface_deny is not None:
+                    return self._decision(
+                        proposal,
+                        kind=ActionDecisionKind.DENY,
+                        reason=surface_deny,
+                        descriptor=descriptor,
+                    )
 
         # Safety overlay: force escalate path only for the safety descriptor.
         # Never widen to open_app_surface, writes, or other arbitrary tools.

--- a/ipfs_accelerate_py/action_runtime/surface_exposure.py
+++ b/ipfs_accelerate_py/action_runtime/surface_exposure.py
@@ -1,0 +1,151 @@
+"""Client-channel surface exposure classes for authority-plane policy (VAS2-010/011).
+
+Content-free: maps surface_id → exposure class only. Must stay in lockstep with
+monorepo exposure matrices under data/voice_app_surface_* /baseline/.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Mapping
+
+# Normative classes (fail closed: unknown → never_voice).
+SURFACE_EXPOSURE_CLASS: Final[Mapping[str, str]] = {
+    "home": "voice_navigable",
+    "register": "voice_navigable",
+    "check-in": "voice_navigable",
+    "calendar": "voice_actionable",
+    "messages": "voice_actionable",
+    "contacts": "voice_navigable",
+    "social-services": "voice_actionable",
+    "interactions": "voice_navigable",
+    "uploads": "voice_actionable",
+    "settings": "voice_navigable",
+    "analytics": "voice_read_only",
+    "proof-center": "voice_read_only",
+    "audit": "never_voice",
+    "security": "never_voice",
+    "exports": "never_voice",
+    "recipient-access": "never_voice",
+    "sharing-rules": "never_voice",
+    "benefits-protection": "never_voice",
+    "shelter": "staff_only",
+    "provider-clients": "staff_only",
+    "provider-cases": "staff_only",
+    "provider-messages": "staff_only",
+    "provider-analytics": "staff_only",
+    "provider-proofs": "staff_only",
+    "provider-operations": "staff_only",
+}
+
+CLIENT_VOICE_OPEN_CLASSES: Final[frozenset[str]] = frozenset(
+    {"voice_navigable", "voice_actionable"}
+)
+NEVER_VOICE_CLASSES: Final[frozenset[str]] = frozenset({"never_voice"})
+STAFF_ONLY_CLASSES: Final[frozenset[str]] = frozenset({"staff_only"})
+STAFF_DENY_CHANNELS: Final[frozenset[str]] = frozenset(
+    {"voice", "phone", "telephony", "chat"}
+)
+
+# Logical actions that open or target an app surface via arguments.surface_id
+# (or open_wallet_documents → uploads).
+SURFACE_TARGETING_ACTIONS: Final[frozenset[str]] = frozenset(
+    {
+        "open_app_surface",
+        "open_wallet_documents",
+    }
+)
+
+# Reviewed surface → logical actions for catalog/surface matrix (client voice).
+VOICE_CLIENT_SURFACE_ACTIONS: Final[Mapping[str, tuple[str, ...]]] = {
+    "home": ("open_app_surface",),
+    "register": ("open_app_surface",),
+    "check-in": ("open_app_surface",),
+    "calendar": (
+        "open_app_surface",
+        "read_calendar",
+        "create_calendar_reminder",
+    ),
+    "messages": (
+        "open_app_surface",
+        "read_provider_messages",
+        "leave_provider_message",
+    ),
+    "contacts": ("open_app_surface",),
+    "social-services": (
+        "open_app_surface",
+        "open_service_detail",
+        "schedule_service_callback",
+    ),
+    "interactions": ("open_app_surface",),
+    "uploads": ("open_app_surface", "open_wallet_documents"),
+    "settings": ("open_app_surface",),
+}
+
+
+def get_surface_exposure_class(surface_id: str) -> str:
+    """Return exposure class; unknown surfaces are never_voice."""
+
+    return SURFACE_EXPOSURE_CLASS.get(str(surface_id).strip(), "never_voice")
+
+
+def resolve_target_surface_id(
+    logical_action: str,
+    arguments: Mapping[str, str] | None,
+) -> str | None:
+    """Extract target surface_id from proposal arguments when applicable."""
+
+    args = arguments or {}
+    if logical_action == "open_wallet_documents":
+        return str(args.get("surface_id") or "uploads").strip() or "uploads"
+    if logical_action == "open_app_surface":
+        raw = str(args.get("surface_id") or args.get("surface") or "").strip()
+        return raw or None
+    # Other actions may still name a surface for context.
+    raw = str(args.get("surface_id") or "").strip()
+    return raw or None
+
+
+def surface_exposure_deny_reason(
+    surface_id: object | None,
+    *,
+    channel: object | None = "voice",
+    role: str = "client",
+) -> str | None:
+    """Return deny reason code for client channels, or None if allowed to open."""
+
+    if surface_id is None or str(surface_id).strip() == "":
+        return "surface_id_required"
+    sid = str(surface_id).strip()
+    klass = get_surface_exposure_class(sid)
+    channel_norm = str(channel or "voice").strip().lower() or "voice"
+    role_norm = str(role or "client").strip().lower() or "client"
+    if klass in NEVER_VOICE_CLASSES:
+        return "surface_never_voice"
+    if klass in STAFF_ONLY_CLASSES:
+        if role_norm != "staff" and channel_norm in STAFF_DENY_CHANNELS:
+            return "surface_staff_only"
+    if klass == "voice_read_only" and channel_norm in {
+        "voice",
+        "phone",
+        "telephony",
+    }:
+        return "surface_voice_read_only"
+    if klass not in CLIENT_VOICE_OPEN_CLASSES and channel_norm in STAFF_DENY_CHANNELS:
+        # Fail closed for any class that is not explicitly openable.
+        if klass not in {"voice_read_only"}:  # already handled
+            return "surface_not_voice_openable"
+    return None
+
+
+__all__ = [
+    "CLIENT_VOICE_OPEN_CLASSES",
+    "NEVER_VOICE_CLASSES",
+    "STAFF_DENY_CHANNELS",
+    "STAFF_ONLY_CLASSES",
+    "SURFACE_EXPOSURE_CLASS",
+    "SURFACE_TARGETING_ACTIONS",
+    "VOICE_CLIENT_SURFACE_ACTIONS",
+    "get_surface_exposure_class",
+    "resolve_target_surface_id",
+    "surface_exposure_deny_reason",
+]

--- a/test/test_action_policy_surface_exposure.py
+++ b/test/test_action_policy_surface_exposure.py
@@ -1,0 +1,77 @@
+"""Surface exposure gates in PilotPolicy (VAS2-011)."""
+
+from __future__ import annotations
+
+from ipfs_accelerate_py.action_runtime.catalog_211ai import (
+    build_pilot_catalog,
+    logical_action_to_descriptor_id,
+)
+from ipfs_accelerate_py.action_runtime.contracts import (
+    ActionDecisionKind,
+    ActionProposal,
+)
+from ipfs_accelerate_py.action_runtime.policy_pilot import PilotAdmissionContext, PilotPolicy
+from ipfs_accelerate_py.action_runtime.surface_exposure import SURFACE_EXPOSURE_CLASS
+
+
+def _proposal(logical: str, surface_id: str, *, channel: str = "voice") -> ActionProposal:
+    mapping = logical_action_to_descriptor_id()
+    return ActionProposal(
+        proposal_id=f"prop-{logical}-{surface_id}",
+        descriptor_id=mapping[logical],
+        logical_action=logical,
+        arguments={"surface_id": surface_id},
+        channel=channel,
+        tenant_id="tenant-test",
+        confidence=0.99,
+    )
+
+
+def test_never_voice_denied_before_confirm() -> None:
+    policy = PilotPolicy(catalog=build_pilot_catalog())
+    for sid, klass in SURFACE_EXPOSURE_CLASS.items():
+        if klass != "never_voice":
+            continue
+        decision = policy.decide(
+            _proposal("open_app_surface", sid),
+            PilotAdmissionContext(confirmed=True, authenticated=True),
+        )
+        assert decision.kind is ActionDecisionKind.DENY, sid
+        assert decision.reason == "surface_never_voice", (sid, decision.reason)
+
+
+def test_staff_only_denied_on_client_voice() -> None:
+    policy = PilotPolicy(catalog=build_pilot_catalog())
+    for sid, klass in SURFACE_EXPOSURE_CLASS.items():
+        if klass != "staff_only":
+            continue
+        decision = policy.decide(
+            _proposal("open_app_surface", sid),
+            PilotAdmissionContext(confirmed=True, authenticated=True),
+        )
+        assert decision.kind is ActionDecisionKind.DENY, sid
+        assert decision.reason == "surface_staff_only", (sid, decision.reason)
+
+
+def test_voice_navigable_requires_confirm_then_permits_read() -> None:
+    policy = PilotPolicy(catalog=build_pilot_catalog())
+    prop = _proposal("open_app_surface", "home")
+    unconfirmed = policy.decide(prop, PilotAdmissionContext(confirmed=False))
+    assert unconfirmed.kind is ActionDecisionKind.CONFIRM
+    confirmed = policy.decide(prop, PilotAdmissionContext(confirmed=True))
+    assert confirmed.kind is ActionDecisionKind.PERMIT_READ
+
+
+def test_open_wallet_documents_defaults_uploads_surface_gate() -> None:
+    policy = PilotPolicy(catalog=build_pilot_catalog())
+    mapping = logical_action_to_descriptor_id()
+    prop = ActionProposal(
+        proposal_id="prop-wallet-docs",
+        descriptor_id=mapping["open_wallet_documents"],
+        logical_action="open_wallet_documents",
+        arguments={},
+        channel="voice",
+        tenant_id="tenant-test",
+    )
+    decision = policy.decide(prop, PilotAdmissionContext(confirmed=True))
+    assert decision.kind is ActionDecisionKind.PERMIT_READ


### PR DESCRIPTION
## Summary
- Add `surface_exposure` map (lockstep with monorepo exposure matrix)
- Gate `open_app_surface` / `open_wallet_documents` in PilotPolicy when surface_id known
- Catalog 1.1 metadata + surface×action matrix export
- Tests for never_voice / staff_only / navigable paths

Supports 211-AI VAS2-010/011 (voice-app-surface-full-coverage-v2).