### PR TITLE
feat: freeze product-generation@1 triples for pre-Q products

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_q_readiness.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_q_readiness.py
@@ -83,6 +83,28 @@ def _object_exists(repo: Path, object_id: str) -> bool:
     return ok
 
 
+def _canonical_patch_sha256(repo: Path, parent: str, commit: str) -> str | None:
+    env = dict(os.environ)
+    for key in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ):
+        env.pop(key, None)
+    patch = subprocess.run(
+        [*_CANONICAL_DIFF_ARGV, parent, commit],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if patch.returncode != 0:
+        return None
+    return "sha256:" + hashlib.sha256(patch.stdout).hexdigest()
+
+
 def _verify_generation(repo: Path, generation: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     required = (
@@ -129,22 +151,92 @@ def _verify_generation(repo: Path, generation: Mapping[str, Any]) -> list[str]:
     )
     if not ok or observed_parent != generation["integrated_parent"]:
         errors.append("integrated_parent mismatch against git")
-    env = dict(os.environ)
-    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY"):
-        env.pop(key, None)
-    patch = subprocess.run(
-        [
-            *_CANONICAL_DIFF_ARGV,
-            str(generation["source_parent"]),
-            str(generation["source_commit"]),
-        ],
-        cwd=repo,
-        env=env,
-        capture_output=True,
-        check=False,
+    expected_patch = str(generation["binary_full_index_patch_sha256"])
+    source_patch = _canonical_patch_sha256(
+        repo,
+        str(generation["source_parent"]),
+        str(generation["source_commit"]),
     )
-    # Note: for hermetic acceptance generations, the sealed patch is parent→source
-    # for source role; integrated patch uses integrated_parent→integrated_commit.
+    integrated_patch = _canonical_patch_sha256(
+        repo,
+        str(generation["integrated_parent"]),
+        str(generation["integrated_commit"]),
+    )
+    if source_patch != expected_patch:
+        errors.append("source binary_full_index_patch_sha256 mismatch")
+    if integrated_patch != expected_patch:
+        errors.append("integrated binary_full_index_patch_sha256 mismatch")
+    if git_merge_base_is_ancestor(repo, str(generation["source_commit"]), "HEAD"):
+        errors.append("source_commit must not be an ancestor of HEAD")
+    if not git_merge_base_is_ancestor(
+        repo, str(generation["integrated_commit"]), "HEAD"
+    ):
+        errors.append("integrated_commit must be an ancestor of HEAD")
+    # Note: hermetic acceptance generations may also carry independent replay
+    # commits under prompt-v3-product-generation@1.
+    return errors
+
+
+def _verify_product_generation_triple(
+    repo: Path, generation: Mapping[str, Any]
+) -> list[str]:
+    """Verify one prompt-v3-product-generation@1 source/replay/integrated triple."""
+
+    errors: list[str] = []
+    required = (
+        "source_commit",
+        "source_parent",
+        "source_tree",
+        "replay_commit",
+        "replay_parent",
+        "replay_tree",
+        "integrated_commit",
+        "integrated_parent",
+        "integrated_tree",
+        "source_patch_sha256",
+        "replay_patch_sha256",
+        "integrated_patch_sha256",
+        "changed_paths",
+    )
+    missing = [key for key in required if key not in generation]
+    if missing:
+        return [f"product-generation missing fields: {','.join(missing)}"]
+    for kind in ("source", "replay", "integrated"):
+        for suffix in ("commit", "parent", "tree"):
+            field = f"{kind}_{suffix}"
+            value = str(generation[field])
+            if value.startswith("FILL_AFTER_") or not _object_exists(repo, value):
+                errors.append(f"{field} unavailable: {value}")
+    if errors:
+        return errors
+    digests: list[str] = []
+    for kind in ("source", "replay", "integrated"):
+        commit = str(generation[f"{kind}_commit"])
+        parent = str(generation[f"{kind}_parent"])
+        tree = str(generation[f"{kind}_tree"])
+        ok, observed_tree = _git_ok(repo, "rev-parse", f"{commit}^{{tree}}")
+        if not ok or observed_tree != tree:
+            errors.append(f"{kind}_tree mismatch against git")
+        ok, observed_parent = _git_ok(repo, "rev-parse", f"{commit}^")
+        if not ok or observed_parent != parent:
+            errors.append(f"{kind}_parent mismatch against git")
+        patch = _canonical_patch_sha256(repo, parent, commit)
+        expected = str(generation[f"{kind}_patch_sha256"])
+        if patch != expected:
+            errors.append(f"{kind}_patch_sha256 mismatch against git")
+        else:
+            digests.append(expected)
+        is_ancestor = git_merge_base_is_ancestor(repo, commit, "HEAD")
+        if kind == "integrated":
+            if not is_ancestor:
+                errors.append(f"{kind}_commit must be an ancestor of HEAD")
+        elif is_ancestor:
+            errors.append(f"{kind}_commit must not be an ancestor of HEAD")
+    if len(set(digests)) != 1 or len(digests) != 3:
+        errors.append("source/replay/integrated patch digests must be identical")
+    if str(generation["source_commit"]) == str(generation["replay_commit"]):
+        errors.append("source and replay commits must be independent objects")
+    return errors
     # Prefer integrated stream hash when binary_full_index is sealed for the product
     # role that binds integrated topology.
     patch_i = subprocess.run(
@@ -261,15 +353,63 @@ def _product_status(repo: Path, task_id: str) -> dict[str, Any]:
             blob_errors.append("cannot bind final_blobs without integrated tip")
     if blob_errors:
         blockers.extend(blob_errors)
-    # Distinct replay commit still required for prompt-v3-product-generation@1
+    # prompt-v3-product-generation@1: independent source/clean-replay/integrated.
+    product_generation = getattr(
+        convergence, "_PRODUCT_GENERATION_FINAL_VALUES", {}
+    ).get(task_id)
+    product_generation_reports: list[dict[str, Any]] = []
     product_generation_ready = False
-    if ready and generations and not blob_errors:
-        # Even with hermetic source/integrated pairs, Q inventory requires
-        # independent source/replay/integrated triples — report as partial.
-        blockers.append(
-            "prompt-v3-product-generation@1 requires independent source, "
-            "clean-replay, and integrated commits with identical inventories"
-        )
+    if product_generation is None:
+        if ready and (generations or task_id in {"ASE3-030", "ASE3-031", "ASE3-032"}):
+            blockers.append(
+                "prompt-v3-product-generation@1 requires independent source, "
+                "clean-replay, and integrated commits with identical inventories"
+            )
+    else:
+        pg_ready = bool(product_generation.get("ready"))
+        pg_pending = product_generation.get("pending")
+        pg_generations = product_generation.get("generations") or ()
+        if not pg_ready:
+            blockers.append(
+                f"prompt-v3-product-generation@1 not ready ({pg_pending})"
+            )
+        elif not pg_generations:
+            blockers.append(
+                "prompt-v3-product-generation@1 has no sealed generation triples"
+            )
+        else:
+            triple_errors: list[str] = []
+            for index, generation in enumerate(pg_generations):
+                if not isinstance(generation, Mapping):
+                    product_generation_reports.append(
+                        {
+                            "index": index,
+                            "ok": False,
+                            "errors": ["generation is not a mapping"],
+                        }
+                    )
+                    triple_errors.append(f"product-generation[{index}] not a mapping")
+                    continue
+                errors = _verify_product_generation_triple(repo, generation)
+                product_generation_reports.append(
+                    {
+                        "index": index,
+                        "ok": not errors,
+                        "role": generation.get("role"),
+                        "source_commit": generation.get("source_commit"),
+                        "replay_commit": generation.get("replay_commit"),
+                        "integrated_commit": generation.get("integrated_commit"),
+                        "errors": errors,
+                    }
+                )
+                if errors:
+                    triple_errors.extend(
+                        f"product-generation[{index}]: {item}" for item in errors
+                    )
+            if triple_errors:
+                blockers.extend(triple_errors)
+            else:
+                product_generation_ready = True
     return {
         "task_id": task_id,
         "ready": ready and not blockers,
@@ -280,6 +420,7 @@ def _product_status(repo: Path, task_id: str) -> dict[str, Any]:
         "final_blob_count": len(final_blobs),
         "blob_errors": blob_errors,
         "product_generation_v1_ready": product_generation_ready,
+        "product_generation_generations": product_generation_reports,
         "blockers": blockers,
     }
 

--- a/ipfs_accelerate_py/agent_supervisor/validation/prompt_v3_convergence.py
+++ b/ipfs_accelerate_py/agent_supervisor/validation/prompt_v3_convergence.py
@@ -2074,9 +2074,11 @@ _ASE3_019_REQUIRED_ACCEPTANCE: Final = (
 # ASE3-023 source/integrated generations and final P-tree blob maps are frozen
 # against Git.  ASE3-019 source-candidate/salvage-base identities are frozen
 # against the attempt-2 seed and main-reachable provider-fallback integration
-# tip.  ASE3-030 and the reload generation still need final identities.
-# Remaining sentinels must be replaced in the protected preparation commit; a
-# receipt never gets to choose those pins.
+# tip.  Product-generation@1 source/clean-replay/integrated triples are frozen
+# for ASE3-023/027/030/031/032 (ASE3-019 still pending).  ASE3-030 hermetic
+# acceptance closure hashes, ASE3-031/032 signed suite pins, and the reload
+# generation still need final identities.  Remaining sentinels must be replaced
+# in the protected preparation commit; a receipt never gets to choose those pins.
 #
 # The lifecycle schemas are fixed, but the protected root/profile/authorship
 # values cannot be populated until the ASE3-019 generation is integrated.
@@ -3403,6 +3405,317 @@ _DUCKDB_POLICY_ACCEPTANCE_FINAL_VALUES: Final = {
     "passed_count": -1,
     "report_sha256": _FINAL_VALUE_PENDING_032_ACCEPTANCE,
 }
+
+_PRODUCT_GENERATION_FINAL_VALUES: Final = {
+    "ASE3-023": {
+        "ready": True,
+        "pending": None,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (
+            {
+                "role": "product-salvage",
+                "source_commit": "b072068dcf8b954d6ec454d89a014a8a80b6d2ef",
+                "source_parent": "c5da756756064869dedab4aff17a0d17d8549488",
+                "source_tree": "8567257c0d101198b5b2e7fde47031c603ab5e09",
+                "replay_commit": "de5d7dcb49503b4bcc648a0aeacbcd0598b6e787",
+                "replay_parent": "c5da756756064869dedab4aff17a0d17d8549488",
+                "replay_tree": "8567257c0d101198b5b2e7fde47031c603ab5e09",
+                "integrated_commit": "dee1c4f09f01bf8131a6b675eccce68e7aacb34d",
+                "integrated_parent": "8f613252c2ff1460e6f2b551a2a8600a2d3ee519",
+                "integrated_tree": "cb0ad281d6e89bea8cce24abe8e6a0bfc3117610",
+                "source_patch_sha256": (
+                    "sha256:ba3000aab09784b9830eec492442da29168a03462e04a6659909e495490500ad"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:ba3000aab09784b9830eec492442da29168a03462e04a6659909e495490500ad"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:ba3000aab09784b9830eec492442da29168a03462e04a6659909e495490500ad"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/entrypoints/execution_plan.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/configured_board_scheduler.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/multi_supervisor_runner.py",
+                    "ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py",
+                    "test/api/test_agent_supervisor_configured_board_scheduler.py",
+                    "test/api/test_agent_supervisor_implementation_supervisor_runner.py",
+                    "test/api/test_agent_supervisor_prompt_v3_parallelism.py",
+                ),
+            },
+            {
+                "role": "capsule-identity",
+                "source_commit": "cb7df87b0b1b96915af01d07fe7b1d3e991dfdc9",
+                "source_parent": "b072068dcf8b954d6ec454d89a014a8a80b6d2ef",
+                "source_tree": "30e9ddf36737f7c0667ec60fb07e90130fd5b899",
+                "replay_commit": "13fb5479f9d5b18d604e6fafe028a45dacef7c80",
+                "replay_parent": "b072068dcf8b954d6ec454d89a014a8a80b6d2ef",
+                "replay_tree": "30e9ddf36737f7c0667ec60fb07e90130fd5b899",
+                "integrated_commit": "bd1cd48d4379b30f1584f8967921345216166f56",
+                "integrated_parent": "dee1c4f09f01bf8131a6b675eccce68e7aacb34d",
+                "integrated_tree": "e0d9a530d559a24a1f5785d2ed250d878571e242",
+                "source_patch_sha256": (
+                    "sha256:ef27f4a69ab3743e0b60eec43e2cae866f3d9cbe18b7b9307cbcb68b0807f892"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:ef27f4a69ab3743e0b60eec43e2cae866f3d9cbe18b7b9307cbcb68b0807f892"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:ef27f4a69ab3743e0b60eec43e2cae866f3d9cbe18b7b9307cbcb68b0807f892"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/entrypoints/execution_plan.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/configured_board_scheduler.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/multi_supervisor_runner.py",
+                    "ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py",
+                    "test/api/test_agent_supervisor_configured_board_scheduler.py",
+                    "test/api/test_agent_supervisor_prompt_v3_parallelism.py",
+                ),
+            },
+            {
+                "role": "recovery-barrier",
+                "source_commit": "7abfc4ca768dd5086600bb30815256c79aaace74",
+                "source_parent": "cb7df87b0b1b96915af01d07fe7b1d3e991dfdc9",
+                "source_tree": "79ed78e765eada55762bae63bdfdf81264111f8a",
+                "replay_commit": "6e93027b6f3b5d5488e3e438d1d6bd89286bed17",
+                "replay_parent": "cb7df87b0b1b96915af01d07fe7b1d3e991dfdc9",
+                "replay_tree": "79ed78e765eada55762bae63bdfdf81264111f8a",
+                "integrated_commit": "a43b2ce74816ac9226f6319b92425d0b002b6be6",
+                "integrated_parent": "bd1cd48d4379b30f1584f8967921345216166f56",
+                "integrated_tree": "bbb94ffe87c3b582e40b1052ba5b9dc1ca8b4c40",
+                "source_patch_sha256": (
+                    "sha256:0dce5226c7e543997cf55c1115622cc150a8261ca68f1d69252600ffd8fc3bb3"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:0dce5226c7e543997cf55c1115622cc150a8261ca68f1d69252600ffd8fc3bb3"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:0dce5226c7e543997cf55c1115622cc150a8261ca68f1d69252600ffd8fc3bb3"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/entrypoints/execution_plan.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/configured_board_scheduler.py",
+                    "ipfs_accelerate_py/agent_supervisor/runtime/multi_supervisor_runner.py",
+                    "ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py",
+                    "test/api/test_agent_supervisor_configured_board_scheduler.py",
+                    "test/api/test_agent_supervisor_implementation_supervisor_runner.py",
+                    "test/api/test_agent_supervisor_prompt_v3_parallelism.py",
+                ),
+            },
+        ),
+    },
+    "ASE3-027": {
+        "ready": True,
+        "pending": None,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (
+            {
+                "role": "product",
+                "source_commit": "aaf7d722a0c23f5a047b38708f6290631848e06b",
+                "source_parent": "e6f8e4a7771907372fc93b0f35cfde30170c2b2a",
+                "source_tree": "323f14dbcd9b15b09046cd3a481eb8588a6ede2a",
+                "replay_commit": "33154678bbdaf8e4a845bdb84be8d4b9937cad0e",
+                "replay_parent": "e6f8e4a7771907372fc93b0f35cfde30170c2b2a",
+                "replay_tree": "323f14dbcd9b15b09046cd3a481eb8588a6ede2a",
+                "integrated_commit": "6a0047436f9515281127c17913132a23cecfe56c",
+                "integrated_parent": "0321fd148bf7c5dc6e91251d119dc25f853e546f",
+                "integrated_tree": "ec240271c204fc8befcddef6b7ca2bcad124dc3b",
+                "source_patch_sha256": (
+                    "sha256:b2f8be2a8126e5302d1a02f627dc1def01c54899181ec5ade59cfa22c2649062"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:b2f8be2a8126e5302d1a02f627dc1def01c54899181ec5ade59cfa22c2649062"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:b2f8be2a8126e5302d1a02f627dc1def01c54899181ec5ade59cfa22c2649062"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/entrypoints/context_adapters.py",
+                    "ipfs_accelerate_py/agent_supervisor/entrypoints/inference_runtime.py",
+                    "test/api/test_agent_supervisor_prompt_v3_resolution_hardening.py",
+                ),
+            },
+            {
+                "role": "test-contract-correction",
+                "source_commit": "bd93ae76c277ae8761cd2abe0df79685d0b1b8ef",
+                "source_parent": "aaf7d722a0c23f5a047b38708f6290631848e06b",
+                "source_tree": "043677ccb5216204b3142bb8e2b7f71d4ca74bd9",
+                "replay_commit": "54969e2987430bb6cc52770de809d0c9540b614b",
+                "replay_parent": "aaf7d722a0c23f5a047b38708f6290631848e06b",
+                "replay_tree": "043677ccb5216204b3142bb8e2b7f71d4ca74bd9",
+                "integrated_commit": "d32415e4308a8462e96b4d04f807338f0a2d8b53",
+                "integrated_parent": "6a0047436f9515281127c17913132a23cecfe56c",
+                "integrated_tree": "87191ce65498a637c7b9500d72d434cadb8efbef",
+                "source_patch_sha256": (
+                    "sha256:e64ab06bc28e13ae08591708f634a855bc752208a8bfbaf7164d704386f0d9fd"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:e64ab06bc28e13ae08591708f634a855bc752208a8bfbaf7164d704386f0d9fd"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:e64ab06bc28e13ae08591708f634a855bc752208a8bfbaf7164d704386f0d9fd"
+                ),
+                "changed_paths": (
+                    "test/api/test_agent_supervisor_inference_runtime.py",
+                    "test/api/test_agent_supervisor_prompt_v3_resolution.py",
+                ),
+            },
+        ),
+    },
+    "ASE3-030": {
+        "ready": True,
+        "pending": None,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (
+            {
+                "role": "hermetic-cid-seal",
+                "source_commit": "fd2fb0b42e60ed6f9e03ccfef175b0cdd9ba9c2b",
+                "source_parent": "c5da756756064869dedab4aff17a0d17d8549488",
+                "source_tree": "22101ffb8eb2568d5f3c457e9664bba014e1e8ee",
+                "replay_commit": "f97cad9607f16e71c7b1383e55b624f5149def71",
+                "replay_parent": "c5da756756064869dedab4aff17a0d17d8549488",
+                "replay_tree": "22101ffb8eb2568d5f3c457e9664bba014e1e8ee",
+                "integrated_commit": "8ef29834e9af7629a621d583ec43bf37f136b10e",
+                "integrated_parent": "32face22bc17eb0b76f09fed2186ef799075b110",
+                "integrated_tree": "46be4b75f0a5ab9be06cf3b85a75691157fba09e",
+                "source_patch_sha256": (
+                    "sha256:863e754bc88c6743b5313548724bbbe5b741263bff1ff143dc5b38aa4f898d16"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:863e754bc88c6743b5313548724bbbe5b741263bff1ff143dc5b38aa4f898d16"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:863e754bc88c6743b5313548724bbbe5b741263bff1ff143dc5b38aa4f898d16"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/core/multiformats_identity.py",
+                    "ipfs_accelerate_py/llm_router.py",
+                    "ipfs_accelerate_py/utils/cid_utils.py",
+                    "test/api/test_agent_supervisor_hermetic_cid_capsule.py",
+                ),
+            },
+            {
+                "role": "hermetic-cid-close",
+                "source_commit": "35992cba2261714a0030dff9d58a7a52c31f1d80",
+                "source_parent": "fd2fb0b42e60ed6f9e03ccfef175b0cdd9ba9c2b",
+                "source_tree": "d91e3cb65806c3dcd4068e10e5f5fe5362a60c6a",
+                "replay_commit": "eb9944cf7c214403531f375f971756f5acc6766b",
+                "replay_parent": "fd2fb0b42e60ed6f9e03ccfef175b0cdd9ba9c2b",
+                "replay_tree": "d91e3cb65806c3dcd4068e10e5f5fe5362a60c6a",
+                "integrated_commit": "3740b4bc2c31a945748bb9cd9861a37a54abd6aa",
+                "integrated_parent": "8ef29834e9af7629a621d583ec43bf37f136b10e",
+                "integrated_tree": "d1956cb171afbe24225ba1c65920c4192b4a8177",
+                "source_patch_sha256": (
+                    "sha256:7666046a183a681f098e75090331172277f1cef988068120bae00c44e6907c26"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:7666046a183a681f098e75090331172277f1cef988068120bae00c44e6907c26"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:7666046a183a681f098e75090331172277f1cef988068120bae00c44e6907c26"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/core/multiformats_identity.py",
+                    "ipfs_accelerate_py/llm_router.py",
+                    "ipfs_accelerate_py/utils/cid_utils.py",
+                    "test/api/test_agent_supervisor_control_plane.py",
+                    "test/api/test_agent_supervisor_control_plane_capsule_identity.py",
+                    "test/api/test_llm_router_agent_implementation_route.py",
+                ),
+            },
+        ),
+    },
+    "ASE3-031": {
+        "ready": True,
+        "pending": None,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (
+            {
+                "role": "native-duckdb-dependency",
+                "source_commit": "25fedf091dad928dad1f83c9f81a54c2d401eabe",
+                "source_parent": "35992cba2261714a0030dff9d58a7a52c31f1d80",
+                "source_tree": "da9e18b507b9991935823dc10d4d7208a47f47f2",
+                "replay_commit": "c9333d7934c5aa19f1888d6d41aa863d1dfc6b85",
+                "replay_parent": "35992cba2261714a0030dff9d58a7a52c31f1d80",
+                "replay_tree": "da9e18b507b9991935823dc10d4d7208a47f47f2",
+                "integrated_commit": "1a419e525699e74254a450c0137264d8dd60ea00",
+                "integrated_parent": "3740b4bc2c31a945748bb9cd9861a37a54abd6aa",
+                "integrated_tree": "06ea3c5444bd190996ad591b5fc82cad2443dcc4",
+                "source_patch_sha256": (
+                    "sha256:3daaf796199701b25e7e231f0bbd3ce5e0c1b487912e699d7f11473d02a784a2"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:3daaf796199701b25e7e231f0bbd3ce5e0c1b487912e699d7f11473d02a784a2"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:3daaf796199701b25e7e231f0bbd3ce5e0c1b487912e699d7f11473d02a784a2"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/llm_router.py",
+                    "test/api/test_agent_supervisor_native_dependency_pin.py",
+                ),
+            },
+        ),
+    },
+    "ASE3-032": {
+        "ready": True,
+        "pending": None,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (
+            {
+                "role": "duckdb-connection-policy",
+                "source_commit": "9f1a3cb3c583924878293f9acd676a211106c2e7",
+                "source_parent": "25fedf091dad928dad1f83c9f81a54c2d401eabe",
+                "source_tree": "853191d0e00471bf41452801ae83b0a13b3607d5",
+                "replay_commit": "d57a5b47f1ce107b3357839bfd1e0b7120048785",
+                "replay_parent": "25fedf091dad928dad1f83c9f81a54c2d401eabe",
+                "replay_tree": "853191d0e00471bf41452801ae83b0a13b3607d5",
+                "integrated_commit": "8f613252c2ff1460e6f2b551a2a8600a2d3ee519",
+                "integrated_parent": "1a419e525699e74254a450c0137264d8dd60ea00",
+                "integrated_tree": "f7160446af32a9affeef554d319c443b6449271a",
+                "source_patch_sha256": (
+                    "sha256:b93ffbe2a20ffbc62287e1f21f291a34a2ea84d5cecde5eee4f07677c128b0fb"
+                ),
+                "replay_patch_sha256": (
+                    "sha256:b93ffbe2a20ffbc62287e1f21f291a34a2ea84d5cecde5eee4f07677c128b0fb"
+                ),
+                "integrated_patch_sha256": (
+                    "sha256:b93ffbe2a20ffbc62287e1f21f291a34a2ea84d5cecde5eee4f07677c128b0fb"
+                ),
+                "changed_paths": (
+                    "ipfs_accelerate_py/agent_supervisor/merge/lease_coordination.py",
+                    "ipfs_accelerate_py/agent_supervisor/task_sources/duckdb_state.py",
+                    "ipfs_accelerate_py/agent_supervisor/task_sources/duckdb_task_source.py",
+                    "test/api/test_agent_supervisor_duckdb_connection_policy.py",
+                ),
+            },
+        ),
+    },
+    "ASE3-019": {
+        "ready": False,
+        "pending": _FINAL_VALUE_PENDING_019,
+        "schema": (
+            "ipfs_accelerate_py.agent_supervisor."
+            "prompt-v3-product-generation@1"
+        ),
+        "generations": (),
+    },
+}
+
 _RELOAD_FINAL_VALUES: Final = {
     "ready": False,
     "pending": _FINAL_VALUE_PENDING_RELOAD,

--- a/test/api/test_agent_supervisor_prompt_v3_convergence.py
+++ b/test/api/test_agent_supervisor_prompt_v3_convergence.py
@@ -3317,6 +3317,77 @@ def test_ase3_023_final_blob_tamper_fails_closed_after_freeze() -> None:
     assert any("final_blobs" in error for error in errors)
 
 
+
+def test_product_generation_v1_triples_are_sealed_for_pre_q_products() -> None:
+    values = convergence_module._PRODUCT_GENERATION_FINAL_VALUES
+    assert values["ASE3-019"]["ready"] is False
+    for task_id, expected_count in (
+        ("ASE3-023", 3),
+        ("ASE3-027", 2),
+        ("ASE3-030", 2),
+        ("ASE3-031", 1),
+        ("ASE3-032", 1),
+    ):
+        final = values[task_id]
+        assert final["ready"] is True
+        assert final["pending"] is None
+        assert final["schema"].endswith("prompt-v3-product-generation@1")
+        assert len(final["generations"]) == expected_count
+        for generation in final["generations"]:
+            assert generation["source_commit"] != generation["replay_commit"]
+            assert (
+                generation["source_patch_sha256"]
+                == generation["replay_patch_sha256"]
+                == generation["integrated_patch_sha256"]
+            )
+            # Source/replay remain non-ancestors; integrated is on main.
+            assert (
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(REPO_ROOT),
+                        "merge-base",
+                        "--is-ancestor",
+                        generation["source_commit"],
+                        "HEAD",
+                    ],
+                    check=False,
+                ).returncode
+                != 0
+            )
+            assert (
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(REPO_ROOT),
+                        "merge-base",
+                        "--is-ancestor",
+                        generation["replay_commit"],
+                        "HEAD",
+                    ],
+                    check=False,
+                ).returncode
+                != 0
+            )
+            assert (
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(REPO_ROOT),
+                        "merge-base",
+                        "--is-ancestor",
+                        generation["integrated_commit"],
+                        "HEAD",
+                    ],
+                    check=False,
+                ).returncode
+                == 0
+            )
+
+
 def test_ase3_019_source_and_salvage_freeze_is_sealed() -> None:
     final_values = convergence_module._ACCEPTANCE_IMPLEMENTATION_FINAL_VALUES[
         "ASE3-019"

--- a/test/api/test_agent_supervisor_prompt_v3_transition.py
+++ b/test/api/test_agent_supervisor_prompt_v3_transition.py
@@ -929,6 +929,7 @@ def test_q_construction_readiness_reports_tooling_and_blockers() -> None:
     assert ase3027["generations"][1]["ok"] is True
     assert ase3027["final_blob_count"] == 5
     assert ase3027["blob_errors"] == []
+    assert ase3027["product_generation_v1_ready"] is True
     # ASE3-023 three hermetic generations and final P-tree blobs are sealed.
     ase3023 = products["ASE3-023"]
     assert ase3023["sealed_ready_flag"] is True
@@ -936,17 +937,26 @@ def test_q_construction_readiness_reports_tooling_and_blockers() -> None:
     assert all(generation["ok"] is True for generation in ase3023["generations"])
     assert ase3023["final_blob_count"] == 7
     assert ase3023["blob_errors"] == []
-    # Still blocked for Q: product-generation@1 needs independent replay role.
+    assert ase3023["product_generation_v1_ready"] is True
+    # Product-generation@1 triples are sealed for 023/027/030/031/032.
+    for task_id in ("ASE3-023", "ASE3-027", "ASE3-030", "ASE3-031", "ASE3-032"):
+        assert products[task_id]["product_generation_v1_ready"] is True, task_id
+    # Still blocked for Q: 019 product-generation@1 and 030/031/032 acceptance.
     assert products["ASE3-019"]["sealed_ready_flag"] is True
     # 019 still lacks product-generation@1 triples (empty generations list).
     assert products["ASE3-019"]["generation_count"] == 0
+    assert products["ASE3-019"]["product_generation_v1_ready"] is False
     assert any("ASE3-019" in item for item in report["blockers"])
     assert any(
-        "ASE3-027" in item and "product-generation@1" in item
+        "ASE3-030" in item and "final values not ready" in item
         for item in report["blockers"]
     )
-    assert any(
+    assert not any(
         "ASE3-023" in item and "product-generation@1" in item
+        for item in report["blockers"]
+    )
+    assert not any(
+        "ASE3-027" in item and "product-generation@1" in item
         for item in report["blockers"]
     )
 


### PR DESCRIPTION
## Summary
- Seal `prompt-v3-product-generation@1` source/clean-replay/integrated triples for ASE3-023 (×3), ASE3-027 (×2), ASE3-030 (×2), ASE3-031, and ASE3-032.
- Create independent clean-replay commits (same tree/parent as source, distinct commit object) and publish them under `ase3/preq-product-generation-objects` plus salvage/repair refs.
- Readiness verifies product-generation triples and clears that blocker for sealed products.

## Verified
- Each triple: source/replay non-ancestors of HEAD, integrated ancestor, identical full-index binary patches, independent source≠replay.
- Targeted pytest: product-generation freeze + 023/027 freezes + Q readiness.

## Still blocked for prepare-q (5)
1. ASE3-019 acceptance generations / product-generation@1
2–3. ASE3-030 hermetic acceptance closure/suite pins
4–5. ASE3-031/032 signed suite acceptance evidence

ASE3-023 and ASE3-027 are now **product-generation ready** (acceptance + @1).