### PR TITLE
feat(todo-daemon): native CLI subreaper + exact Grok quota signal

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/legacy_landed_provider_cli.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/legacy_landed_provider_cli.py
@@ -56,6 +56,27 @@ _CODEX_USAGE_LIMIT_PATTERN: Final = re.compile(
     r"\byou(?:'|\u2019)ve hit your usage limit\b",
     re.IGNORECASE,
 )
+_GROK_BALANCE_EXHAUSTED_MESSAGE: Final = (
+    "API error (status 402 Payment Required): Grok Build usage balance exhausted"
+)
+GROK_BUILD_BALANCE_EXHAUSTED_MARKER: Final = "grok_build_balance_exhausted"
+_MAX_GROK_STREAM_EVENT_BYTES: Final = 64 * 1024
+_NATIVE_CLI_SUBREAPER_PATH: Final = Path(__file__).with_name("native_cli_subreaper.py")
+
+
+class NativeGrokQuotaExhaustionSignal(RuntimeError):
+    """Fixed, secret-free signal from an exact Grok transport event.
+
+    The signal is deliberately transport-specific.  Production policy may
+    translate it into its typed quota exception, while model text and generic
+    provider failures remain ordinary ``RuntimeError`` instances.
+    """
+
+    reason_code: Final = GROK_BUILD_BALANCE_EXHAUSTED_MARKER
+
+    def __init__(self) -> None:
+        super().__init__(self.reason_code)
+
 
 LegacyCLIInvoker = Callable[
     [str, LlmRouterInvocation],
@@ -150,15 +171,79 @@ def _bounded_failure_sample(value: bytearray) -> bytes:
     return bytes(value[:head_bytes]) + b"\n" + bytes(value[-tail_bytes:])
 
 
+def _grok_stream_failure_kind(payload: Mapping[str, Any]) -> str:
+    """Classify only CLI-owned structured failure event shapes."""
+
+    if payload.get("type") == "error":
+        if str(payload.get("message") or "").strip() == _GROK_BALANCE_EXHAUSTED_MESSAGE:
+            return "verified_quota"
+        return "other_failure"
+    if payload.get("method") not in {
+        "_x.ai/session/update",
+        "session/update",
+    }:
+        return ""
+    params = payload.get("params")
+    update = params.get("update") if isinstance(params, Mapping) else None
+    if not isinstance(update, Mapping):
+        return ""
+    if update.get("sessionUpdate") != "retry_state" or update.get("type") != "failed":
+        return ""
+    if (
+        str(update.get("error_type") or "").strip().casefold() == "api"
+        and str(update.get("message") or "").strip() == _GROK_BALANCE_EXHAUSTED_MESSAGE
+    ):
+        return "verified_quota"
+    return "other_failure"
+
+
+def _stdout_is_exact_grok_quota_failure(value: bytearray) -> bool:
+    """Require a strict JSONL quota event with no conflicting failure.
+
+    Grok is invoked with ``streaming-json`` output.  Therefore a non-empty
+    non-JSON stdout line is a protocol failure, not evidence that authorizes a
+    provider switch.  Stderr is intentionally never considered.
+    """
+
+    try:
+        output = bytes(value).decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return False
+    verified_quota = False
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if len(line.encode("utf-8")) > _MAX_GROK_STREAM_EVENT_BYTES:
+            return False
+        try:
+            payload = _strict_json_object(line)
+        except RuntimeError:
+            return False
+        failure_kind = _grok_stream_failure_kind(payload)
+        if failure_kind == "verified_quota":
+            verified_quota = True
+        elif failure_kind == "other_failure":
+            return False
+    return verified_quota
+
+
 def _native_cli_failure(
     command: Sequence[str],
     *,
+    return_code: int,
     stdout: bytearray,
     stderr: bytearray,
 ) -> RuntimeError:
-    """Classify a known Codex capacity failure without exposing diagnostics."""
+    """Classify exact capacity failures without exposing diagnostics."""
 
     executable = Path(str(command[0] or "")).name.casefold() if command else ""
+    if (
+        executable == "grok"
+        and return_code == 1
+        and _stdout_is_exact_grok_quota_failure(stdout)
+    ):
+        return NativeGrokQuotaExhaustionSignal()
     if executable == "codex":
         # ``codex exec --json`` versions have emitted the account-limit event
         # on either JSONL stdout or diagnostic stderr. Inspect bounded samples
@@ -193,7 +278,23 @@ def _run_native_cli_process(
     timeout_seconds: int,
     stdin_text: str | None = None,
 ) -> tuple[str, str]:
-    """Run one exact argv with bounded capture and fenced descendant cleanup."""
+    """Run one exact argv with bounded capture and subreaper confinement."""
+
+    if (
+        sys.platform != "linux"
+        or not Path("/proc/self/task").is_dir()
+        or not _NATIVE_CLI_SUBREAPER_PATH.is_file()
+    ):
+        # Native provider execution must never be attempted when the
+        # fork/setsid confinement boundary cannot be established.
+        raise RuntimeError("legacy native provider confinement unavailable")
+    subreaper_command = [
+        sys.executable,
+        "-I",
+        str(_NATIVE_CLI_SUBREAPER_PATH.resolve(strict=True)),
+        "--",
+        *[str(value) for value in command],
+    ]
 
     # Bind every observed descendant PID to its Linux start time so cleanup
     # cannot accidentally signal a PID that was recycled during a long model
@@ -303,7 +404,7 @@ def _run_native_cli_process(
     captures = {"stdout": bytearray(), "stderr": bytearray()}
     try:
         process = subprocess.Popen(
-            [str(value) for value in command],
+            subreaper_command,
             cwd=str(cwd),
             stdin=stdin_handle if stdin_text is not None else subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -357,6 +458,7 @@ def _run_native_cli_process(
             terminate_family(process)
             raise _native_cli_failure(
                 command,
+                return_code=return_code,
                 stdout=captures["stdout"],
                 stderr=captures["stderr"],
             )

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/native_cli_subreaper.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/native_cli_subreaper.py
@@ -1,0 +1,186 @@
+"""Private Linux subreaper wrapper for native provider CLI execution.
+
+This module is an executable implementation detail of
+``legacy_landed_provider_cli``.  It deliberately has no provider-specific
+logic and emits no diagnostics: the supervising process owns all output and
+failure classification.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from types import FrameType
+
+_PR_SET_CHILD_SUBREAPER = 36
+_PR_GET_CHILD_SUBREAPER = 37
+_CONFINEMENT_FAILURE_EXIT_CODE = 125
+_TERMINATION_POLL_SECONDS = 0.01
+
+_termination_signal = 0
+
+
+def _enable_child_subreaper() -> bool:
+    """Enable and verify the Linux child-subreaper contract."""
+
+    if sys.platform != "linux":
+        return False
+    children_path = Path(f"/proc/self/task/{os.getpid()}/children")
+    try:
+        children_path.read_text(encoding="ascii")
+    except OSError:
+        return False
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        prctl = libc.prctl
+        prctl.restype = ctypes.c_int
+        if prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+            return False
+        enabled = ctypes.c_int(0)
+        if prctl(_PR_GET_CHILD_SUBREAPER, ctypes.byref(enabled), 0, 0, 0) != 0:
+            return False
+        return enabled.value == 1
+    except (AttributeError, OSError, TypeError):
+        return False
+
+
+def _record_termination(signum: int, _frame: FrameType | None) -> None:
+    """Request cleanup from the ordinary interpreter control flow."""
+
+    global _termination_signal
+    if not _termination_signal:
+        _termination_signal = int(signum)
+
+
+def _direct_child_pids() -> set[int]:
+    """Return all children of every thread in this wrapper process."""
+
+    result: set[int] = set()
+    task_root = Path("/proc/self/task")
+    task_paths = tuple(task_root.iterdir())
+    for task_path in task_paths:
+        try:
+            values = (task_path / "children").read_text(encoding="ascii").split()
+        except FileNotFoundError:
+            # A short-lived interpreter helper thread may disappear between
+            # listing and reading.  Re-reading on the next pass is sufficient.
+            continue
+        for value in values:
+            result.add(int(value))
+    return result
+
+
+def _kill_and_reap_orphans() -> None:
+    """Do not return until the kernel reports that no child remains.
+
+    Once this process is a subreaper, an orphan at any depth is reparented
+    here.  Killing only the current direct children and repeating therefore
+    closes the fork/setsid/double-fork race without relying on polling having
+    observed a process before its original parent exited.
+    """
+
+    while True:
+        try:
+            children = _direct_child_pids()
+        except (OSError, ValueError):
+            # The prerequisite check succeeded before provider execution.  A
+            # transient procfs read failure must delay result acceptance, not
+            # allow descendants to escape by making the wrapper exit.
+            time.sleep(_TERMINATION_POLL_SECONDS)
+            continue
+        for process_id in children:
+            try:
+                os.kill(process_id, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                # A genuine child has the same credentials.  Treat a denial
+                # as transient and retain the subreaper fence.
+                pass
+
+        try:
+            waited_pid, _status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if waited_pid == 0:
+            time.sleep(_TERMINATION_POLL_SECONDS)
+
+
+def _normalized_exit_code(return_code: int) -> int:
+    """Translate Popen's signal result into conventional shell status."""
+
+    if return_code < 0:
+        return min(255, 128 + abs(return_code))
+    return min(255, int(return_code))
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Run one argv under the verified subreaper fence."""
+
+    global _termination_signal
+    _termination_signal = 0
+    values = list(sys.argv[1:] if arguments is None else arguments)
+    if len(values) < 2 or values[0] != "--" or not values[1]:
+        return _CONFINEMENT_FAILURE_EXIT_CODE
+    if not _enable_child_subreaper():
+        return _CONFINEMENT_FAILURE_EXIT_CODE
+
+    # Verify that procfs child enumeration works before executing untrusted
+    # provider code.  If confinement is unavailable, the CLI is never run.
+    try:
+        if _direct_child_pids():
+            return _CONFINEMENT_FAILURE_EXIT_CODE
+    except (OSError, ValueError):
+        return _CONFINEMENT_FAILURE_EXIT_CODE
+
+    for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+        signal.signal(signum, _record_termination)
+
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        process = subprocess.Popen(
+            values[1:],
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+            start_new_session=False,
+        )
+        while process.poll() is None:
+            if _termination_signal:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                break
+            try:
+                process.wait(timeout=_TERMINATION_POLL_SECONDS)
+            except subprocess.TimeoutExpired:
+                continue
+        return_code = process.wait()
+        _kill_and_reap_orphans()
+        if _termination_signal:
+            return min(255, 128 + _termination_signal)
+        return _normalized_exit_code(return_code)
+    except BaseException:
+        if process is not None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait()
+            except BaseException:
+                pass
+        _kill_and_reap_orphans()
+        return _CONFINEMENT_FAILURE_EXIT_CODE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/api/test_agent_supervisor_native_cli_confinement.py
+++ b/test/api/test_agent_supervisor_native_cli_confinement.py
@@ -1,0 +1,106 @@
+"""Adversarial native provider CLI process-confinement tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from ipfs_accelerate_py.agent_supervisor.todo_daemon import (
+    legacy_landed_provider_cli as native_cli,
+)
+from ipfs_accelerate_py.agent_supervisor.todo_daemon import (
+    native_cli_subreaper,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux" or not Path("/proc/self/task").is_dir(),
+    reason="native CLI confinement requires Linux procfs",
+)
+
+
+def _process_is_live(process_id: int) -> bool:
+    try:
+        raw = Path(f"/proc/{process_id}/stat").read_text(encoding="ascii")
+    except FileNotFoundError:
+        return False
+    fields = raw[raw.rfind(")") + 2 :].split()
+    return bool(fields) and fields[0] != "Z"
+
+
+def test_successful_cli_cannot_leave_immediate_setsid_descendant(
+    tmp_path: Path,
+) -> None:
+    descendant_pid_path = tmp_path / "descendant.pid"
+    escaped_write_path = tmp_path / "escaped-write"
+    descendant_script = (
+        "import pathlib,time;"
+        "time.sleep(0.4);"
+        f"pathlib.Path({str(escaped_write_path)!r}).write_text('escaped');"
+        "time.sleep(60)"
+    )
+    direct_script = (
+        "import pathlib,subprocess,sys;"
+        "child=subprocess.Popen("
+        f"[sys.executable,'-c',{descendant_script!r}],"
+        "stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,"
+        "stderr=subprocess.DEVNULL,close_fds=True,start_new_session=True);"
+        f"pathlib.Path({str(descendant_pid_path)!r}).write_text(str(child.pid))"
+    )
+
+    stdout, stderr = native_cli._run_native_cli_process(
+        [sys.executable, "-c", direct_script],
+        cwd=tmp_path,
+        timeout_seconds=5,
+    )
+
+    assert stdout == ""
+    assert stderr == ""
+    descendant_pid = int(descendant_pid_path.read_text(encoding="utf-8"))
+    time.sleep(0.6)
+    assert not escaped_write_path.exists()
+    assert not _process_is_live(descendant_pid)
+
+
+def test_subreaper_preserves_stdout_stderr_and_exit_classification(
+    tmp_path: Path,
+) -> None:
+    success_script = "import sys;sys.stdout.write('out');sys.stderr.write('err')"
+    stdout, stderr = native_cli._run_native_cli_process(
+        [sys.executable, "-c", success_script],
+        cwd=tmp_path,
+        timeout_seconds=5,
+    )
+    assert stdout == "out"
+    assert stderr == "err"
+
+    failed_script = "import sys;sys.stderr.write('private');raise SystemExit(17)"
+    with pytest.raises(RuntimeError) as raised:
+        native_cli._run_native_cli_process(
+            [sys.executable, "-c", failed_script],
+            cwd=tmp_path,
+            timeout_seconds=5,
+        )
+    assert str(raised.value) == "legacy native provider command failed"
+    assert "private" not in str(raised.value)
+
+
+def test_wrapper_fails_before_launch_when_subreaper_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launched = False
+
+    def forbidden_popen(*_args: object, **_kwargs: object) -> subprocess.Popen[bytes]:
+        nonlocal launched
+        launched = True
+        raise AssertionError("provider command must not run")
+
+    monkeypatch.setattr(native_cli_subreaper, "_enable_child_subreaper", lambda: False)
+    monkeypatch.setattr(native_cli_subreaper.subprocess, "Popen", forbidden_popen)
+
+    result = native_cli_subreaper.main(["--", sys.executable, "-c", "pass"])
+
+    assert result == native_cli_subreaper._CONFINEMENT_FAILURE_EXIT_CODE
+    assert launched is False


### PR DESCRIPTION
## Summary
Forward-port of **mergeable** residual UIIR work onto current main after the
multi-kLOC residual stack merge proved unmergeable (see
`archive/uiir-residual-*` branches).

### Included
- `native_cli_subreaper.py` — Linux child-subreaper confinement for native CLI
- Wire subreaper into `legacy_landed_provider_cli._run_native_cli_process`
- `NativeGrokQuotaExhaustionSignal` from exact Grok Build 402 streaming-json events
- Tests: `test_agent_supervisor_native_cli_confinement.py` (**3 passed**)

### Explicitly not ported
- Multi-kLOC `post_merge_review` module — main documents this as parallel
  evolution; acceptance uses `post_merge_validation` + production provider review
  (see `test_agent_supervisor_composite_post_merge_binding.py`)
- Bulk tip merge of `archive/uiir-residual-grok-terra-20260803` — 28+ conflicts
  and API regressions against evolved main

## Test plan
- [x] `pytest test/api/test_agent_supervisor_native_cli_confinement.py` (3 passed)
- [x] `py_compile` on changed modules
- [x] Confirmed production_provider_cli baseline failures are pre-existing on main