### PR TITLE
feat(agent-supervisor): ASE3-028 router-owned provider decision

### DIFF
--- a/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
+++ b/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
@@ -721,7 +721,7 @@ Closeout:           ASE3-014
 
 ## ASE3-028 Restore router ownership and the package dependency direction
 
-- Status: todo
+- Status: completed
 - Completion: manual
 - Is schedulable: true
 - Review only: false

--- a/ipfs_accelerate_py/agent_supervisor/control/capability_resolver.py
+++ b/ipfs_accelerate_py/agent_supervisor/control/capability_resolver.py
@@ -1356,7 +1356,80 @@ class CapabilityResolver:
             )
             return route, None, decision, tuple(degradations)
 
-        if grok.ready:
+        # ASE3-028: sole provider-policy decision lives in llm_router.
+        # This method only normalizes non-authoritative observations and
+        # adapts the returned RouterOwnedProviderDecision into route receipts.
+        from ipfs_accelerate_py.llm_router import (
+            ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+            RouterOwnedProviderObservation,
+            RouterOwnedProviderReason,
+            decide_router_owned_implementation_provider,
+        )
+
+        def _observation_for(
+            provider: ProviderCapabilityEvidence,
+        ) -> RouterOwnedProviderObservation:
+            hard_quota = (
+                provider.capability is PreferredProviderCapability.QUOTA_EXHAUSTED
+            )
+            capacity_latched = (
+                provider.capability
+                is PreferredProviderCapability.CAPACITY_UNAVAILABLE
+            )
+            # Expand readiness without re-authorizing: capability AVAILABLE is
+            # an observation of preferred health, not a dispatch grant.
+            ready = (
+                provider.policy_allowed
+                and provider.healthy
+                and provider.authenticated
+                and provider.capability is PreferredProviderCapability.AVAILABLE
+                and provider.request_headroom > 0
+                and provider.max_concurrency > 0
+            )
+            return RouterOwnedProviderObservation(
+                provider_id=provider.provider_id,
+                ready=ready,
+                authenticated=provider.authenticated,
+                binary_available=True,
+                hard_quota_exhausted=hard_quota,
+                capacity_latched=capacity_latched,
+                request_headroom=provider.request_headroom,
+                source="capability_evidence",
+                reason_codes=(provider.capability.value,),
+            )
+
+        router_observations = [_observation_for(grok)]
+        if codex is not None:
+            router_observations.append(_observation_for(codex))
+
+        router_decision = decide_router_owned_implementation_provider(
+            router_observations,
+            preferred_provider=PREFERRED_PROVIDER,
+            fallback_provider=FALLBACK_PROVIDER,
+            secondary_providers=(FALLBACK_PROVIDER,),
+            global_capacity_latched=False,
+            allow_secondary_without_preferred_quota=False,
+            compatibility_mode=ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+        )
+
+        selected_provider = str(router_decision.selected_provider or "")
+        reason_codes = set(router_decision.reason_codes)
+
+        # Map router classification of preferred state onto the protected
+        # fallback-reason vocabulary without re-deciding authorization.
+        if grok.capability is PreferredProviderCapability.AVAILABLE and not grok.ready:
+            preferred_reason = ProviderFallbackReason.PREFERRED_UNAVAILABLE
+        elif grok.capability is PreferredProviderCapability.AVAILABLE:
+            preferred_reason = ProviderFallbackReason.NONE
+        else:
+            preferred_reason = map_preferred_capability_to_fallback_reason(
+                grok.capability
+            )
+
+        if (
+            selected_provider == PREFERRED_PROVIDER
+            and router_decision.authorized
+        ):
             route = ProviderRouteProvenance(
                 preferred_provider=PREFERRED_PROVIDER,
                 fallback_provider=FALLBACK_PROVIDER,
@@ -1403,27 +1476,21 @@ class CapabilityResolver:
                 reason_codes=(
                     "preferred_provider_healthy",
                     "preferred_provider_policy_allowed",
+                    router_decision.decision_cid,
                 ),
                 effect=DecisionEffect.CONFIGURATION,
             )
             return route, None, decision, tuple(degradations)
-
-        # Preferred Grok is not ready. Codex is a fallback only for confirmed
-        # quota exhaustion; authentication, availability, capacity, and
-        # pre-effect failures fail closed even when Codex itself is ready.
-        if grok.capability is PreferredProviderCapability.AVAILABLE:
-            # Capability says available but readiness failed (auth, health,
-            # policy, concurrency, or headroom). Treat as unavailable.
-            reason = ProviderFallbackReason.PREFERRED_UNAVAILABLE
-        else:
-            reason = map_preferred_capability_to_fallback_reason(grok.capability)
 
         degradations.append(
             CapabilityDegradationCode.PREFERRED_PROVIDER_DEGRADED.value
         )
 
         if (
-            reason is ProviderFallbackReason.PREFERRED_QUOTA_EXHAUSTED
+            selected_provider == FALLBACK_PROVIDER
+            and router_decision.authorized
+            and preferred_reason
+            is ProviderFallbackReason.PREFERRED_QUOTA_EXHAUSTED
             and codex is not None
             and codex.ready
         ):
@@ -1449,7 +1516,7 @@ class CapabilityResolver:
             receipt = ProviderFallbackReceipt(
                 preferred_provider=PREFERRED_PROVIDER,
                 fallback_provider=FALLBACK_PROVIDER,
-                reason_code=reason,
+                reason_code=preferred_reason,
                 observed_capability_cid=grok.observed_capability_cid,
                 task_revision_cid=evidence.task_revision_cid,
                 budget_cid=grok.budget_cid,
@@ -1463,7 +1530,7 @@ class CapabilityResolver:
                 preferred_provider=PREFERRED_PROVIDER,
                 fallback_provider=FALLBACK_PROVIDER,
                 selected_provider=ProviderSelection.CODEX,
-                fallback_reason=reason,
+                fallback_reason=preferred_reason,
                 fallback_receipt_cid=receipt.content_id,
                 observed_capability_cid=codex.observed_capability_cid,
                 usage_evidence_cid=codex.usage_evidence_cid,
@@ -1495,14 +1562,20 @@ class CapabilityResolver:
                         source=ResolutionSource.BUILTIN_DEFAULT,
                         precedence=90,
                         evidence_cid=grok.observed_capability_cid,
-                        rejection_reason=reason.value,
+                        rejection_reason=preferred_reason.value,
                     ),
                 ),
-                reason_codes=(reason.value, "codex_fallback_selected"),
+                reason_codes=(
+                    preferred_reason.value,
+                    "codex_fallback_selected",
+                    router_decision.decision_cid,
+                ),
                 effect=DecisionEffect.CONFIGURATION,
             )
             return route, receipt, decision, tuple(sorted(set(degradations)))
 
+        # Router denied dispatch (backoff/unavailable) or selected a provider
+        # the capability surface cannot represent: fail closed.
         codex_ready_but_forbidden = codex is not None and codex.ready
         degradations.append(
             (
@@ -1511,7 +1584,19 @@ class CapabilityResolver:
                 else CapabilityDegradationCode.PROVIDERS_UNAVAILABLE.value
             )
         )
-        unavailable_reason = reason
+        unavailable_reason = (
+            preferred_reason
+            if preferred_reason is not ProviderFallbackReason.NONE
+            else ProviderFallbackReason.PREFERRED_UNAVAILABLE
+        )
+        # Transient capacity backoff is still a fail-closed unavailable route.
+        if (
+            RouterOwnedProviderReason.PREFERRED_TRANSIENT_CAPACITY
+            in reason_codes
+        ):
+            unavailable_reason = (
+                ProviderFallbackReason.PREFERRED_CAPACITY_UNAVAILABLE
+            )
         route = ProviderRouteProvenance(
             preferred_provider=PREFERRED_PROVIDER,
             fallback_provider=FALLBACK_PROVIDER,
@@ -1569,6 +1654,7 @@ class CapabilityResolver:
                     if codex_ready_but_forbidden
                     else "implementation_providers_unavailable"
                 ),
+                router_decision.decision_cid,
             ),
             effect=DecisionEffect.CONFIGURATION,
         )

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_provider_auto.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_provider_auto.py
@@ -1,31 +1,24 @@
 """Automatic implementation-provider selection for the agent supervisor.
 
-This module is the pure ranking / admission surface for ``auto``
-implementation routing.  It reuses:
+This module normalizes non-authoritative backend observations for ``auto``
+implementation routing and adapts the sole router-owned decision from
+:mod:`ipfs_accelerate_py.llm_router`.  It reuses:
 
-* :mod:`entrypoints.capability_resolver` preferred-provider policy
-  (Grok preferred; Grok is the default tie-breaker when multiple backends
-  are healthy);
-* :mod:`ipfs_accelerate_py.llm_router` readiness probes that do **not**
-  charge usage (binary + auth, no generation);
+* :mod:`ipfs_accelerate_py.llm_router` for eligibility, ranking, freshness,
+  authentication/quota/capacity classification, authorization, and final
+  allow/deny via :func:`decide_router_owned_implementation_provider`;
+* readiness probes that do **not** charge usage (binary + auth, no generation);
 * :mod:`cli_provider_balance` for Claude, Gemini, Meta Spark, Mistral, and
-  Copilot readiness plus quota/balance classification;
+  Copilot readiness plus quota/balance *observation* helpers;
 * durable capacity / hard-quota latches already maintained by the
   implementation daemon from classified provider failures;
 * optional :mod:`endpoint_usage.adapters` observations when a caller has
   already normalized provider balance metadata.
 
-Selection rules (fail-closed):
-
-1. Hard filters: not ready, active transient capacity latch, or hard quota
-   exhaustion remove a candidate before ranking.
-2. Soft ranking prefers more headroom / higher preference rank; identical soft
-   scores are broken by the preferred provider (Grok).
-3. Secondary backends (Codex, Claude, Gemini, Copilot, Meta Spark, Mistral)
-   are authorized for *implementation* only when Grok has a durable hard-quota
-   exhaustion latch (or an operator escape hatch).  Transient Grok capacity
-   cooldowns never open a secondary implementer.
-4. Explicit non-``auto`` pins bypass this selector entirely.
+This module must not retain an independent provider/model/trigger/effort
+tuple, preferred-provider rank or tie-break table, authentication/quota
+classifier, freshness rule, authorization branch, or final allow/deny path.
+Explicit non-``auto`` pins bypass this selector entirely.
 """
 
 from __future__ import annotations
@@ -65,16 +58,6 @@ AUTO_OBSERVED_PROVIDERS: tuple[str, ...] = (
     MISTRAL_PROVIDER_ID,
     FALLBACK_PROVIDER,
 )
-
-# Preference rank: lower is better.  Grok is always first when eligible.
-_PROVIDER_PREFERENCE_RANK: dict[str, int] = {
-    PREFERRED_PROVIDER: 0,
-    **{
-        provider: index + 1
-        for index, provider in enumerate(SECONDARY_IMPLEMENTATION_PREFERENCE)
-    },
-}
-
 
 class AutoProviderDecision(str, Enum):
     """Closed set of auto-route outcomes."""
@@ -320,32 +303,6 @@ def merge_usage_observation(
     )
 
 
-def _soft_rank_key(observation: BackendObservation) -> tuple[int, int, int]:
-    """Lower is better (for ascending sort).
-
-    Order: preference rank (Grok=0), inverted headroom, residual name.
-    """
-
-    rank = _PROVIDER_PREFERENCE_RANK.get(observation.provider_id, 100)
-    headroom = (
-        int(observation.request_headroom)
-        if observation.request_headroom is not None
-        else 0
-    )
-    return (rank, -headroom, observation.provider_id)
-
-
-def _best_secondary(eligible: Sequence[BackendObservation]) -> BackendObservation | None:
-    secondaries = [
-        item
-        for item in eligible
-        if item.provider_id in SECONDARY_IMPLEMENTATION_PREFERENCE
-    ]
-    if not secondaries:
-        return None
-    return sorted(secondaries, key=_soft_rank_key)[0]
-
-
 def select_implementation_provider(
     observations: Sequence[BackendObservation],
     *,
@@ -354,6 +311,10 @@ def select_implementation_provider(
     allow_codex_without_grok_quota: bool = False,
 ) -> AutoProviderSelection:
     """Select the implementation backend from frozen observations.
+
+    Observation normalization stays local; eligibility, ranking, freshness,
+    classification, authorization, and final allow/deny are owned solely by
+    :func:`ipfs_accelerate_py.llm_router.decide_router_owned_implementation_provider`.
 
     Parameters
     ----------
@@ -366,102 +327,68 @@ def select_implementation_provider(
         false so secondaries open only after Grok hard-quota evidence.
     """
 
+    from ipfs_accelerate_py.llm_router import (
+        ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+        LegacyAutoProviderCompatibilityAdapter,
+        RouterOwnedProviderObservation,
+        decide_router_owned_implementation_provider,
+    )
+
     # Back-compat alias used by older call sites / tests.
     allow_secondary = bool(
         allow_secondary_without_grok_quota or allow_codex_without_grok_quota
     )
 
     obs = tuple(observations)
-    by_id = {item.provider_id: item for item in obs}
-    grok = by_id.get(PREFERRED_PROVIDER)
-
-    if global_capacity_latched:
-        return AutoProviderSelection(
-            decision=AutoProviderDecision.BACKOFF,
-            selected_provider="",
-            reason_codes=(AutoProviderReason.GLOBAL_CAPACITY.value,),
-            observations=obs,
-            retry_at=next((item.retry_at for item in obs if item.retry_at), ""),
+    router_observations = tuple(
+        RouterOwnedProviderObservation(
+            provider_id=item.provider_id,
+            ready=item.ready,
+            authenticated=item.authenticated,
+            binary_available=item.binary_available,
+            hard_quota_exhausted=item.hard_quota_exhausted,
+            capacity_latched=item.capacity_latched,
+            request_headroom=item.request_headroom,
+            retry_at=item.retry_at,
+            source=item.source,
+            reason_codes=item.reason_codes,
         )
-
-    eligible = [item for item in obs if item.eligible]
-    other_eligible = [
-        item for item in eligible if item.provider_id != PREFERRED_PROVIDER
-    ]
-
-    # Grok ready → always preferred (explicit tie-break when others ready).
-    if grok is not None and grok.eligible:
-        reasons = [AutoProviderReason.PREFERRED_READY.value]
-        if other_eligible:
-            reasons.append(AutoProviderReason.TIE_BREAK_PREFERRED.value)
-        return AutoProviderSelection(
-            decision=AutoProviderDecision.GROK,
-            selected_provider=PREFERRED_PROVIDER,
-            reason_codes=tuple(reasons),
-            observations=obs,
-        )
-
-    # Transient Grok capacity: backoff; never open secondaries without hard quota.
-    if (
-        grok is not None
-        and grok.capacity_latched
-        and not grok.hard_quota_exhausted
-    ):
-        return AutoProviderSelection(
-            decision=AutoProviderDecision.BACKOFF,
-            selected_provider="",
-            reason_codes=(
-                AutoProviderReason.PREFERRED_TRANSIENT_CAPACITY.value,
-            ),
-            observations=obs,
-            retry_at=grok.retry_at,
-        )
-
-    # Durable Grok hard-quota exhaustion authorizes secondary implementers.
-    if grok is not None and grok.hard_quota_exhausted:
-        secondary = _best_secondary(eligible)
-        if secondary is not None:
-            return AutoProviderSelection(
-                decision=_decision_for_provider(secondary.provider_id),
-                selected_provider=secondary.provider_id,
-                reason_codes=(
-                    AutoProviderReason.FALLBACK_AFTER_QUOTA.value,
-                    AutoProviderReason.SECONDARY_AFTER_QUOTA.value,
-                ),
-                observations=obs,
-                retry_at=grok.retry_at,
-            )
-
-    # Optional escape hatch (tests / operator) — off by default.
-    if allow_secondary:
-        secondary = _best_secondary(eligible)
-        if secondary is not None:
-            return AutoProviderSelection(
-                decision=_decision_for_provider(secondary.provider_id),
-                selected_provider=secondary.provider_id,
-                reason_codes=(AutoProviderReason.FALLBACK_AFTER_QUOTA.value,),
-                observations=obs,
-                retry_at=secondary.retry_at,
-            )
-
-    reasons: list[str] = [AutoProviderReason.NO_ELIGIBLE.value]
-    if grok is not None and not grok.eligible:
-        reasons.append(AutoProviderReason.PREFERRED_NOT_READY.value)
-    if not any(
-        item.eligible and item.provider_id in SECONDARY_IMPLEMENTATION_PREFERENCE
         for item in obs
-    ):
-        reasons.append(AutoProviderReason.SECONDARY_NOT_READY.value)
-        reasons.append(AutoProviderReason.FALLBACK_NOT_READY.value)
+    )
+    decision = decide_router_owned_implementation_provider(
+        router_observations,
+        preferred_provider=PREFERRED_PROVIDER,
+        fallback_provider=FALLBACK_PROVIDER,
+        secondary_providers=SECONDARY_IMPLEMENTATION_PREFERENCE,
+        global_capacity_latched=global_capacity_latched,
+        allow_secondary_without_preferred_quota=allow_secondary,
+        compatibility_mode=ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+    )
+    adapted = LegacyAutoProviderCompatibilityAdapter.to_selection_fields(decision)
+    selected_provider = str(adapted["selected_provider"] or "")
+    mapped_decision = str(adapted["decision"] or "unavailable")
+    if mapped_decision == "backoff":
+        auto_decision = AutoProviderDecision.BACKOFF
+    elif mapped_decision == "unavailable" or not selected_provider:
+        auto_decision = AutoProviderDecision.UNAVAILABLE
+    else:
+        auto_decision = _decision_for_provider(selected_provider)
     return AutoProviderSelection(
-        decision=AutoProviderDecision.UNAVAILABLE,
-        selected_provider="",
-        reason_codes=tuple(dict.fromkeys(reasons)),
-        observations=obs,
-        retry_at=(
-            (grok.retry_at if grok is not None else "")
-            or next((item.retry_at for item in obs if item.retry_at), "")
+        decision=auto_decision,
+        selected_provider=selected_provider,
+        preferred_provider=str(
+            adapted.get("preferred_provider") or PREFERRED_PROVIDER
         ),
+        fallback_provider=str(
+            adapted.get("fallback_provider") or FALLBACK_PROVIDER
+        ),
+        secondary_providers=tuple(
+            adapted.get("secondary_providers")
+            or SECONDARY_IMPLEMENTATION_PREFERENCE
+        ),
+        reason_codes=tuple(adapted.get("reason_codes") or ()),
+        observations=obs,
+        retry_at=str(adapted.get("retry_at") or ""),
     )
 
 

--- a/ipfs_accelerate_py/llm_router.py
+++ b/ipfs_accelerate_py/llm_router.py
@@ -125,6 +125,7 @@ from functools import lru_cache
 from html import unescape
 from pathlib import Path, PurePosixPath
 from typing import (
+    Any,
     Callable,
     Dict,
     List,
@@ -1743,6 +1744,590 @@ class AgentImplementationFallbackDecision:
             self.as_dict(),
             identity_field="content_id",
         )
+
+
+
+# ---------------------------------------------------------------------------
+# ASE3-028: sole router-owned implementation-provider decision surface.
+# Callers may only normalize non-authoritative observations and adapt the
+# returned decision; they must not re-rank, reclassify, or re-authorize.
+# ---------------------------------------------------------------------------
+
+ROUTER_OWNED_PROVIDER_DECISION_SCHEMA = (
+    "ipfs_accelerate_py/agent-supervisor/router-owned-provider-decision@1"
+)
+ROUTER_OWNED_PREFERRED_PROVIDER = "grok"
+ROUTER_OWNED_FALLBACK_PROVIDER = "codex"
+ROUTER_OWNED_SECONDARY_PREFERENCE: tuple[str, ...] = (
+    "codex",
+    "claude",
+    "gemini",
+    "copilot",
+    "meta_spark",
+    "mistral",
+)
+ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO = "legacy_auto"
+ROUTER_OWNED_COMPATIBILITY_CANONICAL = "canonical"
+
+
+class RouterOwnedProviderReason:
+    """Stable reason codes owned by the router decision surface."""
+
+    PREFERRED_READY = "preferred_provider_ready"
+    TIE_BREAK_PREFERRED = "tie_break_preferred_provider"
+    FALLBACK_AFTER_QUOTA = "fallback_after_preferred_hard_quota"
+    SECONDARY_AFTER_QUOTA = "secondary_after_preferred_hard_quota"
+    PREFERRED_TRANSIENT_CAPACITY = "preferred_provider_transient_capacity"
+    PREFERRED_NOT_READY = "preferred_provider_not_ready"
+    FALLBACK_NOT_READY = "fallback_provider_not_ready"
+    SECONDARY_NOT_READY = "secondary_providers_not_ready"
+    GLOBAL_CAPACITY = "global_provider_capacity_cooldown"
+    NO_ELIGIBLE = "no_eligible_implementation_provider"
+    PREFERRED_HARD_QUOTA = "preferred_provider_hard_quota_exhausted"
+    AUTHORIZED = "router_owned_provider_authorized"
+    DENIED = "router_owned_provider_denied"
+
+
+@dataclass(frozen=True, slots=True)
+class RouterOwnedProviderObservation:
+    """Bounded non-authoritative backend observation for router policy.
+
+    Observations never authorize dispatch alone. Eligibility, ranking,
+    classification, freshness, and final allow/deny live only in
+    :func:`decide_router_owned_implementation_provider`.
+    """
+
+    provider_id: str
+    ready: bool
+    authenticated: bool = False
+    binary_available: bool = True
+    hard_quota_exhausted: bool = False
+    capacity_latched: bool = False
+    request_headroom: int | None = None
+    retry_at: str = ""
+    source: str = "observation"
+    reason_codes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        provider_id = str(self.provider_id or "").strip().lower()
+        if not provider_id:
+            raise ValueError("router-owned observation requires provider_id")
+        object.__setattr__(self, "provider_id", provider_id)
+        object.__setattr__(self, "ready", bool(self.ready))
+        object.__setattr__(self, "authenticated", bool(self.authenticated))
+        object.__setattr__(self, "binary_available", bool(self.binary_available))
+        object.__setattr__(
+            self, "hard_quota_exhausted", bool(self.hard_quota_exhausted)
+        )
+        object.__setattr__(self, "capacity_latched", bool(self.capacity_latched))
+        headroom = self.request_headroom
+        if headroom is not None:
+            if isinstance(headroom, bool) or not isinstance(headroom, int):
+                raise ValueError("request_headroom must be an int or None")
+            if headroom < 0:
+                raise ValueError("request_headroom must be non-negative")
+        object.__setattr__(self, "retry_at", str(self.retry_at or ""))
+        object.__setattr__(self, "source", str(self.source or "observation"))
+        codes = tuple(
+            str(code)
+            for code in (self.reason_codes or ())
+            if str(code or "").strip()
+        )
+        object.__setattr__(self, "reason_codes", codes)
+
+    @classmethod
+    def from_mapping(
+        cls, value: Mapping[str, Any]
+    ) -> "RouterOwnedProviderObservation":
+        if not isinstance(value, Mapping):
+            raise ValueError("router-owned observation must be a mapping")
+        headroom = value.get("request_headroom")
+        if headroom is not None and not isinstance(headroom, bool):
+            try:
+                headroom = int(headroom)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("request_headroom must be an int or None") from exc
+        return cls(
+            provider_id=str(value.get("provider_id") or ""),
+            ready=bool(value.get("ready")),
+            authenticated=bool(value.get("authenticated", False)),
+            binary_available=bool(value.get("binary_available", True)),
+            hard_quota_exhausted=bool(value.get("hard_quota_exhausted", False)),
+            capacity_latched=bool(value.get("capacity_latched", False)),
+            request_headroom=headroom if headroom is not None else None,
+            retry_at=str(value.get("retry_at") or ""),
+            source=str(value.get("source") or "observation"),
+            reason_codes=tuple(value.get("reason_codes") or ()),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "ready": self.ready,
+            "authenticated": self.authenticated,
+            "binary_available": self.binary_available,
+            "hard_quota_exhausted": self.hard_quota_exhausted,
+            "capacity_latched": self.capacity_latched,
+            "request_headroom": self.request_headroom,
+            "retry_at": self.retry_at,
+            "source": self.source,
+            "reason_codes": list(self.reason_codes),
+        }
+
+    @property
+    def content_id(self) -> str:
+        return _content_addressed_mapping(
+            self.as_dict(), identity_field="content_id"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RouterOwnedProviderPolicyContext:
+    """Verified policy context submitted with capacity observations."""
+
+    preferred_provider: str = ROUTER_OWNED_PREFERRED_PROVIDER
+    fallback_provider: str = ROUTER_OWNED_FALLBACK_PROVIDER
+    secondary_providers: tuple[str, ...] = ROUTER_OWNED_SECONDARY_PREFERENCE
+    global_capacity_latched: bool = False
+    allow_secondary_without_preferred_quota: bool = False
+    compatibility_mode: str = ROUTER_OWNED_COMPATIBILITY_CANONICAL
+
+    def __post_init__(self) -> None:
+        preferred = str(self.preferred_provider or "").strip().lower()
+        fallback = str(self.fallback_provider or "").strip().lower()
+        if not preferred or not fallback:
+            raise ValueError("preferred and fallback providers are required")
+        secondaries = tuple(
+            str(item).strip().lower()
+            for item in (self.secondary_providers or ())
+            if str(item or "").strip()
+        )
+        mode = str(self.compatibility_mode or ROUTER_OWNED_COMPATIBILITY_CANONICAL)
+        if mode not in {
+            ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+            ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+        }:
+            raise ValueError(f"unsupported compatibility_mode {mode!r}")
+        object.__setattr__(self, "preferred_provider", preferred)
+        object.__setattr__(self, "fallback_provider", fallback)
+        object.__setattr__(self, "secondary_providers", secondaries)
+        object.__setattr__(
+            self, "global_capacity_latched", bool(self.global_capacity_latched)
+        )
+        object.__setattr__(
+            self,
+            "allow_secondary_without_preferred_quota",
+            bool(self.allow_secondary_without_preferred_quota),
+        )
+        object.__setattr__(self, "compatibility_mode", mode)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "preferred_provider": self.preferred_provider,
+            "fallback_provider": self.fallback_provider,
+            "secondary_providers": list(self.secondary_providers),
+            "global_capacity_latched": self.global_capacity_latched,
+            "allow_secondary_without_preferred_quota": (
+                self.allow_secondary_without_preferred_quota
+            ),
+            "compatibility_mode": self.compatibility_mode,
+        }
+
+    @property
+    def content_id(self) -> str:
+        return _content_addressed_mapping(
+            self.as_dict(), identity_field="content_id"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RouterOwnedProviderDecision:
+    """Immutable sole provider-policy result for implementation routing."""
+
+    schema: str
+    decision: str
+    selected_provider: str
+    authorized: bool
+    reason_codes: tuple[str, ...]
+    preferred_provider: str
+    fallback_provider: str
+    secondary_providers: tuple[str, ...]
+    retry_at: str
+    compatibility_mode: str
+    observations: tuple[dict[str, Any], ...]
+    policy_context: dict[str, Any]
+    classified: tuple[dict[str, Any], ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "decision": self.decision,
+            "selected_provider": self.selected_provider,
+            "authorized": self.authorized,
+            "reason_codes": list(self.reason_codes),
+            "preferred_provider": self.preferred_provider,
+            "fallback_provider": self.fallback_provider,
+            "secondary_providers": list(self.secondary_providers),
+            "retry_at": self.retry_at,
+            "compatibility_mode": self.compatibility_mode,
+            "observations": [dict(item) for item in self.observations],
+            "policy_context": dict(self.policy_context),
+            "classified": [dict(item) for item in self.classified],
+        }
+
+    @property
+    def content_id(self) -> str:
+        return _content_addressed_mapping(
+            self.as_dict(), identity_field="content_id"
+        )
+
+    @property
+    def decision_cid(self) -> str:
+        return self.content_id
+
+
+def _router_owned_observation(
+    value: RouterOwnedProviderObservation | Mapping[str, Any],
+) -> RouterOwnedProviderObservation:
+    if isinstance(value, RouterOwnedProviderObservation):
+        return value
+    return RouterOwnedProviderObservation.from_mapping(value)
+
+
+def _router_owned_is_eligible(
+    observation: RouterOwnedProviderObservation,
+) -> bool:
+    return (
+        observation.ready
+        and observation.authenticated
+        and observation.binary_available
+        and not observation.hard_quota_exhausted
+        and not observation.capacity_latched
+    )
+
+
+def _router_owned_preference_rank(
+    provider_id: str,
+    *,
+    preferred_provider: str,
+    secondary_providers: Sequence[str],
+) -> int:
+    if provider_id == preferred_provider:
+        return 0
+    try:
+        return list(secondary_providers).index(provider_id) + 1
+    except ValueError:
+        return 100
+
+
+def _router_owned_soft_rank_key(
+    observation: RouterOwnedProviderObservation,
+    *,
+    preferred_provider: str,
+    secondary_providers: Sequence[str],
+) -> tuple[int, int, str]:
+    rank = _router_owned_preference_rank(
+        observation.provider_id,
+        preferred_provider=preferred_provider,
+        secondary_providers=secondary_providers,
+    )
+    headroom = (
+        int(observation.request_headroom)
+        if observation.request_headroom is not None
+        else 0
+    )
+    return (rank, -headroom, observation.provider_id)
+
+
+def _router_owned_best_secondary(
+    eligible: Sequence[RouterOwnedProviderObservation],
+    *,
+    secondary_providers: Sequence[str],
+    preferred_provider: str,
+) -> RouterOwnedProviderObservation | None:
+    secondaries = [
+        item
+        for item in eligible
+        if item.provider_id in set(secondary_providers)
+        and item.provider_id != preferred_provider
+    ]
+    if not secondaries:
+        return None
+    return sorted(
+        secondaries,
+        key=lambda item: _router_owned_soft_rank_key(
+            item,
+            preferred_provider=preferred_provider,
+            secondary_providers=secondary_providers,
+        ),
+    )[0]
+
+
+def _router_owned_classify(
+    observation: RouterOwnedProviderObservation,
+) -> dict[str, Any]:
+    if observation.hard_quota_exhausted:
+        classification = "hard_quota_exhausted"
+    elif observation.capacity_latched:
+        classification = "capacity_latched"
+    elif _router_owned_is_eligible(observation):
+        classification = "eligible"
+    elif not observation.authenticated:
+        classification = "unauthenticated"
+    elif not observation.binary_available:
+        classification = "binary_unavailable"
+    elif not observation.ready:
+        classification = "not_ready"
+    else:
+        classification = "ineligible"
+    return {
+        "provider_id": observation.provider_id,
+        "classification": classification,
+        "eligible": _router_owned_is_eligible(observation),
+        "hard_quota_exhausted": observation.hard_quota_exhausted,
+        "capacity_latched": observation.capacity_latched,
+        "observation_cid": observation.content_id,
+    }
+
+
+def decide_router_owned_implementation_provider(
+    observations: Sequence[RouterOwnedProviderObservation | Mapping[str, Any]],
+    *,
+    policy_context: RouterOwnedProviderPolicyContext | Mapping[str, Any] | None = None,
+    preferred_provider: str = ROUTER_OWNED_PREFERRED_PROVIDER,
+    fallback_provider: str = ROUTER_OWNED_FALLBACK_PROVIDER,
+    secondary_providers: Sequence[str] | None = None,
+    global_capacity_latched: bool = False,
+    allow_secondary_without_preferred_quota: bool = False,
+    compatibility_mode: str = ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+) -> RouterOwnedProviderDecision:
+    """Sole provider-policy decision for implementation routing.
+
+    Both ``implementation_provider_auto`` and ``capability_resolver`` must
+    submit normalized observations plus verified policy context and consume
+    this decision without reclassification or a second decision table.
+    """
+
+    if policy_context is None:
+        context = RouterOwnedProviderPolicyContext(
+            preferred_provider=preferred_provider,
+            fallback_provider=fallback_provider,
+            secondary_providers=tuple(
+                secondary_providers
+                if secondary_providers is not None
+                else ROUTER_OWNED_SECONDARY_PREFERENCE
+            ),
+            global_capacity_latched=global_capacity_latched,
+            allow_secondary_without_preferred_quota=(
+                allow_secondary_without_preferred_quota
+            ),
+            compatibility_mode=compatibility_mode,
+        )
+    elif isinstance(policy_context, RouterOwnedProviderPolicyContext):
+        context = policy_context
+    else:
+        context = RouterOwnedProviderPolicyContext(
+            preferred_provider=str(
+                policy_context.get("preferred_provider") or preferred_provider
+            ),
+            fallback_provider=str(
+                policy_context.get("fallback_provider") or fallback_provider
+            ),
+            secondary_providers=tuple(
+                policy_context.get("secondary_providers")
+                if policy_context.get("secondary_providers") is not None
+                else (
+                    secondary_providers
+                    if secondary_providers is not None
+                    else ROUTER_OWNED_SECONDARY_PREFERENCE
+                )
+            ),
+            global_capacity_latched=bool(
+                policy_context.get(
+                    "global_capacity_latched", global_capacity_latched
+                )
+            ),
+            allow_secondary_without_preferred_quota=bool(
+                policy_context.get(
+                    "allow_secondary_without_preferred_quota",
+                    allow_secondary_without_preferred_quota,
+                )
+            ),
+            compatibility_mode=str(
+                policy_context.get("compatibility_mode") or compatibility_mode
+            ),
+        )
+
+    obs = tuple(_router_owned_observation(item) for item in observations)
+    classified = tuple(_router_owned_classify(item) for item in obs)
+    by_id = {item.provider_id: item for item in obs}
+    preferred = by_id.get(context.preferred_provider)
+    context_payload = context.as_dict()
+    observation_payloads = tuple(item.as_dict() for item in obs)
+
+    def _build(
+        *,
+        decision: str,
+        selected_provider: str,
+        reason_codes: Sequence[str],
+        retry_at: str = "",
+    ) -> RouterOwnedProviderDecision:
+        authorized = bool(selected_provider) and decision not in {
+            "unavailable",
+            "backoff",
+        }
+        codes = list(reason_codes)
+        codes.append(
+            RouterOwnedProviderReason.AUTHORIZED
+            if authorized
+            else RouterOwnedProviderReason.DENIED
+        )
+        return RouterOwnedProviderDecision(
+            schema=ROUTER_OWNED_PROVIDER_DECISION_SCHEMA,
+            decision=decision,
+            selected_provider=selected_provider,
+            authorized=authorized,
+            reason_codes=tuple(dict.fromkeys(str(code) for code in codes if code)),
+            preferred_provider=context.preferred_provider,
+            fallback_provider=context.fallback_provider,
+            secondary_providers=context.secondary_providers,
+            retry_at=str(retry_at or ""),
+            compatibility_mode=context.compatibility_mode,
+            observations=observation_payloads,
+            policy_context=context_payload,
+            classified=classified,
+        )
+
+    if context.global_capacity_latched:
+        return _build(
+            decision="backoff",
+            selected_provider="",
+            reason_codes=(RouterOwnedProviderReason.GLOBAL_CAPACITY,),
+            retry_at=next((item.retry_at for item in obs if item.retry_at), ""),
+        )
+
+    eligible = [item for item in obs if _router_owned_is_eligible(item)]
+    other_eligible = [
+        item
+        for item in eligible
+        if item.provider_id != context.preferred_provider
+    ]
+
+    if preferred is not None and _router_owned_is_eligible(preferred):
+        reasons = [RouterOwnedProviderReason.PREFERRED_READY]
+        if other_eligible:
+            reasons.append(RouterOwnedProviderReason.TIE_BREAK_PREFERRED)
+        return _build(
+            decision=context.preferred_provider,
+            selected_provider=context.preferred_provider,
+            reason_codes=reasons,
+        )
+
+    if (
+        preferred is not None
+        and preferred.capacity_latched
+        and not preferred.hard_quota_exhausted
+    ):
+        return _build(
+            decision="backoff",
+            selected_provider="",
+            reason_codes=(RouterOwnedProviderReason.PREFERRED_TRANSIENT_CAPACITY,),
+            retry_at=preferred.retry_at,
+        )
+
+    if preferred is not None and preferred.hard_quota_exhausted:
+        secondary = _router_owned_best_secondary(
+            eligible,
+            secondary_providers=context.secondary_providers,
+            preferred_provider=context.preferred_provider,
+        )
+        if secondary is not None:
+            return _build(
+                decision=secondary.provider_id,
+                selected_provider=secondary.provider_id,
+                reason_codes=(
+                    RouterOwnedProviderReason.PREFERRED_HARD_QUOTA,
+                    RouterOwnedProviderReason.FALLBACK_AFTER_QUOTA,
+                    RouterOwnedProviderReason.SECONDARY_AFTER_QUOTA,
+                ),
+                retry_at=preferred.retry_at or secondary.retry_at,
+            )
+
+    if context.allow_secondary_without_preferred_quota:
+        secondary = _router_owned_best_secondary(
+            eligible,
+            secondary_providers=context.secondary_providers,
+            preferred_provider=context.preferred_provider,
+        )
+        if secondary is not None:
+            return _build(
+                decision=secondary.provider_id,
+                selected_provider=secondary.provider_id,
+                reason_codes=(RouterOwnedProviderReason.FALLBACK_AFTER_QUOTA,),
+                retry_at=secondary.retry_at,
+            )
+
+    reasons: list[str] = [RouterOwnedProviderReason.NO_ELIGIBLE]
+    if preferred is not None and not _router_owned_is_eligible(preferred):
+        reasons.append(RouterOwnedProviderReason.PREFERRED_NOT_READY)
+    if not any(
+        _router_owned_is_eligible(item)
+        and item.provider_id in set(context.secondary_providers)
+        for item in obs
+    ):
+        reasons.append(RouterOwnedProviderReason.SECONDARY_NOT_READY)
+        reasons.append(RouterOwnedProviderReason.FALLBACK_NOT_READY)
+    return _build(
+        decision="unavailable",
+        selected_provider="",
+        reason_codes=reasons,
+        retry_at=(
+            (preferred.retry_at if preferred is not None else "")
+            or next((item.retry_at for item in obs if item.retry_at), "")
+        ),
+    )
+
+
+class LegacyAutoProviderCompatibilityAdapter:
+    """Map a router decision onto legacy auto-provider receipt fields.
+
+    The adapter never re-decides eligibility, ranking, or authorization.
+    """
+
+    @staticmethod
+    def to_selection_fields(
+        decision: RouterOwnedProviderDecision,
+    ) -> dict[str, Any]:
+        selected = str(decision.selected_provider or "")
+        kind = str(decision.decision or "")
+        if not selected and kind == "backoff":
+            mapped_decision = "backoff"
+        elif not selected:
+            mapped_decision = "unavailable"
+        else:
+            mapped_decision = selected
+        # Drop router-internal authorize/deny markers for legacy receipts.
+        reasons = tuple(
+            code
+            for code in decision.reason_codes
+            if code
+            not in {
+                RouterOwnedProviderReason.AUTHORIZED,
+                RouterOwnedProviderReason.DENIED,
+                RouterOwnedProviderReason.PREFERRED_HARD_QUOTA,
+            }
+        )
+        return {
+            "decision": mapped_decision,
+            "selected_provider": selected,
+            "reason_codes": reasons,
+            "retry_at": decision.retry_at,
+            "preferred_provider": decision.preferred_provider,
+            "fallback_provider": decision.fallback_provider,
+            "secondary_providers": decision.secondary_providers,
+            "decision_cid": decision.decision_cid,
+            "authorized": decision.authorized,
+        }
 
 
 _AGENT_EFFECT_AUTHORIZATION_CONTEXT_SCHEMA = (

--- a/test/api/test_agent_supervisor_router_owned_provider_decision.py
+++ b/test/api/test_agent_supervisor_router_owned_provider_decision.py
@@ -1,0 +1,399 @@
+"""ASE3-028: sole router-owned implementation-provider decision."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor.control.capability_resolver import (
+    FALLBACK_PROVIDER,
+    PREFERRED_PROVIDER,
+    CapabilityEvidence,
+    PreferredProviderCapability,
+    ProviderCapabilityEvidence,
+    ResourceSampleEvidence,
+    TopologyEvidence,
+    TopologyMode,
+    ValidationPolicyEvidence,
+    resolve_capabilities,
+)
+from ipfs_accelerate_py.agent_supervisor.contracts.execution import ProviderSelection
+from ipfs_accelerate_py.agent_supervisor.contracts.provider_capacity import (
+    NON_AUTHORITATIVE_CAPACITY_SCHEMA,
+    NonAuthoritativeProviderCapacityObservation,
+)
+from ipfs_accelerate_py.agent_supervisor.core.multiformats_identity import (
+    cid_for_dag_json,
+)
+from ipfs_accelerate_py.agent_supervisor.todo_daemon.implementation_provider_auto import (
+    AutoProviderDecision,
+    BackendObservation,
+    select_implementation_provider,
+)
+from ipfs_accelerate_py.llm_router import (
+    ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+    ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+    ROUTER_OWNED_PROVIDER_DECISION_SCHEMA,
+    LegacyAutoProviderCompatibilityAdapter,
+    RouterOwnedProviderDecision,
+    RouterOwnedProviderObservation,
+    RouterOwnedProviderPolicyContext,
+    RouterOwnedProviderReason,
+    decide_router_owned_implementation_provider,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LLM_ROUTER = REPO_ROOT / "ipfs_accelerate_py" / "llm_router.py"
+PROVIDER_AUTO = (
+    REPO_ROOT
+    / "ipfs_accelerate_py"
+    / "agent_supervisor"
+    / "todo_daemon"
+    / "implementation_provider_auto.py"
+)
+CAPABILITY_RESOLVER = (
+    REPO_ROOT
+    / "ipfs_accelerate_py"
+    / "agent_supervisor"
+    / "control"
+    / "capability_resolver.py"
+)
+
+
+def _cid(label: str) -> str:
+    return cid_for_dag_json({"fixture": label})
+
+
+def _obs(
+    provider_id: str,
+    *,
+    ready: bool = True,
+    authenticated: bool = True,
+    binary_available: bool = True,
+    hard_quota_exhausted: bool = False,
+    capacity_latched: bool = False,
+    request_headroom: int | None = 10,
+) -> RouterOwnedProviderObservation:
+    return RouterOwnedProviderObservation(
+        provider_id=provider_id,
+        ready=ready,
+        authenticated=authenticated,
+        binary_available=binary_available,
+        hard_quota_exhausted=hard_quota_exhausted,
+        capacity_latched=capacity_latched,
+        request_headroom=request_headroom,
+        source="test",
+    )
+
+
+def _backend(
+    provider_id: str,
+    *,
+    ready: bool = True,
+    authenticated: bool = True,
+    binary_available: bool = True,
+    hard_quota_exhausted: bool = False,
+    capacity_latched: bool = False,
+    request_headroom: int | None = 10,
+) -> BackendObservation:
+    return BackendObservation(
+        provider_id=provider_id,
+        ready=ready,
+        authenticated=authenticated,
+        binary_available=binary_available,
+        hard_quota_exhausted=hard_quota_exhausted,
+        capacity_latched=capacity_latched,
+        request_headroom=request_headroom,
+        source="test",
+    )
+
+
+def _provider(
+    provider_id: str,
+    *,
+    capability: PreferredProviderCapability = PreferredProviderCapability.AVAILABLE,
+    policy_allowed: bool = True,
+    healthy: bool = True,
+    authenticated: bool = True,
+    request_headroom: int = 10,
+    max_concurrency: int = 4,
+) -> ProviderCapabilityEvidence:
+    return ProviderCapabilityEvidence(
+        provider_id=provider_id,
+        capability=capability,
+        policy_allowed=policy_allowed,
+        healthy=healthy,
+        authenticated=authenticated,
+        observed_capability_cid=_cid(f"{provider_id}-capability"),
+        usage_evidence_cid=_cid(f"{provider_id}-usage"),
+        budget_cid=_cid(f"{provider_id}-budget"),
+        max_concurrency=max_concurrency,
+        request_headroom=request_headroom,
+    )
+
+
+def _evidence(
+    *,
+    grok: ProviderCapabilityEvidence | None = None,
+    codex: ProviderCapabilityEvidence | None = None,
+) -> CapabilityEvidence:
+    preferred = grok or _provider(PREFERRED_PROVIDER)
+    fallback = codex if codex is not None else _provider(FALLBACK_PROVIDER)
+    return CapabilityEvidence(
+        providers={
+            preferred.provider_id: preferred,
+            fallback.provider_id: fallback,
+        },
+        resources=ResourceSampleEvidence(
+            ready_width=4,
+            host_worker_limit=8,
+            host_available_workers=6,
+            max_processes=8,
+            max_validation_workers=4,
+            cpu_millis=8_000,
+            memory_bytes=8 * 1024**3,
+            provider_request_limit=100,
+            deadline_ms=3_600_000,
+            lane_labels=("alpha", "beta"),
+        ),
+        validation=ValidationPolicyEvidence(
+            allowlisted_argv=(("python", "-m", "pytest", "test/api", "-q"),),
+            policy_cid=_cid("validation-policy"),
+        ),
+        topology=TopologyEvidence(
+            distributed_capable=False,
+            shard_count=1,
+            owner_principal_ref="did:key:local-owner",
+            state_root="/var/lib/supervisor/state",
+            database_relative_path="coordination.duckdb",
+            coordinator_cid=_cid("coordinator"),
+            lease_namespace="repo-run",
+            fencing_generation=3,
+            ipfs_publish_capable=True,
+            parquet_capable=True,
+            preferred_mode=TopologyMode.LOCAL,
+            ipfs_backend_handle="ipfs-kit:development",
+        ),
+        task_revision_cid=_cid("task-revision"),
+        attempt_cid=_cid("attempt"),
+        worktree_cid=_cid("worktree"),
+    )
+
+
+def test_router_decision_prefers_ready_grok_and_is_content_addressed() -> None:
+    decision = decide_router_owned_implementation_provider(
+        (
+            _obs("grok"),
+            _obs("codex"),
+            _obs("claude"),
+        )
+    )
+    assert isinstance(decision, RouterOwnedProviderDecision)
+    assert decision.schema == ROUTER_OWNED_PROVIDER_DECISION_SCHEMA
+    assert decision.selected_provider == "grok"
+    assert decision.authorized is True
+    assert RouterOwnedProviderReason.PREFERRED_READY in decision.reason_codes
+    assert decision.decision_cid.startswith("sha256:")
+    again = decide_router_owned_implementation_provider(
+        (
+            _obs("grok"),
+            _obs("codex"),
+            _obs("claude"),
+        )
+    )
+    assert again.decision_cid == decision.decision_cid
+
+
+def test_router_decision_opens_secondary_only_after_preferred_hard_quota() -> None:
+    denied = decide_router_owned_implementation_provider(
+        (
+            _obs(
+                "grok",
+                ready=False,
+                capacity_latched=True,
+                hard_quota_exhausted=False,
+            ),
+            _obs("codex"),
+        )
+    )
+    assert denied.authorized is False
+    assert denied.decision == "backoff"
+    assert (
+        RouterOwnedProviderReason.PREFERRED_TRANSIENT_CAPACITY
+        in denied.reason_codes
+    )
+
+    allowed = decide_router_owned_implementation_provider(
+        (
+            _obs(
+                "grok",
+                ready=False,
+                hard_quota_exhausted=True,
+            ),
+            _obs("codex"),
+            _obs("claude", request_headroom=99),
+        )
+    )
+    assert allowed.authorized is True
+    assert allowed.selected_provider == "codex"
+    assert RouterOwnedProviderReason.FALLBACK_AFTER_QUOTA in allowed.reason_codes
+
+
+def test_identical_observations_yield_same_decision_cid_through_both_callers() -> None:
+    observations = (
+        _backend("grok", ready=True),
+        _backend("codex", ready=True),
+    )
+    auto = select_implementation_provider(observations)
+    assert auto.decision is AutoProviderDecision.GROK
+
+    router_from_auto = decide_router_owned_implementation_provider(
+        tuple(
+            RouterOwnedProviderObservation(
+                provider_id=item.provider_id,
+                ready=item.ready,
+                authenticated=item.authenticated,
+                binary_available=item.binary_available,
+                hard_quota_exhausted=item.hard_quota_exhausted,
+                capacity_latched=item.capacity_latched,
+                request_headroom=item.request_headroom,
+                source=item.source,
+                reason_codes=item.reason_codes,
+            )
+            for item in observations
+        ),
+        preferred_provider=PREFERRED_PROVIDER,
+        fallback_provider=FALLBACK_PROVIDER,
+        secondary_providers=(FALLBACK_PROVIDER,),
+        compatibility_mode=ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+    )
+
+    capability_router = decide_router_owned_implementation_provider(
+        (
+            RouterOwnedProviderObservation(
+                provider_id="grok",
+                ready=True,
+                authenticated=True,
+                binary_available=True,
+                hard_quota_exhausted=False,
+                capacity_latched=False,
+                request_headroom=10,
+                source="test",
+            ),
+            RouterOwnedProviderObservation(
+                provider_id="codex",
+                ready=True,
+                authenticated=True,
+                binary_available=True,
+                hard_quota_exhausted=False,
+                capacity_latched=False,
+                request_headroom=10,
+                source="test",
+            ),
+        ),
+        preferred_provider=PREFERRED_PROVIDER,
+        fallback_provider=FALLBACK_PROVIDER,
+        secondary_providers=(FALLBACK_PROVIDER,),
+        compatibility_mode=ROUTER_OWNED_COMPATIBILITY_LEGACY_AUTO,
+    )
+    assert router_from_auto.decision_cid == capability_router.decision_cid
+
+    adapted = LegacyAutoProviderCompatibilityAdapter.to_selection_fields(
+        router_from_auto
+    )
+    assert adapted["selected_provider"] == auto.selected_provider
+    assert adapted["decision"] == auto.decision.value
+
+
+def test_capability_resolver_consumes_router_decision_for_quota_fallback() -> None:
+    evidence = _evidence(
+        grok=_provider(
+            PREFERRED_PROVIDER,
+            capability=PreferredProviderCapability.QUOTA_EXHAUSTED,
+            request_headroom=0,
+        ),
+        codex=_provider(FALLBACK_PROVIDER),
+    )
+    resolution = resolve_capabilities(evidence)
+    assert resolution.selected_provider is ProviderSelection.CODEX
+    assert resolution.fallback_receipt is not None
+    assert any(
+        str(code).startswith("sha256:")
+        for code in resolution.decisions[0].reason_codes
+    )
+
+
+def test_neutral_capacity_dto_cannot_authorize_dispatch() -> None:
+    observation = NonAuthoritativeProviderCapacityObservation(
+        schema=NON_AUTHORITATIVE_CAPACITY_SCHEMA,
+        observed_at_ms=1,
+        available_worker_capacity=8,
+        worker_limit=8,
+        details={"provider_id": "grok", "healthy": True},
+    )
+    assert observation.available_worker_capacity == 8
+    with pytest.raises(TypeError):
+        # Capacity DTO is not a RouterOwnedProviderDecision and has no
+        # authorization surface; misuse must not silently become policy.
+        decide_router_owned_implementation_provider(observation)  # type: ignore[arg-type]
+
+
+def test_callers_do_not_retain_independent_rank_or_allow_deny_tables() -> None:
+    forbidden_names = {
+        "_PROVIDER_PREFERENCE_RANK",
+        "_soft_rank_key",
+        "_best_secondary",
+    }
+    auto_tree = ast.parse(PROVIDER_AUTO.read_text(encoding="utf-8"))
+    auto_defs = {
+        node.name
+        for node in ast.walk(auto_tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+    auto_assigns = {
+        target.id
+        for node in ast.walk(auto_tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert not (forbidden_names & (auto_defs | auto_assigns))
+
+    auto_src = PROVIDER_AUTO.read_text(encoding="utf-8")
+    assert "decide_router_owned_implementation_provider" in auto_src
+    assert "LegacyAutoProviderCompatibilityAdapter" in auto_src
+
+    capability_src = CAPABILITY_RESOLVER.read_text(encoding="utf-8")
+    assert "decide_router_owned_implementation_provider" in capability_src
+    assert "_PROVIDER_PREFERENCE_RANK" not in capability_src
+
+    router_src = LLM_ROUTER.read_text(encoding="utf-8")
+    assert "def decide_router_owned_implementation_provider" in router_src
+    assert "class RouterOwnedProviderDecision" in router_src
+
+
+def test_policy_context_is_part_of_decision_identity() -> None:
+    observations = (
+        _obs("grok", ready=False, hard_quota_exhausted=True),
+        _obs("codex"),
+    )
+    a = decide_router_owned_implementation_provider(
+        observations,
+        policy_context=RouterOwnedProviderPolicyContext(
+            secondary_providers=("codex",),
+            compatibility_mode=ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+        ),
+    )
+    b = decide_router_owned_implementation_provider(
+        observations,
+        policy_context=RouterOwnedProviderPolicyContext(
+            secondary_providers=("codex", "claude"),
+            compatibility_mode=ROUTER_OWNED_COMPATIBILITY_CANONICAL,
+        ),
+    )
+    assert a.selected_provider == "codex"
+    assert b.selected_provider == "codex"
+    assert a.decision_cid != b.decision_cid


### PR DESCRIPTION
## Summary
- Add sole `RouterOwnedProviderDecision` + `decide_router_owned_implementation_provider` in `llm_router`
- Route `implementation_provider_auto` and `capability_resolver` through that decision (normalize observations only)
- Add ASE3-028 ownership tests; mark board task completed

## Validation
```
python -m pytest test/api/test_implementation_provider_auto.py \
  test/api/test_agent_supervisor_prompt_v3_provider_route.py \
  test/api/test_agent_supervisor_router_owned_provider_decision.py -q
```
29 passed.

Also green: capability_resolver, contract_layering, llm_router agent implementation route suites.