### PR TITLE
feat: ASE3-033 Q construction readiness probe

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_q_readiness.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_q_readiness.py
@@ -1,0 +1,331 @@
+"""Fail-closed readiness probe for ASE3-033 Q construction.
+
+Does not create Q inventory, change task status, sign artifacts, or start a
+supervisor.  Reports exact blockers for the six pre-Q product freezes, the
+lifecycle root DID, tooling presence, and inventory absence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..core.protected_acceptance_contracts import (
+    PRE_Q_PRODUCT_TASKS,
+    Q_INVENTORY_SCHEMA,
+)
+from ..validation import prompt_v3_convergence as convergence
+
+Q_INVENTORY_RELATIVE_PATH = (
+    "data/agent_supervisor/prompt_only_self_improvement_v3/convergence/"
+    "protected_acceptance_q_inventory.json"
+)
+ASE3_033_TOOLING_PATHS = (
+    "ipfs_accelerate_py/agent_supervisor/core/protected_acceptance_contracts.py",
+    "ipfs_accelerate_py/agent_supervisor/merge/protected_acceptance_transition.py",
+    "ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition.py",
+    "ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition_cli.py",
+    "test/api/test_agent_supervisor_prompt_v3_transition.py",
+)
+_CANONICAL_DIFF_ARGV = (
+    "/usr/bin/git",
+    "diff",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-renames",
+    "--binary",
+    "--full-index",
+)
+
+
+def _git_ok(repo: Path, *arguments: str) -> tuple[bool, str]:
+    env = dict(os.environ)
+    for key in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_EDITOR",
+        "GIT_SEQUENCE_EDITOR",
+        "GIT_TERMINAL_PROMPT",
+    ):
+        env.pop(key, None)
+    try:
+        completed = subprocess.run(
+            ["/usr/bin/git", *arguments],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        return False, str(exc)
+    if completed.returncode != 0:
+        return False, (completed.stderr or completed.stdout or "git failed").strip()
+    return True, completed.stdout.strip()
+
+
+def _object_exists(repo: Path, object_id: str) -> bool:
+    ok, _ = _git_ok(repo, "cat-file", "-e", f"{object_id}^{{commit}}")
+    if ok:
+        return True
+    ok, _ = _git_ok(repo, "cat-file", "-e", object_id)
+    return ok
+
+
+def _verify_generation(repo: Path, generation: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    required = (
+        "source_commit",
+        "source_parent",
+        "source_tree",
+        "integrated_commit",
+        "integrated_parent",
+        "integrated_tree",
+        "binary_full_index_patch_sha256",
+        "changed_paths",
+    )
+    missing = [key for key in required if key not in generation]
+    if missing:
+        return [f"generation missing fields: {','.join(missing)}"]
+    for field in (
+        "source_commit",
+        "source_parent",
+        "source_tree",
+        "integrated_commit",
+        "integrated_parent",
+        "integrated_tree",
+    ):
+        value = str(generation[field])
+        if value.startswith("FILL_AFTER_") or not _object_exists(repo, value):
+            errors.append(f"{field} unavailable: {value}")
+    if errors:
+        return errors
+    ok, observed_tree = _git_ok(
+        repo, "rev-parse", f"{generation['source_commit']}^{{tree}}"
+    )
+    if not ok or observed_tree != generation["source_tree"]:
+        errors.append("source_tree mismatch against git")
+    ok, observed_parent = _git_ok(repo, "rev-parse", f"{generation['source_commit']}^")
+    if not ok or observed_parent != generation["source_parent"]:
+        errors.append("source_parent mismatch against git")
+    ok, observed_tree = _git_ok(
+        repo, "rev-parse", f"{generation['integrated_commit']}^{{tree}}"
+    )
+    if not ok or observed_tree != generation["integrated_tree"]:
+        errors.append("integrated_tree mismatch against git")
+    ok, observed_parent = _git_ok(
+        repo, "rev-parse", f"{generation['integrated_commit']}^"
+    )
+    if not ok or observed_parent != generation["integrated_parent"]:
+        errors.append("integrated_parent mismatch against git")
+    env = dict(os.environ)
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY"):
+        env.pop(key, None)
+    patch = subprocess.run(
+        [
+            *_CANONICAL_DIFF_ARGV,
+            str(generation["source_parent"]),
+            str(generation["source_commit"]),
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    # Note: for hermetic acceptance generations, the sealed patch is parent→source
+    # for source role; integrated patch uses integrated_parent→integrated_commit.
+    # Prefer integrated stream hash when binary_full_index is sealed for the product
+    # role that binds integrated topology.
+    patch_i = subprocess.run(
+        [
+            *_CANONICAL_DIFF_ARGV,
+            str(generation["integrated_parent"]),
+            str(generation["integrated_commit"]),
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if patch_i.returncode != 0:
+        errors.append("unable to reconstruct integrated full-index patch")
+    else:
+        digest = "sha256:" + hashlib.sha256(patch_i.stdout).hexdigest()
+        if digest != generation["binary_full_index_patch_sha256"]:
+            # Fall back to source-parent→source stream (some seals bind source side)
+            if patch.returncode == 0:
+                digest_s = "sha256:" + hashlib.sha256(patch.stdout).hexdigest()
+                if digest_s != generation["binary_full_index_patch_sha256"]:
+                    errors.append(
+                        "binary_full_index_patch_sha256 mismatch against git "
+                        f"(integrated={digest}, source={digest_s})"
+                    )
+            else:
+                errors.append(
+                    f"binary_full_index_patch_sha256 mismatch against git ({digest})"
+                )
+    return errors
+
+
+def _product_status(repo: Path, task_id: str) -> dict[str, Any]:
+    blockers: list[str] = []
+    final_values = convergence._ACCEPTANCE_IMPLEMENTATION_FINAL_VALUES.get(task_id)
+    if final_values is None:
+        # Hermetic / native / duckdb tasks use other tables
+        if task_id == "ASE3-030":
+            final_values = convergence._HERMETIC_IDENTITY_FINAL_VALUES
+        elif task_id == "ASE3-031":
+            final_values = convergence._NATIVE_DEPENDENCY_ACCEPTANCE_FINAL_VALUES
+        elif task_id == "ASE3-032":
+            final_values = convergence._DUCKDB_POLICY_ACCEPTANCE_FINAL_VALUES
+        else:
+            return {
+                "task_id": task_id,
+                "ready": False,
+                "blockers": [f"no final-value table for {task_id}"],
+            }
+    ready = bool(final_values.get("ready"))
+    pending = final_values.get("pending")
+    if not ready:
+        blockers.append(f"final values not ready ({pending})")
+    generations = final_values.get("generations") or ()
+    generation_reports: list[dict[str, Any]] = []
+    if not generations and task_id in {"ASE3-019", "ASE3-023", "ASE3-027"}:
+        blockers.append("no sealed source/integrated generation records")
+    for index, generation in enumerate(generations):
+        if not isinstance(generation, Mapping):
+            generation_reports.append(
+                {"index": index, "ok": False, "errors": ["generation is not a mapping"]}
+            )
+            blockers.append(f"generation[{index}] is not a mapping")
+            continue
+        errors = _verify_generation(repo, generation)
+        generation_reports.append(
+            {
+                "index": index,
+                "ok": not errors,
+                "role": generation.get("role"),
+                "source_commit": generation.get("source_commit"),
+                "integrated_commit": generation.get("integrated_commit"),
+                "errors": errors,
+            }
+        )
+        if errors:
+            blockers.extend(f"generation[{index}]: {item}" for item in errors)
+    final_blobs = final_values.get("final_blobs") or {}
+    blob_errors: list[str] = []
+    if final_blobs and generations:
+        # Bind blobs against the last integrated commit when available.
+        tip = None
+        for generation in reversed(tuple(generations)):
+            if isinstance(generation, Mapping) and generation.get("integrated_commit"):
+                tip = str(generation["integrated_commit"])
+                break
+        if tip and _object_exists(repo, tip):
+            for path, blob in final_blobs.items():
+                ok, observed = _git_ok(repo, "rev-parse", f"{tip}:{path}")
+                if not ok or observed != blob:
+                    blob_errors.append(f"{path}: blob mismatch or missing at {tip[:12]}")
+        else:
+            blob_errors.append("cannot bind final_blobs without integrated tip")
+    if blob_errors:
+        blockers.extend(blob_errors)
+    # Distinct replay commit still required for prompt-v3-product-generation@1
+    product_generation_ready = False
+    if ready and generations and not blob_errors:
+        # Even with hermetic source/integrated pairs, Q inventory requires
+        # independent source/replay/integrated triples — report as partial.
+        blockers.append(
+            "prompt-v3-product-generation@1 requires independent source, "
+            "clean-replay, and integrated commits with identical inventories"
+        )
+    return {
+        "task_id": task_id,
+        "ready": ready and not blockers,
+        "sealed_ready_flag": ready,
+        "pending": pending,
+        "generation_count": len(tuple(generations)),
+        "generations": generation_reports,
+        "final_blob_count": len(final_blobs),
+        "blob_errors": blob_errors,
+        "product_generation_v1_ready": product_generation_ready,
+        "blockers": blockers,
+    }
+
+
+def assess_prompt_v3_q_construction_readiness(
+    repo_root: Path | str | None = None,
+) -> dict[str, Any]:
+    """Return a structured, fail-closed Q construction readiness report."""
+
+    repo = Path(repo_root or Path.cwd()).resolve()
+    tooling = {
+        path: (repo / path).is_file() for path in ASE3_033_TOOLING_PATHS
+    }
+    inventory_path = repo / Q_INVENTORY_RELATIVE_PATH
+    inventory_present = inventory_path.exists() or inventory_path.is_symlink()
+    products = {
+        task_id: _product_status(repo, task_id)
+        for task_id in sorted(PRE_Q_PRODUCT_TASKS)
+    }
+    lifecycle_blockers: list[str] = []
+    root_did = None
+    try:
+        from .local_profile import lifecycle_root_identity_did
+
+        root_did = lifecycle_root_identity_did()
+        if not isinstance(root_did, str) or not root_did.startswith("did:key:z"):
+            lifecycle_blockers.append("lifecycle root DID is not a did:key")
+            root_did = None
+    except Exception as exc:  # local profile may be uninitialized
+        lifecycle_blockers.append(f"lifecycle root unavailable: {type(exc).__name__}")
+
+    product_blockers = [
+        f"{task_id}: {blocker}"
+        for task_id, report in products.items()
+        for blocker in report["blockers"]
+    ]
+    tooling_blockers = [
+        f"missing tooling: {path}" for path, present in tooling.items() if not present
+    ]
+    inventory_blockers = (
+        ["Q inventory already present (expected only after prepare-q)"]
+        if inventory_present
+        else []
+    )
+    blockers = (
+        tooling_blockers
+        + inventory_blockers
+        + lifecycle_blockers
+        + product_blockers
+    )
+    return {
+        "schema": "ipfs_accelerate_py.agent_supervisor.prompt-v3-q-readiness@1",
+        "q_inventory_schema": Q_INVENTORY_SCHEMA,
+        "q_inventory_path": Q_INVENTORY_RELATIVE_PATH,
+        "q_inventory_present": inventory_present,
+        "ase3_033_tooling": tooling,
+        "lifecycle_root_identity_did": root_did,
+        "pre_q_products": products,
+        "ready_for_prepare_q": not blockers,
+        "blocker_count": len(blockers),
+        "blockers": blockers,
+        "notes": [
+            "Does not create Q, receipts, signatures, or start a supervisor.",
+            "prepare-q remains blocked until every pre-Q product has "
+            "prompt-v3-product-generation@1 source/replay/integrated freezes.",
+        ],
+    }
+
+
+__all__ = (
+    "ASE3_033_TOOLING_PATHS",
+    "Q_INVENTORY_RELATIVE_PATH",
+    "assess_prompt_v3_q_construction_readiness",
+)

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition.py
@@ -42,6 +42,9 @@ from ..merge.protected_acceptance_transition import (
     validate_phase_candidate,
 )
 
+from .protected_acceptance_q_readiness import (
+    assess_prompt_v3_q_construction_readiness,
+)
 ROOT_PIN_SCHEMA = (
     "ipfs_accelerate_py.agent_supervisor.local-profile-lifecycle-root-pin@1"
 )
@@ -461,6 +464,7 @@ def load_verified_prompt_v3_runtime_launch_authority(
 
 
 __all__ = (
+    "assess_prompt_v3_q_construction_readiness",
     "build_prompt_v3_phase_candidate",
     "build_prompt_v3_provider_authorization",
     "build_prompt_v3_reload_authorization",

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition_cli.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition_cli.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from ..core.protected_acceptance_contracts import EvidenceHandle
 
-CLI_COMMANDS = ("inspect", "prepare-q", "advance-one-phase", "birth")
+CLI_COMMANDS = ("inspect", "readiness", "prepare-q", "advance-one-phase", "birth")
 
 
 def _evidence(value: str) -> EvidenceHandle:
@@ -31,6 +31,15 @@ def build_parser() -> argparse.ArgumentParser:
         "inspect", help="inspect immutable transition capability"
     )
     inspect.add_argument("--evidence", action="append", type=_evidence, default=[])
+    readiness = subcommands.add_parser(
+        "readiness",
+        help="report fail-closed Q construction readiness without creating Q",
+    )
+    readiness.add_argument(
+        "--repo-root",
+        default=".",
+        help="repository root to assess (default: cwd)",
+    )
     for name in ("prepare-q", "advance-one-phase", "birth"):
         command = subcommands.add_parser(name, help=f"perform exactly {name}")
         command.add_argument(
@@ -50,20 +59,29 @@ def main(
     | None = None,
 ) -> int:
     arguments = build_parser().parse_args(argv)
-    evidence = tuple(arguments.evidence)
+    evidence = tuple(getattr(arguments, "evidence", None) or ())
     if any(not isinstance(item, EvidenceHandle) for item in evidence):
         raise TypeError("CLI evidence was not fully transcoded")
     if handlers is None:
-        if arguments.command != "inspect":
+        if arguments.command == "readiness":
+            from .protected_acceptance_q_readiness import (
+                assess_prompt_v3_q_construction_readiness,
+            )
+
+            result = assess_prompt_v3_q_construction_readiness(
+                getattr(arguments, "repo_root", ".")
+            )
+        elif arguments.command != "inspect":
             build_parser().error(
                 "production command requires injected protected composition"
             )
-        result: Mapping[str, Any] = {
-            "commands": list(CLI_COMMANDS),
-            "run_all": False,
-            "raw_key_input": False,
-            "evidence_handles": [item.to_dict() for item in evidence],
-        }
+        else:
+            result = {
+                "commands": list(CLI_COMMANDS),
+                "run_all": False,
+                "raw_key_input": False,
+                "evidence_handles": [item.to_dict() for item in evidence],
+            }
     else:
         if set(handlers) - set(CLI_COMMANDS):
             raise ValueError("CLI handlers contain unsupported commands")

--- a/test/api/test_agent_supervisor_prompt_v3_transition.py
+++ b/test/api/test_agent_supervisor_prompt_v3_transition.py
@@ -50,6 +50,8 @@ from ipfs_accelerate_py.agent_supervisor.entrypoints.protected_acceptance_transi
 from ipfs_accelerate_py.agent_supervisor.entrypoints.protected_acceptance_transition_cli import (
     main as transition_cli_main,
 )
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 from ipfs_accelerate_py.agent_supervisor.merge.protected_acceptance_transition import (
     ProtectedTransitionGitError,
     ProtectedTransitionRace,
@@ -865,11 +867,19 @@ def test_cli_surface_is_bounded_and_has_no_run_all_or_raw_key(
     help_text = parser.format_help()
     assert all(
         name in help_text
-        for name in ("inspect", "prepare-q", "advance-one-phase", "birth")
+        for name in (
+            "inspect",
+            "readiness",
+            "prepare-q",
+            "advance-one-phase",
+            "birth",
+        )
     )
     assert "run-all" not in help_text and "raw-key" not in help_text
     assert transition_cli_main(["inspect"]) == 0
-    assert json.loads(capsys.readouterr().out)["run_all"] is False
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_all"] is False
+    assert "readiness" in payload["commands"]
     with pytest.raises(SystemExit):
         transition_cli_main(["birth", "--raw-key", "secret"])
 
@@ -890,3 +900,42 @@ def test_gitignore_anchors_root_core_without_ignoring_nested_module() -> None:
         == 0
     )
     assert stat.S_IMODE((repo / ".gitignore").stat().st_mode) == 0o644
+
+
+def test_q_construction_readiness_reports_tooling_and_blockers() -> None:
+    from ipfs_accelerate_py.agent_supervisor.entrypoints.protected_acceptance_q_readiness import (
+        assess_prompt_v3_q_construction_readiness,
+    )
+
+    report = assess_prompt_v3_q_construction_readiness(REPO_ROOT)
+    assert report["schema"].endswith("prompt-v3-q-readiness@1")
+    assert report["ready_for_prepare_q"] is False
+    assert report["q_inventory_present"] is False
+    assert all(report["ase3_033_tooling"].values())
+    products = report["pre_q_products"]
+    assert set(products) == {
+        "ASE3-019",
+        "ASE3-023",
+        "ASE3-027",
+        "ASE3-030",
+        "ASE3-031",
+        "ASE3-032",
+    }
+    # ASE3-027 sealed generations reconstruct from git even while ready=False.
+    ase3027 = products["ASE3-027"]
+    assert ase3027["generation_count"] == 2
+    assert ase3027["generations"][0]["ok"] is True
+    assert ase3027["generations"][1]["ok"] is True
+    assert ase3027["final_blob_count"] == 5
+    assert ase3027["blob_errors"] == []
+    assert any("ASE3-019" in item for item in report["blockers"])
+    assert any("ASE3-027" in item for item in report["blockers"])
+
+
+def test_cli_readiness_command_is_available_without_injected_handlers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert transition_cli_main(["readiness", "--repo-root", str(REPO_ROOT)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ready_for_prepare_q"] is False
+    assert payload["blocker_count"] >= 1


### PR DESCRIPTION
## Summary
- Adds `assess_prompt_v3_q_construction_readiness()` and CLI `readiness`.
- Reports exact prepare-q blockers for ASE3-019/023/027/030/031/032, lifecycle root DID, tooling, and Q inventory absence.
- Live-verifies ASE3-027 sealed generations + final blobs against Git (both generations reconstruct).

## Does not
- Create Q inventory
- Mark ASE3-033 completed
- Sign receipts or start a supervisor

## Verification
- Transition suite: **38/38**
- ASE3-033 dormant contract: **pass**

## Current readiness (local main tree)
- Tooling: present
- Q inventory: absent (correct pre-Q)
- Lifecycle root DID: available when local profile initialized
- Blockers: final-value freezes for 019/023/027/030/031/032 (027 generations verify; ready flag still pending)