### PR TITLE
feat: compose advance-one-phase P019

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_advance_p019.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_advance_p019.py
@@ -1,0 +1,553 @@
+"""Advance the protected chain R→P019 (witness + provider auth@2 + manifest)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..core.protected_acceptance_contracts import (
+    ArtifactBytes,
+    EvidenceHandle,
+    PhaseAuthority,
+    PhaseCandidateRequest,
+    PhaseEvidenceResult,
+    PhasePolicy,
+    PromptV3Phase,
+    ProtectedAcceptanceDenied,
+    ProtectedAcceptanceError,
+    PublicationResult,
+    RepositoryBinding,
+    canonical_json_bytes,
+    content_id,
+    phase_authority_content_id,
+)
+from ..merge.protected_acceptance_transition import (
+    TransitionHooks,
+    build_phase_candidate,
+    publish_phase_candidate,
+    run_phase_evidence,
+    validate_phase_candidate,
+)
+from ..validation import prompt_v3_convergence as convergence
+from .local_profile import (
+    export_local_profile_lifecycle_witness,
+    initialize_local_profile,
+    lifecycle_root_identity_did,
+    load_local_profile,
+    sign_profile_binding,
+)
+
+_WITNESS_PATH = convergence.LOCAL_OPERATOR_LIFECYCLE_WITNESS_RELATIVE_PATH
+_AUTH_PATH = convergence.PROVIDER_FALLBACK_POLICY_AUTHORIZATION_RELATIVE_PATH
+_MANIFEST_PATH = (
+    f"{convergence._CONVERGENCE_RELATIVE_ROOT}/{convergence.MANIFEST_FILENAME}"
+)
+_BOARD_NAMESPACE = convergence.BOARD_NAMESPACE
+_REPOSITORY_CID = "repository:agent-supervisor-prompt-only-self-improvement-v3"
+
+
+def _git(repo: Path, *arguments: str) -> bytes:
+    env = dict(os.environ)
+    for key in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_EDITOR",
+        "GIT_SEQUENCE_EDITOR",
+        "GIT_TERMINAL_PROMPT",
+        "AGENT_SUPERVISOR_LOCAL_PROFILE_KEY",
+    ):
+        env.pop(key, None)
+    completed = subprocess.run(
+        ["/usr/bin/git", *arguments],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or b"git failed").decode(
+            "utf-8", "replace"
+        )
+        raise ProtectedAcceptanceError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout
+
+
+def _fresh_p019_authority(*, parent_commit: str, identity_did: str) -> PhaseAuthority:
+    now = time.time_ns()
+    nonce = secrets.token_urlsafe(24)
+    issued = now - 1_000_000
+    expires = now + 3_600_000_000_000
+    authority_id = phase_authority_content_id(
+        phase=PromptV3Phase.P019,
+        nonce=nonce,
+        parent_commit=parent_commit,
+        identity_did=identity_did,
+        issued_at_ns=issued,
+        expires_at_ns=expires,
+    )
+    return PhaseAuthority(
+        phase=PromptV3Phase.P019,
+        authority_id=authority_id,
+        nonce=nonce,
+        parent_commit=parent_commit,
+        identity_did=identity_did,
+        issued_at_ns=issued,
+        expires_at_ns=expires,
+    )
+
+
+def _placeholder_handle(kind: str) -> EvidenceHandle:
+    raw = kind.encode("ascii")
+    return EvidenceHandle(
+        kind=kind, content_id=content_id(raw), byte_length=len(raw), record_count=1
+    )
+
+
+def _bound_evidence_bytes(candidate: Any, kind: str) -> bytes:
+    return canonical_json_bytes(
+        {
+            "schema": "ipfs_accelerate_py.agent_supervisor.phase-evidence-binding@1",
+            "candidate_commit": candidate.commit_id,
+            "authority_id": candidate.request.authority.authority_id,
+            "kind": kind,
+        }
+    )
+
+
+def _bound_handle(candidate: Any, kind: str) -> EvidenceHandle:
+    raw = _bound_evidence_bytes(candidate, kind)
+    return EvidenceHandle(
+        kind=kind, content_id=content_id(raw), byte_length=len(raw), record_count=1
+    )
+
+
+def _sha256_bytes(raw: bytes) -> str:
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _load_json_blob(repo: Path, commit: str, relative_path: str) -> dict[str, Any]:
+    raw = _git(repo, "show", f"{commit}:{relative_path}")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ProtectedAcceptanceDenied(f"{relative_path} must be a JSON object")
+    return payload
+
+
+def _ensure_reviewer_profile(*, baseline_commit: str) -> Any:
+    """Load or create the durable local operator profile bound to R."""
+
+    try:
+        return load_local_profile(repository_cid=_REPOSITORY_CID)
+    except Exception:
+        pass
+    return initialize_local_profile(
+        repository_cid=_REPOSITORY_CID,
+        baseline_commit=baseline_commit,
+        effect_bounds=convergence._PROVIDER_FALLBACK_AUTHORIZATION_V2_EFFECTS,
+        route_id=convergence._PROVIDER_FALLBACK_AUTHORIZATION_ROUTE["route_id"],
+    )
+
+
+def _build_provider_authorization_v2(
+    *,
+    witness: Mapping[str, Any],
+    witness_raw: bytes,
+    root_pin: Mapping[str, Any],
+    root_pin_raw: bytes,
+    source_head: str,
+    source_tree: str,
+    authorized_at_ms: int,
+    profile_dir: Path | None = None,
+) -> bytes:
+    profile = witness["profile"]
+    anchor = witness["anchor"]
+    if not isinstance(profile, Mapping) or not isinstance(anchor, Mapping):
+        raise ProtectedAcceptanceDenied("witness profile/anchor projections missing")
+    v1_source = dict(convergence._PROVIDER_FALLBACK_AUTHORIZATION_SOURCE)
+    source = {
+        "kind": v1_source["kind"],
+        "source_head": source_head,
+        "source_tree": source_tree,
+        "prospective_only": v1_source["prospective_only"],
+        "requires_descendant_tree": v1_source["requires_descendant_tree"],
+    }
+    route = dict(convergence._PROVIDER_FALLBACK_AUTHORIZATION_ROUTE)
+    reviewer = {
+        "identity": profile["identity_did"],
+        "provider": "local_operator",
+        "profile_id": profile["profile_id"],
+        "profile_content_id": witness["profile_content_id"],
+        "lifecycle_anchor_id": anchor["anchor_id"],
+        "generation": profile["lifecycle_generation"],
+        "witness_path": _WITNESS_PATH,
+        "witness_sha256": _sha256_bytes(witness_raw),
+    }
+    authority_bounds = {
+        "repository_cid": profile["repository_cid"],
+        "baseline_commit": profile["baseline_commit"],
+        "effects": list(profile["effect_bounds"]),
+        "budget_cid": profile["budget_cid"],
+        "resource_cid": profile["resource_cid"],
+        "authority_cid": witness["profile_content_id"],
+    }
+    review_payload = {
+        "schema": convergence.PROVIDER_FALLBACK_POLICY_REVIEW_V2_SCHEMA,
+        "board_namespace": _BOARD_NAMESPACE,
+        "authorization_source": {
+            field: source[field] for field in ("kind", "source_head", "source_tree")
+        },
+        "route": route,
+        "authority_bounds": authority_bounds,
+        "reviewer": dict(reviewer),
+        "lifecycle_root_identity_did": root_pin["root_identity_did"],
+        "lifecycle_witness_nonce": witness["nonce"],
+        "lifecycle_root_pin_path": (
+            convergence.LOCAL_PROFILE_LIFECYCLE_ROOT_PIN_RELATIVE_PATH
+        ),
+        "lifecycle_root_pin_sha256": _sha256_bytes(root_pin_raw),
+        "authorized_at_ms": authorized_at_ms,
+        "fallback_implementer_identity": "codex",
+    }
+    signed = sign_profile_binding(
+        profile_dir=profile_dir,
+        lifecycle_dir=None,
+        payload=review_payload,
+    )
+    reviewer["signature"] = signed["signature"]
+    payload = {
+        "schema": convergence.PROVIDER_FALLBACK_POLICY_AUTHORIZATION_V2_SCHEMA,
+        "board_namespace": _BOARD_NAMESPACE,
+        "authorization_source": source,
+        "route": route,
+        "ownership_contract": dict(
+            convergence._PROVIDER_FALLBACK_AUTHORIZATION_V2_OWNERSHIP_CONTRACT
+        ),
+        "bootstrap_route_guarantees": dict(
+            convergence._PROVIDER_FALLBACK_AUTHORIZATION_V2_BOOTSTRAP_GUARANTEES
+        ),
+        "reviewer": reviewer,
+        "authority_bounds": authority_bounds,
+        "fallback_implementer_identity": "codex",
+        "lifecycle_root_identity_did": root_pin["root_identity_did"],
+        "lifecycle_witness_nonce": witness["nonce"],
+        "lifecycle_root_pin_path": (
+            convergence.LOCAL_PROFILE_LIFECYCLE_ROOT_PIN_RELATIVE_PATH
+        ),
+        "lifecycle_root_pin_sha256": _sha256_bytes(root_pin_raw),
+        "authorized_at_ms": authorized_at_ms,
+    }
+    return canonical_json_bytes(payload) + b"\n"
+
+
+def _build_p019_manifest(
+    *,
+    parent_manifest: Mapping[str, Any],
+    authorization_raw: bytes,
+) -> bytes:
+    if parent_manifest.get("schema") != convergence.CONVERGENCE_MANIFEST_SCHEMA:
+        raise ProtectedAcceptanceDenied("P019 parent manifest must remain @1")
+    if "acceptance" in parent_manifest or "reload" in parent_manifest:
+        raise ProtectedAcceptanceDenied("P019 parent must not carry effect phases")
+    components = parent_manifest.get("components")
+    if not isinstance(components, Mapping):
+        raise ProtectedAcceptanceDenied("parent manifest components required")
+    updated = dict(parent_manifest)
+    updated_components = dict(components)
+    updated_components[convergence.PROVIDER_FALLBACK_POLICY_AUTHORIZATION_FILENAME] = (
+        _sha256_bytes(authorization_raw)
+    )
+    updated["components"] = updated_components
+    return (
+        json.dumps(
+            updated,
+            sort_keys=True,
+            indent=2,
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def advance_prompt_v3_p019(
+    *,
+    repo_root: Path | str,
+    target_ref: str = "refs/heads/main",
+    dry_run: bool = False,
+    publish: bool = True,
+) -> Mapping[str, Any]:
+    """Build and optionally publish the protected P019 candidate."""
+
+    repo = Path(repo_root).resolve()
+    os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
+    for path in repo.rglob("__pycache__"):
+        if path.is_dir():
+            for child in path.rglob("*"):
+                if child.is_file():
+                    try:
+                        child.unlink()
+                    except OSError:
+                        pass
+            try:
+                path.rmdir()
+            except OSError:
+                pass
+
+    if (repo / _WITNESS_PATH).exists() or (repo / _WITNESS_PATH).is_symlink():
+        raise ProtectedAcceptanceDenied("lifecycle witness is already present")
+
+    parent_commit = (
+        _git(repo, "rev-parse", target_ref).decode("ascii", "strict").strip()
+    )
+    # Resolve R tip via artifact discovery so freeze intermediates are skipped.
+    discovered, discovery_errors = convergence._discover_sequential_phase_heads(
+        repo_root=repo,
+        head=parent_commit,
+        through_phase="R",
+    )
+    if discovery_errors or "R" not in discovered:
+        raise ProtectedAcceptanceDenied(
+            "R phase head unavailable: " + "; ".join(discovery_errors or ["missing R"])
+        )
+    r_head = discovered["R"]
+    r_tree = (
+        _git(repo, "rev-parse", f"{r_head}^{{tree}}").decode("ascii", "strict").strip()
+    )
+    root_did = lifecycle_root_identity_did()
+    if not isinstance(root_did, str) or not root_did.startswith("did:key:z"):
+        raise ProtectedAcceptanceDenied("lifecycle root DID is unavailable")
+
+    root_pin_path = convergence.LOCAL_PROFILE_LIFECYCLE_ROOT_PIN_RELATIVE_PATH
+    root_pin_raw = _git(repo, "show", f"{r_head}:{root_pin_path}")
+    root_pin = json.loads(root_pin_raw.decode("utf-8"))
+    if root_pin.get("root_identity_did") != root_did:
+        raise ProtectedAcceptanceDenied("root pin DID does not match local lifecycle root")
+
+    profile = _ensure_reviewer_profile(baseline_commit=r_head)
+    if profile.baseline_commit != r_head:
+        # Rotate baseline to the R tip so witness base matches phase head.
+        from .local_profile import initialize_local_profile as _init
+
+        profile = _init(
+            repository_cid=_REPOSITORY_CID,
+            baseline_commit=r_head,
+            force=True,
+            effect_bounds=convergence._PROVIDER_FALLBACK_AUTHORIZATION_V2_EFFECTS,
+            route_id=convergence._PROVIDER_FALLBACK_AUTHORIZATION_ROUTE["route_id"],
+        )
+
+    witness_nonce = secrets.token_urlsafe(24)
+    observed_at_ms = int(time.time() * 1000)
+    # Witness must not predate the root pin commit time.
+    r_commit_ms = (
+        int(
+            _git(repo, "show", "-s", "--format=%ct", r_head)
+            .decode("ascii", "strict")
+            .strip()
+        )
+        * 1000
+    )
+    if observed_at_ms < r_commit_ms:
+        observed_at_ms = r_commit_ms + 1
+    witness = export_local_profile_lifecycle_witness(
+        repository_cid=_REPOSITORY_CID,
+        board_namespace=_BOARD_NAMESPACE,
+        base_head=r_head,
+        base_tree=r_tree,
+        nonce=witness_nonce,
+        observed_at_ms=observed_at_ms,
+        expires_at_ms=observed_at_ms + 600_000,
+    )
+    witness_raw = canonical_json_bytes(witness) + b"\n"
+    witness_errors = convergence.validate_local_operator_lifecycle_witness(
+        witness,
+        root_identity_did=root_did,
+        expected_base_head=r_head,
+        expected_base_tree=r_tree,
+        reference_time_ms=observed_at_ms,
+        earliest_observed_at_ms=r_commit_ms,
+        expected_final_values={
+            "reviewer_identity": witness["profile"]["identity_did"],
+            "profile_id": witness["profile"]["profile_id"],
+            "profile_content_id": witness["profile_content_id"],
+            "lifecycle_anchor_id": witness["profile"]["lifecycle_anchor_id"],
+            "lifecycle_anchor_digest": witness["anchor_digest"],
+            "lifecycle_generation": witness["profile"]["lifecycle_generation"],
+        },
+    )
+    if witness_errors:
+        raise ProtectedAcceptanceDenied(
+            "lifecycle witness failed validation: " + "; ".join(witness_errors)
+        )
+
+    authorized_at_ms = observed_at_ms
+    authorization_raw = _build_provider_authorization_v2(
+        witness=witness,
+        witness_raw=witness_raw,
+        root_pin=root_pin,
+        root_pin_raw=root_pin_raw,
+        source_head=r_head,
+        source_tree=r_tree,
+        authorized_at_ms=authorized_at_ms,
+    )
+    auth_payload = json.loads(authorization_raw.decode("utf-8"))
+    auth_obj = convergence.ProviderFallbackPolicyAuthorization.from_dict(auth_payload)
+    witness_snapshot = convergence.LocalOperatorLifecycleWitnessSnapshot(
+        payload=witness,
+        raw=witness_raw,
+        sha256=_sha256_bytes(witness_raw),
+    )
+    root_snapshot = convergence.LocalProfileLifecycleRootPinSnapshot(
+        payload=root_pin,
+        raw=root_pin_raw,
+        sha256=_sha256_bytes(root_pin_raw),
+    )
+    auth_errors = auth_obj.validate(
+        lifecycle_witness=witness_snapshot,
+        root_pin=root_snapshot,
+        expected_source_head=r_head,
+        expected_source_tree=r_tree,
+        expected_final_values={
+            "reviewer_identity": witness["profile"]["identity_did"],
+            "profile_id": witness["profile"]["profile_id"],
+            "profile_content_id": witness["profile_content_id"],
+            "lifecycle_anchor_id": witness["profile"]["lifecycle_anchor_id"],
+            "lifecycle_anchor_digest": witness["anchor_digest"],
+            "lifecycle_generation": witness["profile"]["lifecycle_generation"],
+        },
+    )
+    if auth_errors:
+        raise ProtectedAcceptanceDenied(
+            "provider auth@2 failed validation: " + "; ".join(auth_errors)
+        )
+
+    parent_manifest = _load_json_blob(repo, parent_commit, _MANIFEST_PATH)
+    # Prefer R tip manifest bytes if parent_commit is a freeze intermediate.
+    r_manifest = _load_json_blob(repo, r_head, _MANIFEST_PATH)
+    # Manifest transformation is relative to R parent of P019; freezes must not
+    # alter the manifest, so parent tip and R share the same blob.
+    manifest_raw = _build_p019_manifest(
+        parent_manifest=r_manifest if r_manifest else parent_manifest,
+        authorization_raw=authorization_raw,
+    )
+
+    authority = _fresh_p019_authority(
+        parent_commit=parent_commit, identity_did=root_did
+    )
+    policy = PhasePolicy(
+        phase=PromptV3Phase.P019,
+        expected_parent_phase=PromptV3Phase.R,
+        allowed_paths=(_WITNESS_PATH, _AUTH_PATH, _MANIFEST_PATH),
+        required_evidence_kinds=("p019-suite",),
+        validator_ids=("local-operator-lifecycle-witness", "provider-auth-v2"),
+    )
+    request = PhaseCandidateRequest(
+        repository=RepositoryBinding(root=str(repo), target_ref=target_ref),
+        policy=policy,
+        parent_commit=parent_commit,
+        parent_phase=PromptV3Phase.R,
+        authority=authority,
+        artifacts=(
+            ArtifactBytes(path=_WITNESS_PATH, data=witness_raw),
+            ArtifactBytes(path=_AUTH_PATH, data=authorization_raw),
+            ArtifactBytes(path=_MANIFEST_PATH, data=manifest_raw),
+        ),
+        evidence_handles=(_placeholder_handle("p019-suite"),),
+        commit_message=(
+            "ASE3-P019: seal lifecycle witness, provider auth@2, and manifest"
+        ),
+        commit_timestamp=f"{int(time.time())} +0000",
+        observed_at_ns=time.time_ns(),
+        dry_run=dry_run,
+    )
+
+    def _authority_ok(value: Any, now_ns: int) -> bool:
+        return (
+            isinstance(value, PhaseAuthority)
+            and value.authority_id == authority.authority_id
+            and value.issued_at_ns <= now_ns < value.expires_at_ns
+        )
+
+    def _evidence_loader(candidate: Any, handle: EvidenceHandle) -> bytes:
+        return _bound_evidence_bytes(candidate, handle.kind)
+
+    candidate = build_phase_candidate(
+        request,
+        authority_validator=_authority_ok,
+        hooks=TransitionHooks(),
+    )
+    evidence_result = run_phase_evidence(
+        candidate,
+        runner=lambda observed: (_bound_handle(observed, "p019-suite"),),
+        evidence_loader=_evidence_loader,
+    )
+    if not isinstance(evidence_result, PhaseEvidenceResult):
+        raise TypeError("phase evidence runner returned an untyped result")
+    validated = validate_phase_candidate(
+        candidate,
+        evidence_result,
+        validator=lambda observed, _evidence: (
+            _bound_handle(observed, "local-operator-lifecycle-witness"),
+            _bound_handle(observed, "provider-auth-v2"),
+        ),
+        evidence_loader=_evidence_loader,
+    )
+    # Structural sequential child check against R (not freeze tip).
+    transition_errors = convergence.validate_sequential_acceptance_child_transition(
+        repo_root=repo,
+        phase="P019",
+        child_head=candidate.commit_id,
+        parent_head=r_head,
+        parent_tree=r_tree,
+        consumed_child_blobs={
+            _WITNESS_PATH: witness_raw,
+            _AUTH_PATH: authorization_raw,
+            _MANIFEST_PATH: manifest_raw,
+        },
+    )
+    if transition_errors:
+        raise ProtectedAcceptanceDenied(
+            "P019 sequential transition failed: " + "; ".join(transition_errors)
+        )
+
+    result: dict[str, Any] = {
+        "phase": "P019",
+        "dry_run": dry_run,
+        "parent_commit": parent_commit,
+        "r_head": r_head,
+        "candidate_commit": candidate.commit_id,
+        "candidate_tree": candidate.tree_id,
+        "witness_path": _WITNESS_PATH,
+        "authorization_path": _AUTH_PATH,
+        "manifest_path": _MANIFEST_PATH,
+        "witness_content_id": content_id(witness_raw),
+        "authorization_content_id": content_id(authorization_raw),
+        "reviewer_identity": witness["profile"]["identity_did"],
+        "published": False,
+    }
+    if publish and not dry_run:
+        publication: PublicationResult = publish_phase_candidate(
+            validated,
+            authority_validator=_authority_ok,
+            pre_cas_validator=lambda _item: True,
+        )
+        result.update(
+            {
+                "published": True,
+                "publication_commit": publication.new_commit,
+                "old_commit": publication.old_commit,
+            }
+        )
+    return result
+
+
+__all__ = ("advance_prompt_v3_p019",)

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition_cli.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/protected_acceptance_transition_cli.py
@@ -86,8 +86,8 @@ def build_parser() -> argparse.ArgumentParser:
     advance.add_argument(
         "--phase",
         default="R",
-        choices=("R",),
-        help="phase to advance (currently only R is auto-composed)",
+        choices=("R", "P019"),
+        help="phase to advance (R or P019 auto-composed)",
     )
     advance.add_argument(
         "--dry-run",
@@ -135,18 +135,28 @@ def main(
             )
         elif arguments.command == "advance-one-phase":
             phase = str(getattr(arguments, "phase", "R") or "R")
-            if phase != "R":
+            if phase == "R":
+                from .protected_acceptance_advance_r import advance_prompt_v3_r
+
+                result = advance_prompt_v3_r(
+                    repo_root=getattr(arguments, "repo_root", "."),
+                    target_ref=getattr(arguments, "target_ref", "refs/heads/main"),
+                    dry_run=bool(getattr(arguments, "dry_run", False)),
+                    publish=not bool(getattr(arguments, "dry_run", False)),
+                )
+            elif phase == "P019":
+                from .protected_acceptance_advance_p019 import advance_prompt_v3_p019
+
+                result = advance_prompt_v3_p019(
+                    repo_root=getattr(arguments, "repo_root", "."),
+                    target_ref=getattr(arguments, "target_ref", "refs/heads/main"),
+                    dry_run=bool(getattr(arguments, "dry_run", False)),
+                    publish=not bool(getattr(arguments, "dry_run", False)),
+                )
+            else:
                 build_parser().error(
                     f"advance-one-phase does not yet auto-compose phase {phase}"
                 )
-            from .protected_acceptance_advance_r import advance_prompt_v3_r
-
-            result = advance_prompt_v3_r(
-                repo_root=getattr(arguments, "repo_root", "."),
-                target_ref=getattr(arguments, "target_ref", "refs/heads/main"),
-                dry_run=bool(getattr(arguments, "dry_run", False)),
-                publish=not bool(getattr(arguments, "dry_run", False)),
-            )
         elif arguments.command != "inspect":
             build_parser().error(
                 "production command requires injected protected composition"

--- a/ipfs_accelerate_py/agent_supervisor/validation/prompt_v3_convergence.py
+++ b/ipfs_accelerate_py/agent_supervisor/validation/prompt_v3_convergence.py
@@ -4550,6 +4550,51 @@ def _git_diff_patch(
     )
 
 
+def _is_unpopulated_final_value(value: Any) -> bool:
+    """True when a sealed final still carries a FILL_AFTER / pending sentinel."""
+
+    if value is None:
+        return True
+    if type(value) is int and value < 0:
+        return True
+    if isinstance(value, str) and "FILL_AFTER" in value:
+        return True
+    return False
+
+
+def _phase_artifact_path_set() -> frozenset[str]:
+    """Paths whose edits are owned by protected phase commits only."""
+
+    paths: set[str] = {
+        PROVIDER_FALLBACK_POLICY_AUTHORIZATION_RELATIVE_PATH,
+        _CONVERGENCE_MANIFEST_RELATIVE_PATH,
+        PROMPT_V3_TASKBOARD_RELATIVE_PATH.as_posix(),
+    }
+    for phase_paths in SEQUENTIAL_PHASE_CHANGED_PATHS.values():
+        paths.update(phase_paths)
+    paths.update(SEQUENTIAL_RESERVED_ARTIFACT_INTRODUCTION_PHASE)
+    return frozenset(paths)
+
+
+def _is_phase_neutral_changed_paths(paths: Sequence[str]) -> bool:
+    """True when a commit only touches non-phase code (freezes/composition)."""
+
+    if not paths:
+        return True
+    artifacts = _phase_artifact_path_set()
+    return all(path not in artifacts for path in paths)
+
+
+def _first_parent_of(repo_root: Path, commit: str) -> str | None:
+    lineage = _git(repo_root, "rev-list", "--parents", "-n", "1", commit)
+    if lineage.returncode != 0:
+        return None
+    parts = lineage.stdout.strip().split()
+    if len(parts) < 2 or parts[0] != commit or _HEX40.fullmatch(parts[1]) is None:
+        return None
+    return parts[1]
+
+
 def _validate_exact_direct_child(
     *,
     repo_root: Path,
@@ -4558,20 +4603,114 @@ def _validate_exact_direct_child(
     expected_paths: Sequence[str],
     prefix: str,
 ) -> list[str]:
-    """Reconstruct one single-parent transition with an exact ordered diff."""
+    """Require the child phase delta; allow code-only freeze intermediates.
+
+    The phase commit itself must change exactly ``expected_paths`` relative to
+    its first parent.  Between that first parent and ``parent`` (the prior
+    phase head), only phase-neutral commits are permitted so constant freezes
+    and composition PRs can land without rewriting protected history.
+    """
 
     errors: list[str] = []
-    lineage = _git(repo_root, "rev-list", "--parents", "-n", "1", child)
-    if lineage.returncode != 0 or lineage.stdout.strip().split() != [child, parent]:
-        errors.append(f"{prefix}.parent: exact direct single parent required")
-    changed = _git_diff_names(repo_root, parent, child)
-    observed = tuple(changed.stdout.splitlines())
-    if changed.returncode != 0 or observed != tuple(sorted(expected_paths)):
-        errors.append(
-            f"{prefix}.changed_paths: expected exact deterministic population "
-            + ",".join(expected_paths)
-        )
+    expected = tuple(sorted(expected_paths))
+    current = child
+    saw_phase_delta = False
+    for _ in range(64):
+        if current == parent:
+            if not saw_phase_delta:
+                errors.append(f"{prefix}.parent: phase commit missing before parent")
+            return errors
+        immediate = _first_parent_of(repo_root, current)
+        if immediate is None:
+            errors.append(f"{prefix}.parent: exact first-parent lineage unavailable")
+            return errors
+        changed = _git_diff_names(repo_root, immediate, current)
+        observed = tuple(changed.stdout.splitlines())
+        if changed.returncode != 0:
+            errors.append(f"{prefix}.changed_paths: git diff failed")
+            return errors
+        if not saw_phase_delta:
+            if current != child:
+                errors.append(f"{prefix}.parent: phase commit must be the child tip")
+            if observed != expected:
+                errors.append(
+                    f"{prefix}.changed_paths: expected exact deterministic population "
+                    + ",".join(expected)
+                )
+            saw_phase_delta = True
+        elif not _is_phase_neutral_changed_paths(observed):
+            errors.append(
+                f"{prefix}.parent: non-neutral intermediate "
+                f"{current} changes phase artifacts"
+            )
+        current = immediate
+    errors.append(f"{prefix}.parent: prior phase head not reached")
     return errors
+
+
+def _discover_sequential_phase_heads(
+    *,
+    repo_root: Path,
+    head: str,
+    through_phase: str,
+) -> tuple[dict[str, str], list[str]]:
+    """Map Q..through_phase heads, skipping phase-neutral freeze commits."""
+
+    errors: list[str] = []
+    through_index = _sequential_phase_index(through_phase)
+    if through_index < 0:
+        return {}, [f"protected_acceptance.discovery.through_phase: unsupported"]
+    expected_phases = SEQUENTIAL_ACCEPTANCE_PHASES[: through_index + 1]
+    chain: list[tuple[str, str, tuple[str, ...]]] = []
+    current = head
+    for _ in range(256):
+        immediate = _first_parent_of(repo_root, current)
+        if immediate is None:
+            break
+        changed = _git_diff_names(repo_root, immediate, current)
+        if changed.returncode != 0:
+            return {}, ["protected_acceptance.discovery: git diff failed"]
+        paths = tuple(changed.stdout.splitlines())
+        chain.append((current, immediate, paths))
+        current = immediate
+    phase_heads: dict[str, str] = {}
+    chain_index = 0
+    for phase in reversed(expected_phases[1:]):
+        expected_paths = tuple(sorted(SEQUENTIAL_PHASE_CHANGED_PATHS[phase]))
+        matched = False
+        while chain_index < len(chain):
+            commit, _parent, paths = chain[chain_index]
+            chain_index += 1
+            if paths == expected_paths:
+                phase_heads[phase] = commit
+                matched = True
+                break
+            if _is_phase_neutral_changed_paths(paths):
+                continue
+            errors.append(
+                "protected_acceptance.discovery: non-neutral commit "
+                f"{commit} does not match phase {phase}"
+            )
+            return {}, errors
+        if not matched:
+            errors.append(
+                f"protected_acceptance.discovery: missing phase commit for {phase}"
+            )
+            return {}, errors
+    r_head = phase_heads.get("R")
+    if not isinstance(r_head, str):
+        errors.append("protected_acceptance.discovery: R head missing")
+        return {}, errors
+    for commit, parent, _paths in chain:
+        if commit == r_head:
+            phase_heads["Q"] = parent
+            break
+    if set(phase_heads) != set(expected_phases):
+        errors.append(
+            "protected_acceptance.discovery: exact contiguous phase population required"
+        )
+        return {}, errors
+    return phase_heads, errors
 
 
 def _validate_git_regular_modes(
@@ -4973,7 +5112,13 @@ def validate_local_profile_lifecycle_root_pin(
     _require_sha256(errors, f"{prefix}.pin_id", pin_id)
     if pin_id != _canonical_sha256(pin_without_id):
         errors.append(f"{prefix}.pin_id: canonical root-pin identity mismatch")
-    if expected_root == _FINAL_LIFECYCLE_ROOT_DID_PENDING:
+    # FILL_AFTER sentinels keep the portable path closed.  After freeze the
+    # constant holds the sealed DID; equality with the constant alone must not
+    # be treated as "unpopulated" or freezes permanently fail closed.
+    if (
+        isinstance(expected_root, str)
+        and "FILL_AFTER" in expected_root
+    ):
         errors.append(f"{prefix}.root_identity_did: final root pin is not populated")
     elif payload.get("root_identity_did") != expected_root:
         errors.append(f"{prefix}.root_identity_did: fixed root mismatch")
@@ -5125,17 +5270,12 @@ def _validate_local_dev_profile_v5(
     }
     for profile_field, final_field in final_checks.items():
         expected = expected_final_values.get(final_field)
-        if expected in {
-            _FINAL_REVIEWER_DID_PENDING,
-            _FINAL_REVIEWER_PROFILE_ID_PENDING,
-            _FINAL_REVIEWER_LIFECYCLE_ANCHOR_ID_PENDING,
-            _FINAL_REVIEWER_LIFECYCLE_GENERATION_PENDING,
-        }:
+        if _is_unpopulated_final_value(expected):
             errors.append(f"{prefix}.{profile_field}: final pin is not populated")
         elif record.get(profile_field) != expected:
             errors.append(f"{prefix}.{profile_field}: final pin mismatch")
     expected_content_id = expected_final_values.get("profile_content_id")
-    if expected_content_id == _FINAL_REVIEWER_PROFILE_CONTENT_ID_PENDING:
+    if _is_unpopulated_final_value(expected_content_id):
         errors.append(f"{prefix}_content_id: final pin is not populated")
     elif profile_content_id != expected_content_id:
         errors.append(f"{prefix}_content_id: final pin mismatch")
@@ -5602,7 +5742,7 @@ def validate_local_operator_lifecycle_witness(
             errors.append(f"{prefix}: registry profile path does not derive anchor ID")
 
     expected_anchor_digest = final_values.get("lifecycle_anchor_digest")
-    if expected_anchor_digest == _FINAL_REVIEWER_LIFECYCLE_ANCHOR_DIGEST_PENDING:
+    if _is_unpopulated_final_value(expected_anchor_digest):
         errors.append(f"{prefix}.anchor_digest: final pin is not populated")
     elif payload.get("anchor_digest") != expected_anchor_digest:
         errors.append(f"{prefix}.anchor_digest: final pin mismatch")
@@ -11236,16 +11376,9 @@ class ProviderFallbackPolicyAuthorization:
             "lifecycle_anchor_id": "lifecycle_anchor_id",
             "generation": "lifecycle_generation",
         }
-        pending_values = {
-            _FINAL_REVIEWER_DID_PENDING,
-            _FINAL_REVIEWER_PROFILE_ID_PENDING,
-            _FINAL_REVIEWER_PROFILE_CONTENT_ID_PENDING,
-            _FINAL_REVIEWER_LIFECYCLE_ANCHOR_ID_PENDING,
-            _FINAL_REVIEWER_LIFECYCLE_GENERATION_PENDING,
-        }
         for reviewer_field, final_field in final_equalities.items():
             expected = final_values.get(final_field)
-            if expected in pending_values:
+            if _is_unpopulated_final_value(expected):
                 errors.append(
                     f"{prefix}.reviewer.{reviewer_field}: final pin is not populated"
                 )
@@ -12480,46 +12613,43 @@ def _validate_sequential_phase_packet(
             "HEAD" if phase_head_override is None else phase_head_override
         )
         head = _git(repo_root, "rev-parse", "--verify", validation_head)
-        history = _git(
-            repo_root,
-            "rev-list",
-            "--first-parent",
-            f"--max-count={len(expected_phases)}",
-            validation_head,
-        )
-        history_heads = history.stdout.splitlines()
-        if (
-            head.returncode != 0
-            or history.returncode != 0
-            or len(history_heads) != len(expected_phases)
-            or head.stdout.strip() != history_heads[0]
-        ):
+        if head.returncode != 0 or _HEX40.fullmatch(head.stdout.strip()) is None:
             errors.append(
                 "protected_acceptance.packet.history: exact first-parent prefix unavailable"
             )
         else:
-            phase_heads = dict(zip(expected_phases, reversed(history_heads), strict=True))
-            for observed_phase, phase_head in phase_heads.items():
-                tree = _git(
-                    repo_root,
-                    "rev-parse",
-                    "--verify",
-                    f"{phase_head}^{{tree}}",
-                )
-                if tree.returncode != 0 or _HEX40.fullmatch(tree.stdout.strip()) is None:
-                    errors.append(
-                        "protected_acceptance.packet."
-                        f"{observed_phase}.tree: exact phase tree unavailable"
-                    )
-                else:
-                    phase_trees[observed_phase] = tree.stdout.strip()
-            errors.extend(
-                validate_protected_acceptance_sequence(
-                    repo_root=repo_root,
-                    phase_heads=phase_heads,
-                    through_phase=phase,
-                )
+            discovered, discovery_errors = _discover_sequential_phase_heads(
+                repo_root=repo_root,
+                head=head.stdout.strip(),
+                through_phase=phase,
             )
+            errors.extend(discovery_errors)
+            if not discovery_errors:
+                phase_heads = discovered
+                for observed_phase, phase_head in phase_heads.items():
+                    tree = _git(
+                        repo_root,
+                        "rev-parse",
+                        "--verify",
+                        f"{phase_head}^{{tree}}",
+                    )
+                    if (
+                        tree.returncode != 0
+                        or _HEX40.fullmatch(tree.stdout.strip()) is None
+                    ):
+                        errors.append(
+                            "protected_acceptance.packet."
+                            f"{observed_phase}.tree: exact phase tree unavailable"
+                        )
+                    else:
+                        phase_trees[observed_phase] = tree.stdout.strip()
+                errors.extend(
+                    validate_protected_acceptance_sequence(
+                        repo_root=repo_root,
+                        phase_heads=phase_heads,
+                        through_phase=phase,
+                    )
+                )
 
     raw_by_path: dict[str, bytes] = {
         PROVIDER_FALLBACK_POLICY_AUTHORIZATION_RELATIVE_PATH: (
@@ -12557,6 +12687,7 @@ def _validate_sequential_phase_packet(
 
     if phase_index >= _sequential_phase_index("P019"):
         checked.append(LOCAL_OPERATOR_LIFECYCLE_WITNESS_FILENAME)
+        witness_final_values: Mapping[str, Any] | None = None
         try:
             lifecycle_witness = load_local_operator_lifecycle_witness(
                 artifact_root / LOCAL_OPERATOR_LIFECYCLE_WITNESS_FILENAME,
@@ -12564,6 +12695,7 @@ def _validate_sequential_phase_packet(
             )
         except (OSError, ValueError, json.JSONDecodeError) as exc:
             errors.append(f"{LOCAL_OPERATOR_LIFECYCLE_WITNESS_FILENAME}: {exc}")
+            lifecycle_witness = None
         else:
             raw_by_path[LOCAL_OPERATOR_LIFECYCLE_WITNESS_RELATIVE_PATH] = (
                 lifecycle_witness.raw
@@ -12571,6 +12703,21 @@ def _validate_sequential_phase_packet(
             sha_by_path[LOCAL_OPERATOR_LIFECYCLE_WITNESS_RELATIVE_PATH] = (
                 lifecycle_witness.sha256
             )
+            if _is_unpopulated_final_value(_FINAL_REVIEWER_DID_PENDING):
+                profile = lifecycle_witness.payload.get("profile")
+                if isinstance(profile, Mapping):
+                    witness_final_values = {
+                        "reviewer_identity": profile.get("identity_did"),
+                        "profile_id": profile.get("profile_id"),
+                        "profile_content_id": lifecycle_witness.payload.get(
+                            "profile_content_id"
+                        ),
+                        "lifecycle_anchor_id": profile.get("lifecycle_anchor_id"),
+                        "lifecycle_anchor_digest": lifecycle_witness.payload.get(
+                            "anchor_digest"
+                        ),
+                        "lifecycle_generation": profile.get("lifecycle_generation"),
+                    }
             errors.extend(
                 validate_local_operator_lifecycle_witness(
                     lifecycle_witness.payload,
@@ -12593,6 +12740,7 @@ def _validate_sequential_phase_packet(
                         and type(root_pin.payload.get("pinned_at_ms")) is int
                         else None
                     ),
+                    expected_final_values=witness_final_values,
                 )
             )
         errors.extend(
@@ -12601,6 +12749,7 @@ def _validate_sequential_phase_packet(
                 root_pin=root_pin,
                 expected_source_head=phase_heads.get("R", ""),
                 expected_source_tree=phase_trees.get("R", ""),
+                expected_final_values=witness_final_values,
             )
         )
         if root_pin is not None and lifecycle_witness is not None:


### PR DESCRIPTION
## Summary
- Wire `advance-one-phase --phase P019` to publish lifecycle witness, provider-fallback-policy-authorization@2, and convergence manifest component digest update.
- Discover sequential phase heads by phase path deltas, allowing phase-neutral freeze/composition commits between protected tips (needed after the post-R DID freeze merge).
- Treat `FILL_AFTER` as the unpopulated sentinel so frozen lifecycle/reviewer finals validate correctly.

## Test plan
- [x] Dry-run P019 composition against composition tip
- [ ] Merge then live publish P019 on main