### PR TITLE
fix(docs): README TOC anchors for documentation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@
 
 ## 📋 Table of Contents
 
-- [Overview](#-overview)
-- [Installation](#-installation)
-- [Quick Start](#-quick-start)
-- [MCP Server](#-mcp-server)
-- [Architecture](#️-architecture)
-- [Hardware and Providers](#-hardware-and-providers)
-- [Models and Inference](#-models-and-inference)
-- [IPFS and P2P](#-ipfs-and-p2p)
-- [Performance and Scaling](#-performance-and-scaling)
-- [Testing](#-testing)
-- [Documentation](#-documentation)
-- [Troubleshooting](#-troubleshooting)
-- [Contributing](#-contributing)
-- [License](#-license)
-- [Acknowledgments](#-acknowledgments)
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [MCP Server](#mcp-server)
+- [Architecture](#architecture)
+- [Hardware and Providers](#hardware-and-providers)
+- [Models and Inference](#models-and-inference)
+- [IPFS and P2P](#ipfs-and-p2p)
+- [Performance and Scaling](#performance-and-scaling)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix README table-of-contents fragments so they match the repo's GitHub-style heading slugger (emoji stripped, no leading `-`).
- Unblocks Documentation Gates on `main` after the ASE3 merge (also failed on the prior LFP-047 tip — pre-existing).

## Verification
- `python scripts/docs/check_current_docs_links.py` → OK (46 files)