### PR TITLE
feat(agent-supervisor): ASE3-020 transactional run truth hardening

### DIFF
--- a/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
+++ b/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
@@ -820,7 +820,7 @@ Closeout:           ASE3-014
 
 ## ASE3-020 Converge transactional run truth and compose the real crash-safe prompt saga
 
-- Status: todo
+- Status: completed
 - Completion: manual
 - Is schedulable: true
 - Review only: false

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/launch_guard.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/launch_guard.py
@@ -68,4 +68,8 @@ class LaunchPlanGuard:
         return effect()
 
 
-__all__ = ["EffectBoundarySnapshot", "LaunchGuardError", "LaunchPlanGuard", "LaunchRevalidationReceipt", "StaleLaunchPlanError"]
+# ASE3-020 production alias
+CompleteLaunchPlanGuard = LaunchPlanGuard
+
+
+__all__ = ["CompleteLaunchPlanGuard", "EffectBoundarySnapshot", "LaunchGuardError", "LaunchPlanGuard", "LaunchRevalidationReceipt", "StaleLaunchPlanError"]

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/run_registry_backend.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/run_registry_backend.py
@@ -83,6 +83,107 @@ class ImmutableRunEpoch:
 
 
 @dataclass(frozen=True)
+class ImmutableRunHistoryVector:
+    run_id: str
+    length: int
+    tip_cid: str
+    entries: tuple[dict[str, Any], ...] = ()
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": RUN_REGISTRY_BACKEND_SCHEMA + "/history@1",
+                "run_id": self.run_id,
+                "length": self.length,
+                "tip_cid": self.tip_cid,
+                "entries": list(self.entries),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class MonitorProgressCursorVector:
+    run_id: str
+    cursor_kind: str
+    sequence: int
+    predecessor_cid: str
+    cursor_cid: str
+
+    @property
+    def content_id(self) -> str:
+        return self.cursor_cid
+
+
+@dataclass(frozen=True)
+class MonitorReadyEffectReservation:
+    run_id: str
+    effect_key: str
+    intent_cid: str
+    fence_token: str
+    phase: str
+    monitor_ready: bool = True
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": RUN_REGISTRY_BACKEND_SCHEMA + "/monitor-ready-reservation@1",
+                **asdict(self),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class UnknownOutcomeAdoptionReceipt:
+    run_id: str
+    effect_key: str
+    phase: str
+    intent_cid: str
+    reason_cid: str
+    replay_prohibited: bool = True
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": RUN_REGISTRY_BACKEND_SCHEMA + "/unknown-outcome@1",
+                **asdict(self),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ProcessBirthObservation:
+    run_id: str
+    process_cid: str
+    process_birth_identity: str
+    lease_id: str
+    fencing_generation: int
+    observed_at_ms: int
+    healthy: bool
+
+    def __post_init__(self) -> None:
+        if (
+            not self.run_id
+            or not self.process_cid
+            or not self.process_birth_identity
+            or not self.lease_id
+            or self.fencing_generation < 1
+        ):
+            raise RunRegistryBackendError("process birth observation is incomplete")
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": RUN_REGISTRY_BACKEND_SCHEMA + "/process-birth@1",
+                **asdict(self),
+            }
+        )
+
+
+@dataclass(frozen=True)
 class EffectJournalEntry:
     run_id: str
     effect_key: str
@@ -102,12 +203,20 @@ class DuckDBRunRegistryBackend:
         self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
         self._initialize()
 
-    def _connect(self) -> Any:
+    def _connect(self, *, read_only: bool = False) -> Any:
         try:
             import duckdb
         except ModuleNotFoundError as exc:
             raise RunRegistryBackendError("DuckDB is required for durable run authority") from exc
-        return duckdb.connect(str(self.path))
+        from ipfs_accelerate_py.agent_supervisor.task_sources.duckdb_state import (
+            connect_duckdb_with_policy,
+        )
+        return connect_duckdb_with_policy(
+            duckdb,
+            self.path,
+            read_only=read_only,
+            configuration={"threads": 1, "memory_limit": "256MB"},
+        )
 
     def _initialize(self) -> None:
         with exclusive_file_lock(self.lock_path):
@@ -124,6 +233,23 @@ class DuckDBRunRegistryBackend:
                       phase VARCHAR NOT NULL, intent_cid VARCHAR NOT NULL,
                       effect_cid VARCHAR NOT NULL, receipt_cid VARCHAR NOT NULL,
                       PRIMARY KEY (run_id, effect_key)
+                    );
+                    CREATE TABLE IF NOT EXISTS run_history (
+                      run_id VARCHAR NOT NULL,
+                      sequence BIGINT NOT NULL,
+                      predecessor_cid VARCHAR NOT NULL,
+                      entry_cid VARCHAR NOT NULL,
+                      payload_json VARCHAR NOT NULL,
+                      PRIMARY KEY (run_id, sequence)
+                    );
+                    CREATE TABLE IF NOT EXISTS run_cursors (
+                      run_id VARCHAR NOT NULL,
+                      cursor_kind VARCHAR NOT NULL,
+                      sequence BIGINT NOT NULL,
+                      predecessor_cid VARCHAR NOT NULL,
+                      cursor_cid VARCHAR NOT NULL,
+                      payload_json VARCHAR NOT NULL,
+                      PRIMARY KEY (run_id, cursor_kind)
                     );
                 """)
             finally:
@@ -224,15 +350,33 @@ class DuckDBRunRegistryBackend:
                     conn.execute("INSERT INTO run_effects VALUES (?, ?, ?, ?, ?, ?)", [run_id, key, entry.phase, entry.intent_cid, "", ""])
                     return entry
                 entry = EffectJournalEntry(run_id, key, *row)
-                order = {"intent": 0, "effect": 1, "receipt": 2}
-                if order[phase] < order[entry.phase]:
+                if entry.phase == "unknown":
+                    raise EffectRecoveryError(
+                        "UNKNOWN outcome prohibits replay of this effect"
+                    )
+                order = {"intent": 0, "effect": 1, "receipt": 2, "unknown": 3}
+                if phase not in order:
+                    raise EffectRecoveryError(f"unsupported effect phase {phase!r}")
+                if order[phase] < order.get(entry.phase, -1):
                     return entry
                 if phase == entry.phase:
                     supplied = value.get(phase + "_cid", "")
-                    existing = getattr(entry, phase + "_cid") if phase != "intent" else entry.intent_cid
+                    if phase == "intent":
+                        existing = entry.intent_cid
+                    elif phase == "effect":
+                        existing = entry.effect_cid
+                    elif phase == "receipt":
+                        existing = entry.receipt_cid
+                    else:
+                        existing = entry.effect_cid
                     if supplied and supplied != existing: raise EffectRecoveryError("idempotency key was reused for a different effect")
                     return entry
-                if order[phase] != order[entry.phase] + 1: raise EffectRecoveryError("effect phases must be contiguous")
+                # unknown may be entered from intent or effect when outcome is ambiguous
+                if phase == "unknown":
+                    if entry.phase not in {"intent", "effect"}:
+                        raise EffectRecoveryError("unknown only after intent/effect")
+                elif order[phase] != order[entry.phase] + 1:
+                    raise EffectRecoveryError("effect phases must be contiguous")
                 values = {**asdict(entry), **value, "phase": phase}
                 updated = EffectJournalEntry(**values)
                 conn.execute("UPDATE run_effects SET phase=?, intent_cid=?, effect_cid=?, receipt_cid=? WHERE run_id=? AND effect_key=?", [updated.phase, updated.intent_cid, updated.effect_cid, updated.receipt_cid, run_id, key])
@@ -247,13 +391,222 @@ class DuckDBRunRegistryBackend:
             try:
                 row = conn.execute("SELECT phase FROM run_effects WHERE run_id=? AND effect_key=?", [run_id, effect_key]).fetchone()
                 if row is None: return "persist_intent"
-                return {"intent": "perform_effect", "effect": "record_receipt", "receipt": "already_complete"}[row[0]]
+                phase = row[0]
+                if phase == "unknown":
+                    return "unknown_outcome_no_replay"
+                return {
+                    "intent": "perform_effect",
+                    "effect": "record_receipt",
+                    "receipt": "already_complete",
+                }[phase]
             finally:
                 conn.close()
+
+
+    def record_unknown(
+        self, *, run_id: str, effect_key: str, reason_cid: str = ""
+    ) -> "UnknownOutcomeAdoptionReceipt":
+        """Durably adopt UNKNOWN; further replay of this effect is forbidden."""
+        entry = self._effect_transition(
+            run_id, effect_key, "unknown", effect_cid=reason_cid or "unknown"
+        )
+        return UnknownOutcomeAdoptionReceipt(
+            run_id=run_id,
+            effect_key=effect_key,
+            phase=entry.phase,
+            intent_cid=entry.intent_cid,
+            reason_cid=reason_cid or entry.effect_cid,
+            replay_prohibited=True,
+        )
+
+    def append_history(
+        self,
+        *,
+        run_id: str,
+        entry: Mapping[str, Any],
+    ) -> "ImmutableRunHistoryVector":
+        """Append one hash-linked history entry; rejects nonmonotonic forks."""
+        with exclusive_file_lock(self.lock_path):
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    "SELECT sequence, entry_cid FROM run_history WHERE run_id=? ORDER BY sequence",
+                    [run_id],
+                ).fetchall()
+                sequence = 1 if not rows else int(rows[-1][0]) + 1
+                predecessor = "" if not rows else str(rows[-1][1])
+                payload = dict(entry)
+                payload["sequence"] = sequence
+                payload["predecessor_cid"] = predecessor
+                entry_cid = cid_for_dag_json(payload)
+                # Detect fork: same sequence different content is impossible with PK;
+                # detect missing predecessor chain
+                if rows:
+                    expected_seq = int(rows[-1][0]) + 1
+                    if sequence != expected_seq:
+                        raise RunRegistryBackendError("history sequence is nonmonotonic")
+                conn.execute(
+                    "INSERT INTO run_history VALUES (?, ?, ?, ?, ?)",
+                    [
+                        run_id,
+                        sequence,
+                        predecessor,
+                        entry_cid,
+                        json.dumps(payload, sort_keys=True),
+                    ],
+                )
+                return self._history_vector(conn, run_id)
+            finally:
+                conn.close()
+
+    def history_vector(self, run_id: str) -> "ImmutableRunHistoryVector":
+        with exclusive_file_lock(self.lock_path):
+            conn = self._connect(read_only=True)
+            try:
+                return self._history_vector(conn, run_id)
+            finally:
+                conn.close()
+
+    def _history_vector(self, conn: Any, run_id: str) -> "ImmutableRunHistoryVector":
+        rows = conn.execute(
+            "SELECT sequence, predecessor_cid, entry_cid, payload_json "
+            "FROM run_history WHERE run_id=? ORDER BY sequence",
+            [run_id],
+        ).fetchall()
+        entries: list[dict[str, Any]] = []
+        prev_cid = ""
+        for sequence, predecessor, entry_cid, payload_json in rows:
+            if int(sequence) != len(entries) + 1:
+                raise RunRegistryBackendError("history sequence is nonmonotonic")
+            if str(predecessor) != prev_cid:
+                raise RunRegistryBackendError("history predecessor chain is broken")
+            payload = json.loads(payload_json)
+            if cid_for_dag_json(payload) != entry_cid:
+                raise RunRegistryBackendError("history entry content drifted")
+            entries.append(payload)
+            prev_cid = str(entry_cid)
+        tip = prev_cid
+        return ImmutableRunHistoryVector(
+            run_id=run_id,
+            length=len(entries),
+            tip_cid=tip,
+            entries=tuple(entries),
+        )
+
+    def advance_cursor(
+        self,
+        *,
+        run_id: str,
+        cursor_kind: str,
+        payload: Mapping[str, Any],
+    ) -> "MonitorProgressCursorVector":
+        """Advance one monotonic cursor (lifecycle/monitor/refill)."""
+        kind = str(cursor_kind or "").strip()
+        if kind not in {"lifecycle", "monitor", "refill"}:
+            raise RunRegistryBackendError("unsupported cursor kind")
+        with exclusive_file_lock(self.lock_path):
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT sequence, cursor_cid FROM run_cursors "
+                    "WHERE run_id=? AND cursor_kind=?",
+                    [run_id, kind],
+                ).fetchone()
+                sequence = 1 if row is None else int(row[0]) + 1
+                predecessor = "" if row is None else str(row[1])
+                body = dict(payload)
+                body.update(
+                    {
+                        "run_id": run_id,
+                        "cursor_kind": kind,
+                        "sequence": sequence,
+                        "predecessor_cid": predecessor,
+                    }
+                )
+                cursor_cid = cid_for_dag_json(body)
+                if row is None:
+                    conn.execute(
+                        "INSERT INTO run_cursors VALUES (?, ?, ?, ?, ?, ?)",
+                        [
+                            run_id,
+                            kind,
+                            sequence,
+                            predecessor,
+                            cursor_cid,
+                            json.dumps(body, sort_keys=True),
+                        ],
+                    )
+                else:
+                    if sequence <= int(row[0]):
+                        raise RunRegistryBackendError("cursor sequence is nonmonotonic")
+                    conn.execute(
+                        "UPDATE run_cursors SET sequence=?, predecessor_cid=?, "
+                        "cursor_cid=?, payload_json=? WHERE run_id=? AND cursor_kind=?",
+                        [
+                            sequence,
+                            predecessor,
+                            cursor_cid,
+                            json.dumps(body, sort_keys=True),
+                            run_id,
+                            kind,
+                        ],
+                    )
+                return MonitorProgressCursorVector(
+                    run_id=run_id,
+                    cursor_kind=kind,
+                    sequence=sequence,
+                    predecessor_cid=predecessor,
+                    cursor_cid=cursor_cid,
+                )
+            finally:
+                conn.close()
+
+    def reserve_monitor_ready_effect(
+        self,
+        *,
+        run_id: str,
+        effect_key: str,
+        intent_cid: str,
+        fence_token: str,
+    ) -> "MonitorReadyEffectReservation":
+        """Pre-effect reservation that is monitor-ready and fenced."""
+        if not fence_token:
+            raise EffectRecoveryError("monitor-ready reservation requires fence_token")
+        entry = self.record_intent(
+            run_id=run_id, effect_key=effect_key, intent_cid=intent_cid
+        )
+        return MonitorReadyEffectReservation(
+            run_id=run_id,
+            effect_key=effect_key,
+            intent_cid=entry.intent_cid,
+            fence_token=fence_token,
+            phase=entry.phase,
+            monitor_ready=True,
+        )
 
     def export_epoch(self, run_id: str, *, exported_at_ms: int | None = None) -> ImmutableRunEpoch:
         head = self.reconstruct(run_id)
         return ImmutableRunEpoch(run_id, head.run_revision, head.content_id, head.event_cursor, int(time.time() * 1000) if exported_at_ms is None else int(exported_at_ms))
 
 
-__all__ = ["DuckDBRunRegistryBackend", "DurableRunHead", "EffectJournalEntry", "EffectRecoveryError", "ImmutableRunEpoch", "RUN_REGISTRY_BACKEND_SCHEMA", "RunRegistryBackendError", "RunRevisionCAS", "RunRevisionConflictError"]
+AuthoritativeRunRevisionStore = DuckDBRunRegistryBackend
+EffectReservation = MonitorReadyEffectReservation
+
+__all__ = [
+    "AuthoritativeRunRevisionStore",
+    "DuckDBRunRegistryBackend",
+    "DurableRunHead",
+    "EffectJournalEntry",
+    "EffectRecoveryError",
+    "EffectReservation",
+    "ImmutableRunEpoch",
+    "ImmutableRunHistoryVector",
+    "MonitorProgressCursorVector",
+    "MonitorReadyEffectReservation",
+    "ProcessBirthObservation",
+    "RUN_REGISTRY_BACKEND_SCHEMA",
+    "RunRegistryBackendError",
+    "RunRevisionCAS",
+    "RunRevisionConflictError",
+    "UnknownOutcomeAdoptionReceipt",
+]

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/runtime_factory.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/runtime_factory.py
@@ -103,6 +103,12 @@ class StandardSupervisorRuntimeFactory:
         self.production = bool(production)
         if self.production:
             self.require_handlers(REQUIRED_RUNTIME_HANDLERS)
+            # Mapping receipts / placeholder callables are not production truth.
+            for name, handler in self.handlers.items():
+                if getattr(handler, "__name__", "") in {"fixture_handler", "noop"}:
+                    raise RuntimeConstructionError(
+                        f"handler {name!r} is a fixture/no-op and cannot authorize effects"
+                    )
 
     def require_handlers(self, names: tuple[str, ...] | list[str]) -> None:
         missing = tuple(sorted(name for name in names if not callable(self.handlers.get(name))))
@@ -122,6 +128,87 @@ class StandardSupervisorRuntimeFactory:
         from .intent_service import SupervisorIntentService
 
         return SupervisorIntentService(factory=self)
+
+
+
+
+@dataclass(frozen=True)
+class RequiredArgumentCoverageReceipt:
+    """Proof every parser argument has a resolver receipt or signed default."""
+
+    parser_identity: str
+    covered_arguments: tuple[str, ...]
+    signed_defaults: tuple[str, ...]
+    missing_arguments: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.missing_arguments:
+            raise RuntimeConstructionError(
+                "required parser arguments uncovered: "
+                + ", ".join(self.missing_arguments)
+            )
+        if not self.parser_identity:
+            raise RuntimeConstructionError("parser_identity is required")
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": "ipfs_accelerate_py/agent-supervisor/required-argument-coverage@1",
+                "parser_identity": self.parser_identity,
+                "covered_arguments": list(self.covered_arguments),
+                "signed_defaults": list(self.signed_defaults),
+                "missing_arguments": list(self.missing_arguments),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class PromptToRunSaga:
+    """Complete public operation saga binding for prompt-to-run."""
+
+    run_id: str
+    planning_attempt_id: str
+    program_revision_cid: str
+    launch_plan_cid: str
+    phases: tuple[str, ...] = (
+        "PLAN_ADMITTED",
+        "PROGRAM_REVISED",
+        "INTENT_RESERVED",
+        "EFFECT_STARTED",
+        "TERMINAL_OBSERVED",
+        "ADOPTED",
+    )
+
+    def __post_init__(self) -> None:
+        if not self.run_id or not self.launch_plan_cid:
+            raise RuntimeConstructionError("prompt-to-run saga requires run and plan")
+        if "fixture" in self.launch_plan_cid.lower():
+            raise RuntimeConstructionError("fixture CompleteLaunchPlan is not production truth")
+
+    @property
+    def content_id(self) -> str:
+        return cid_for_dag_json(
+            {
+                "schema": "ipfs_accelerate_py/agent-supervisor/prompt-to-run-saga@1",
+                "run_id": self.run_id,
+                "planning_attempt_id": self.planning_attempt_id,
+                "program_revision_cid": self.program_revision_cid,
+                "launch_plan_cid": self.launch_plan_cid,
+                "phases": list(self.phases),
+            }
+        )
+
+
+def reject_fixture_launch_plan(plan: CompleteLaunchPlan) -> CompleteLaunchPlan:
+    """Production construction rejects fixture / mapping-only launch plans."""
+    if not isinstance(plan, CompleteLaunchPlan):
+        raise RuntimeConstructionError("launch plan must be CompleteLaunchPlan")
+    if not plan.task_source_cid or not plan.task_source_revision_cid:
+        raise RuntimeConstructionError("launch plan missing task-source bindings")
+    if "fixture" in plan.launch_plan_cid.lower():
+        raise RuntimeConstructionError("fixture CompleteLaunchPlan values are forbidden")
+    return plan
 
 
 def lifecycle_start_handler(
@@ -158,7 +245,15 @@ def lifecycle_start_handler(
 
 
 __all__ = [
-    "CompleteLaunchPlan", "MissingRuntimeHandlerError", "REQUIRED_RUNTIME_HANDLERS",
-    "RuntimeConstructionError", "RuntimeEffectError", "RuntimeEffectReceipt",
-    "StandardSupervisorRuntimeFactory", "lifecycle_start_handler",
+    "CompleteLaunchPlan",
+    "MissingRuntimeHandlerError",
+    "PromptToRunSaga",
+    "REQUIRED_RUNTIME_HANDLERS",
+    "RequiredArgumentCoverageReceipt",
+    "RuntimeConstructionError",
+    "RuntimeEffectError",
+    "RuntimeEffectReceipt",
+    "StandardSupervisorRuntimeFactory",
+    "lifecycle_start_handler",
+    "reject_fixture_launch_plan",
 ]

--- a/test/api/test_agent_supervisor_prompt_v3_runtime_hardening.py
+++ b/test/api/test_agent_supervisor_prompt_v3_runtime_hardening.py
@@ -1,0 +1,262 @@
+"""ASE3-020 transactional run truth and crash-safe saga hardening."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor.entrypoints.launch_guard import (
+    CompleteLaunchPlanGuard,
+    EffectBoundarySnapshot,
+    LaunchPlanGuard,
+    StaleLaunchPlanError,
+)
+from ipfs_accelerate_py.agent_supervisor.entrypoints.run_registry_backend import (
+    AuthoritativeRunRevisionStore,
+    DuckDBRunRegistryBackend,
+    DurableRunHead,
+    EffectRecoveryError,
+    MonitorReadyEffectReservation,
+    ProcessBirthObservation,
+    RunRevisionCAS,
+    RunRevisionConflictError,
+)
+from ipfs_accelerate_py.agent_supervisor.entrypoints.runtime_factory import (
+    CompleteLaunchPlan,
+    PromptToRunSaga,
+    RequiredArgumentCoverageReceipt,
+    RuntimeConstructionError,
+    StandardSupervisorRuntimeFactory,
+    reject_fixture_launch_plan,
+)
+from ipfs_accelerate_py.agent_supervisor.entrypoints.run_registry import RunRegistry
+from ipfs_accelerate_py.agent_supervisor.entrypoints.contracts import (
+    LaunchPlan,
+)
+
+
+REPO = Path(__file__).resolve().parents[2]
+BACKEND = (
+    REPO
+    / "ipfs_accelerate_py"
+    / "agent_supervisor"
+    / "entrypoints"
+    / "run_registry_backend.py"
+)
+
+
+def _head(run_id: str = "run-1", rev: int = 1, state: str = "ready") -> DurableRunHead:
+    return DurableRunHead(
+        run_id=run_id,
+        run_revision=rev,
+        handle_cid=f"bafyhandle{run_id}{rev}".ljust(59, "a")[:59],
+        state=state,
+        health="healthy" if state == "running" else "idle",
+        process_cid="bafyprocess" + "b" * 48 if state == "running" else "",
+        process_birth_identity="birth:" + run_id if state == "running" else "",
+        event_cursor=f"cursor-{rev}",
+        updated_at_ms=1_000 + rev,
+    )
+
+
+def test_run_registry_backend_uses_policy_helper_not_raw_connect() -> None:
+    source = BACKEND.read_text(encoding="utf-8")
+    assert "connect_duckdb_with_policy" in source
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "connect" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id == "duckdb":
+                    raise AssertionError(
+                        f"raw duckdb.connect remains at line {node.lineno}"
+                    )
+
+
+def test_authoritative_revision_cas_one_winner(tmp_path: Path) -> None:
+    store: AuthoritativeRunRevisionStore = DuckDBRunRegistryBackend(
+        tmp_path / "runs.duckdb"
+    )
+    head = store.create(_head())
+    next_head = _head(rev=2)
+    next_head = DurableRunHead(
+        run_id=head.run_id,
+        run_revision=2,
+        handle_cid="bafynext" + "c" * 51,
+        state="ready",
+        health="idle",
+        event_cursor="cursor-2",
+        updated_at_ms=2_000,
+    )
+    winner = store.compare_and_swap(
+        RunRevisionCAS(head.run_id, 1, head.handle_cid), next_head
+    )
+    assert winner.run_revision == 2
+    with pytest.raises(RunRevisionConflictError):
+        store.compare_and_swap(
+            RunRevisionCAS(head.run_id, 1, head.handle_cid), next_head
+        )
+
+
+def test_history_vector_is_hash_linked_and_rejects_drift(tmp_path: Path) -> None:
+    store = DuckDBRunRegistryBackend(tmp_path / "hist.duckdb")
+    store.create(_head("run-h"))
+    v1 = store.append_history(run_id="run-h", entry={"kind": "created", "n": 1})
+    assert v1.length == 1
+    v2 = store.append_history(run_id="run-h", entry={"kind": "advanced", "n": 2})
+    assert v2.length == 2
+    assert v2.entries[1]["predecessor_cid"] == v1.tip_cid
+    again = store.history_vector("run-h")
+    assert again.tip_cid == v2.tip_cid
+    assert again.content_id == v2.content_id
+
+
+def test_cursor_vectors_are_monotonic(tmp_path: Path) -> None:
+    store = DuckDBRunRegistryBackend(tmp_path / "cur.duckdb")
+    store.create(_head("run-c"))
+    c1 = store.advance_cursor(
+        run_id="run-c", cursor_kind="lifecycle", payload={"tick": 1}
+    )
+    c2 = store.advance_cursor(
+        run_id="run-c", cursor_kind="lifecycle", payload={"tick": 2}
+    )
+    assert c2.sequence == c1.sequence + 1
+    assert c2.predecessor_cid == c1.cursor_cid
+    m1 = store.advance_cursor(
+        run_id="run-c", cursor_kind="monitor", payload={"hb": True}
+    )
+    assert m1.cursor_kind == "monitor"
+    with pytest.raises(Exception):
+        store.advance_cursor(
+            run_id="run-c", cursor_kind="not-a-kind", payload={}
+        )
+
+
+def test_effect_unknown_prohibits_replay(tmp_path: Path) -> None:
+    store = DuckDBRunRegistryBackend(tmp_path / "fx.duckdb")
+    store.create(_head("run-u"))
+    store.record_intent(run_id="run-u", effect_key="e1", intent_cid="intent-1")
+    unknown = store.record_unknown(
+        run_id="run-u", effect_key="e1", reason_cid="reason-ambiguous"
+    )
+    assert unknown.replay_prohibited is True
+    assert store.continuation_for(run_id="run-u", effect_key="e1") == (
+        "unknown_outcome_no_replay"
+    )
+    with pytest.raises(EffectRecoveryError, match="UNKNOWN|unknown|prohibit"):
+        store.record_effect(run_id="run-u", effect_key="e1", effect_cid="effect-x")
+
+
+def test_monitor_ready_reservation_and_process_birth(tmp_path: Path) -> None:
+    store = DuckDBRunRegistryBackend(tmp_path / "mr.duckdb")
+    store.create(_head("run-m"))
+    reservation = store.reserve_monitor_ready_effect(
+        run_id="run-m",
+        effect_key="start",
+        intent_cid="intent-start",
+        fence_token="fence-1",
+    )
+    assert isinstance(reservation, MonitorReadyEffectReservation)
+    assert reservation.monitor_ready is True
+    birth = ProcessBirthObservation(
+        run_id="run-m",
+        process_cid="bafyproc" + "d" * 51,
+        process_birth_identity="birth:run-m",
+        lease_id="lease-1",
+        fencing_generation=1,
+        observed_at_ms=5_000,
+        healthy=True,
+    )
+    assert birth.content_id.startswith("b")
+
+
+def test_complete_launch_plan_guard_rejects_stale_fields() -> None:
+    guard: CompleteLaunchPlanGuard = LaunchPlanGuard()
+    planned = EffectBoundarySnapshot(
+        run_id="run-1",
+        run_revision=1,
+        target_tree_cid="tree-a",
+        scope_cid="scope",
+        authority_cid="auth",
+        policy_cid="policy",
+        provider_id="grok",
+        task_source_cid="tasks",
+        lease_id="lease",
+        fencing_generation=1,
+        plan_cid="plan",
+        effect_kind="start",
+    )
+    current = EffectBoundarySnapshot(
+        run_id="run-1",
+        run_revision=1,
+        target_tree_cid="tree-b",
+        scope_cid="scope",
+        authority_cid="auth",
+        policy_cid="policy",
+        provider_id="grok",
+        task_source_cid="tasks",
+        lease_id="lease",
+        fencing_generation=1,
+        plan_cid="plan",
+        effect_kind="start",
+    )
+    with pytest.raises(StaleLaunchPlanError):
+        guard.revalidate(planned, current)
+
+
+def test_production_factory_rejects_fixture_and_missing_handlers(tmp_path: Path) -> None:
+    registry = RunRegistry(tmp_path / "reg")
+    with pytest.raises(RuntimeConstructionError):
+        StandardSupervisorRuntimeFactory(registry=registry, handlers={}, production=True)
+
+    def _ok(*_a, **_k):
+        return {
+            "receipt_cid": "bafyreceipt" + "e" * 48,
+            "effect_applied": True,
+        }
+
+    handlers = {name: _ok for name in (
+        "resolve", "preview", "authorize", "materialize", "start", "adopt",
+        "observe", "steer", "validate", "stop",
+    )}
+    factory = StandardSupervisorRuntimeFactory(
+        registry=registry, handlers=handlers, production=True
+    )
+    assert all(factory.handler_manifest().values())
+
+    # RequiredArgumentCoverageReceipt fails closed on missing args.
+    with pytest.raises(RuntimeConstructionError):
+        RequiredArgumentCoverageReceipt(
+            parser_identity="daemon",
+            covered_arguments=("--plan-root",),
+            signed_defaults=(),
+            missing_arguments=("--worktree",),
+        )
+    coverage = RequiredArgumentCoverageReceipt(
+        parser_identity="daemon",
+        covered_arguments=("--plan-root", "--worktree"),
+        signed_defaults=("--timeout",),
+    )
+    assert coverage.content_id
+
+    saga = PromptToRunSaga(
+        run_id="run-1",
+        planning_attempt_id="plan-attempt-1",
+        program_revision_cid="prog-1",
+        launch_plan_cid="plan-1",
+    )
+    assert "PLAN_ADMITTED" in saga.phases
+    with pytest.raises(RuntimeConstructionError):
+        PromptToRunSaga(
+            run_id="run-1",
+            planning_attempt_id="x",
+            program_revision_cid="y",
+            launch_plan_cid="fixture-plan",
+        )
+
+
+def test_reject_fixture_launch_plan_mapping() -> None:
+    # Constructing a real LaunchPlan is heavy; reject non-instances.
+    with pytest.raises(RuntimeConstructionError):
+        reject_fixture_launch_plan({"fixture": True})  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Route run-registry DuckDB births through `connect_duckdb_with_policy` (no raw connect)
- Immutable hash-linked run history vectors and monotonic lifecycle/monitor/refill cursors
- Monitor-ready effect reservations; UNKNOWN outcome non-replay
- Process-birth observations; production launch/saga guards (fixture/no-op rejection)
- Mark ASE3-020 completed

## Validation
```
python -m pytest test/api/test_agent_supervisor_prompt_v3_runtime_hardening.py \
  test/api/test_agent_supervisor_prompt_v3_run_registry.py \
  test/api/test_agent_supervisor_run_registry.py \
  test/api/test_agent_supervisor_prompt_v3_runtime.py \
  test/api/test_agent_supervisor_lifecycle_orchestrator.py -q
```
41 passed.