### PR TITLE
feat(todo-daemon): verified Grok quota promotion for Terra fallback

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/contract_packet_provider_router.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/contract_packet_provider_router.py
@@ -184,6 +184,22 @@ class ProviderQuotaError(RuntimeError):
         self.reason_code = str(reason_code or ProviderReason.PROVIDER_QUOTA_EXHAUSTED.value)
 
 
+class VerifiedGrokQuotaExhaustion(ProviderQuotaError):
+    """Supervisor-observed, exact Grok Build balance-exhaustion signal.
+
+    Only the native transport adapter may construct this signal after checking
+    the CLI exit status and its structured transport event.  Provider/model
+    response text and generic quota exceptions deliberately cannot authorize
+    the Codex Terra implementation fallback.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            ProviderReason.GROK_QUOTA_EXHAUSTED.value,
+            reason_code=ProviderReason.GROK_QUOTA_EXHAUSTED.value,
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class ProviderBounds:
     """Frozen prompt, response, and wall-clock bounds for every provider call."""
@@ -3360,6 +3376,7 @@ __all__ = [
     "ProviderExecutionReceipt",
     "ProviderProposal",
     "ProviderQuotaError",
+    "VerifiedGrokQuotaExhaustion",
     "ProviderQuotaLatch",
     "ProviderReason",
     "ProviderRequest",

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/production_provider_cli.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/production_provider_cli.py
@@ -42,8 +42,10 @@ from .contract_packet_provider_router import (
     MAX_PROVIDER_TIMEOUT_SECONDS,
     ProviderRequest,
     ProviderRole,
+    VerifiedGrokQuotaExhaustion,
 )
 from .legacy_landed_provider_cli import (
+    NativeGrokQuotaExhaustionSignal,
     _invoke_native_structured_cli,
 )
 from .llm import (
@@ -610,21 +612,28 @@ class BoundProductionCLIProvider:
         *,
         max_response_bytes: int,
     ) -> tuple[str, LlmChildResultEnvelope | None]:
-        if self.invoker is not None:
-            return self.invoker(prompt, config)
-        return _invoke_native_structured_cli(
-            prompt,
-            config,
-            response_schema,
-            response_validator=_validate_production_native_response,
-            execution_schema=PRODUCTION_NATIVE_STRUCTURED_EXECUTION_SCHEMA,
-            max_response_bytes=max_response_bytes,
-            codex_reasoning_effort=(
-                self.policy.codex_reasoning_effort
-                if self.role is ProviderRole.CODEX_REVIEW
-                else ""
-            ),
-        )
+        try:
+            if self.invoker is not None:
+                return self.invoker(prompt, config)
+            return _invoke_native_structured_cli(
+                prompt,
+                config,
+                response_schema,
+                response_validator=_validate_production_native_response,
+                execution_schema=PRODUCTION_NATIVE_STRUCTURED_EXECUTION_SCHEMA,
+                max_response_bytes=max_response_bytes,
+                codex_reasoning_effort=(
+                    self.policy.codex_reasoning_effort
+                    if self.role is ProviderRole.CODEX_REVIEW
+                    else ""
+                ),
+            )
+        except NativeGrokQuotaExhaustionSignal as exc:
+            if self.role is ProviderRole.GROK_IMPLEMENT:
+                raise VerifiedGrokQuotaExhaustion() from exc
+            raise RuntimeError(
+                "non-Grok production provider emitted a Grok quota signal"
+            ) from exc
 
     def __call__(self, request: ProviderRequest) -> Mapping[str, Any]:
         if not isinstance(request, ProviderRequest):

--- a/test/api/test_agent_supervisor_native_grok_quota_signal.py
+++ b/test/api/test_agent_supervisor_native_grok_quota_signal.py
@@ -1,0 +1,49 @@
+"""Exact Grok Build quota signal must promote to verified router exception."""
+
+from __future__ import annotations
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor.todo_daemon.contract_packet_provider_router import (
+    ProviderRole,
+    VerifiedGrokQuotaExhaustion,
+)
+from ipfs_accelerate_py.agent_supervisor.todo_daemon.legacy_landed_provider_cli import (
+    GROK_BUILD_BALANCE_EXHAUSTED_MARKER,
+    NativeGrokQuotaExhaustionSignal,
+    _native_cli_failure,
+)
+from ipfs_accelerate_py.agent_supervisor.todo_daemon.production_provider_cli import (
+    BoundProductionCLIProvider,
+)
+
+
+def test_native_cli_failure_classifies_exact_streaming_json_402() -> None:
+    event = (
+        b'{"type":"error","message":"API error (status 402 Payment Required): '
+        b'Grok Build usage balance exhausted"}\n'
+    )
+    err = _native_cli_failure(
+        ["grok", "prompt"],
+        return_code=1,
+        stdout=bytearray(event),
+        stderr=bytearray(),
+    )
+    assert isinstance(err, NativeGrokQuotaExhaustionSignal)
+    assert str(err) == GROK_BUILD_BALANCE_EXHAUSTED_MARKER
+
+
+def test_production_cli_promotes_native_signal_only_for_grok_implement() -> None:
+    def boom(_prompt, _config):
+        raise NativeGrokQuotaExhaustionSignal()
+
+    provider = object.__new__(BoundProductionCLIProvider)
+    object.__setattr__(provider, "role", ProviderRole.GROK_IMPLEMENT)
+    object.__setattr__(provider, "invoker", boom)
+
+    with pytest.raises(VerifiedGrokQuotaExhaustion):
+        provider._invoke("prompt", object(), {}, max_response_bytes=1024)
+
+    object.__setattr__(provider, "role", ProviderRole.CODEX_REVIEW)
+    with pytest.raises(RuntimeError, match="non-Grok production provider"):
+        provider._invoke("prompt", object(), {}, max_response_bytes=1024)


### PR DESCRIPTION
## Summary
Second slice of the UIIR residual forward-port (after #135 subreaper):

- `VerifiedGrokQuotaExhaustion` on the contract-packet router
- Production CLI promotes `NativeGrokQuotaExhaustionSignal` → verified quota
  **only** for `GROK_IMPLEMENT` (non-Grok roles fail closed)
- Tests: `test_agent_supervisor_native_grok_quota_signal.py`

This is the policy-facing half of exact Grok Build 402 classification so Codex
Terra medium can be authorized only after a verified native signal—not free-form
model text.

## Test plan
- [x] `pytest test/api/test_agent_supervisor_native_grok_quota_signal.py test/api/test_agent_supervisor_native_cli_confinement.py`