### PR TITLE
feat(agent-supervisor): ASE3-010 CLI and ASE3-011 MCP prompt lifecycle

### DIFF
--- a/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
+++ b/docs/architecture/agent_supervisor_prompt_only_self_improvement_v3.todo.md
@@ -287,7 +287,7 @@ Closeout:           ASE3-014
 
 ## ASE3-010 Add the prompt-first product CLI and console registration
 
-- Status: todo
+- Status: completed
 - Completion: manual
 - Is schedulable: true
 - Review only: false
@@ -311,7 +311,7 @@ Closeout:           ASE3-014
 
 ## ASE3-011 Register equivalent MCP and MCP++ prompt lifecycle tools
 
-- Status: todo
+- Status: completed
 - Completion: manual
 - Is schedulable: true
 - Review only: false

--- a/ipfs_accelerate_py/agent_supervisor/entrypoints/cli.py
+++ b/ipfs_accelerate_py/agent_supervisor/entrypoints/cli.py
@@ -1,0 +1,362 @@
+"""Prompt-first product CLI: ``ipfs-accelerate supervisor …`` (ASE3-010).
+
+Registration is parser-only and cold-safe: help/parse paths do not import the
+production facade, open DuckDB, or start processes. Dispatch lazily composes
+:class:`~.facade.Supervisor`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, TextIO
+
+# Stable exit codes for typed facade outcomes.
+EXIT_SUCCESS = 0
+EXIT_UNAVAILABLE = 1
+EXIT_INVALID = 2
+EXIT_AMBIGUITY = 3
+EXIT_CONFIG = 4
+
+SUPERVISOR_COMMANDS: Final[tuple[str, ...]] = (
+    "run",
+    "preview",
+    "steer",
+    "status",
+    "follow",
+    "explain",
+    "doctor",
+    "init",
+)
+
+
+class SupervisorCLIError(RuntimeError):
+    """Typed CLI failure before facade dispatch."""
+
+
+def register_supervisor_cli(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> argparse.ArgumentParser:
+    """Register the lightweight ``supervisor`` group (parser-only)."""
+
+    group = subparsers.add_parser(
+        "supervisor",
+        help="Prompt-first supervisor lifecycle (run/preview/steer/status/…).",
+        description=(
+            "Product path for prompt-only self-improvement. Normal run/preview "
+            "input is a prompt; advanced flags are optional authorized overrides."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            '  ipfs-accelerate supervisor run "Improve validation gates"\n'
+            "  ipfs-accelerate supervisor preview --prompt-file intent.txt\n"
+            "  ipfs-accelerate supervisor status --run-id RUN --output-json\n"
+            "  ipfs-accelerate supervisor init --consent\n"
+        ),
+    )
+    commands = group.add_subparsers(
+        dest="supervisor_command",
+        metavar="COMMAND",
+        help="Supervisor lifecycle operation.",
+    )
+
+    def _add_common(child: argparse.ArgumentParser) -> None:
+        child.add_argument(
+            "--repository",
+            help="Repository root (defaults to nearest enclosing Git root).",
+        )
+        child.add_argument(
+            "--state-root",
+            help="Optional state root override.",
+        )
+        child.add_argument(
+            "--output-json",
+            action="store_true",
+            help="Emit a structured JSON envelope on stdout.",
+        )
+
+    def _add_prompt(child: argparse.ArgumentParser, *, required: bool = False) -> None:
+        child.add_argument(
+            "prompt",
+            nargs="?" if not required else None,
+            help="Prompt text (positional).",
+        )
+        child.add_argument(
+            "--prompt-file",
+            type=Path,
+            help="Read prompt body from a file (preferred over argv for secrets).",
+        )
+        child.add_argument(
+            "--prompt-stdin",
+            action="store_true",
+            help="Read prompt body from stdin (bounded).",
+        )
+
+    run_p = commands.add_parser("run", help="Start or resume a durable run from a prompt.")
+    _add_common(run_p)
+    _add_prompt(run_p)
+
+    preview_p = commands.add_parser(
+        "preview", help="Preview resolution without authorizing effects."
+    )
+    _add_common(preview_p)
+    _add_prompt(preview_p)
+
+    steer_p = commands.add_parser("steer", help="Steer an existing run with a prompt.")
+    _add_common(steer_p)
+    steer_p.add_argument("--run-id", required=True, help="Exact run identifier.")
+    _add_prompt(steer_p)
+
+    status_p = commands.add_parser("status", help="Observe run status.")
+    _add_common(status_p)
+    status_p.add_argument("--run-id", help="Run id (optional when unique).")
+
+    follow_p = commands.add_parser("follow", help="Follow run event cursor.")
+    _add_common(follow_p)
+    follow_p.add_argument("--run-id", help="Run id (optional when unique).")
+
+    explain_p = commands.add_parser("explain", help="Body-free explanation of a run.")
+    _add_common(explain_p)
+    explain_p.add_argument("--run-id", help="Run id (optional when unique).")
+
+    doctor_p = commands.add_parser(
+        "doctor", help="Doctor snapshot (detection does not grant restart)."
+    )
+    _add_common(doctor_p)
+    doctor_p.add_argument("--run-id", help="Run id (optional when unique).")
+
+    init_p = commands.add_parser(
+        "init", help="One-time local profile bootstrap (requires --consent)."
+    )
+    _add_common(init_p)
+    init_p.add_argument(
+        "--consent",
+        action="store_true",
+        help="Explicit consent for local initialization.",
+    )
+    return group
+
+
+def supervisor_cli_discovery_manifest() -> dict[str, Any]:
+    """Static vocabulary for help/conformance without constructing services."""
+
+    return {
+        "schema": "ipfs_accelerate_py.agent_supervisor.supervisor-cli-discovery@1",
+        "group": "supervisor",
+        "commands": list(SUPERVISOR_COMMANDS),
+        "console_entry": "ipfs-accelerate",
+        "cold_help": True,
+        "side_effect_free_parse": True,
+    }
+
+
+def _resolve_prompt(args: argparse.Namespace, *, stdin: TextIO = sys.stdin) -> str:
+    sources = [
+        bool(getattr(args, "prompt", None)),
+        bool(getattr(args, "prompt_file", None)),
+        bool(getattr(args, "prompt_stdin", False)),
+    ]
+    if sum(1 for item in sources if item) > 1:
+        raise SupervisorCLIError("supply exactly one of prompt, --prompt-file, or --prompt-stdin")
+    if getattr(args, "prompt_file", None) is not None:
+        path = Path(args.prompt_file)
+        if not path.is_file():
+            raise SupervisorCLIError(f"prompt file not found: {path}")
+        text = path.read_text(encoding="utf-8")
+    elif getattr(args, "prompt_stdin", False):
+        text = stdin.read(1_048_576)
+    else:
+        text = str(getattr(args, "prompt", None) or "")
+    if not text or not str(text).strip():
+        raise SupervisorCLIError("prompt must be a non-empty string")
+    return str(text)
+
+
+def _envelope(
+    *,
+    ok: bool,
+    command: str,
+    payload: Mapping[str, Any] | None = None,
+    error: str | None = None,
+    error_code: str | None = None,
+    composition_cid: str | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema": "ipfs_accelerate_py.agent_supervisor.supervisor-cli-result@1",
+        "ok": ok,
+        "command": command,
+    }
+    if composition_cid:
+        body["composition_cid"] = composition_cid
+    if payload is not None:
+        body["result"] = dict(payload)
+    if error is not None:
+        body["error"] = error
+    if error_code is not None:
+        body["error_code"] = error_code
+    return body
+
+
+def _emit(
+    payload: Mapping[str, Any],
+    *,
+    output_json: bool,
+    stream: TextIO = sys.stdout,
+) -> None:
+    if output_json:
+        stream.write(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+        return
+    if payload.get("ok"):
+        result = payload.get("result") or {}
+        if isinstance(result, Mapping):
+            summary = result.get("summary") or result.get("run_id") or "ok"
+            stream.write(f"{summary}\n")
+            if result.get("run_id"):
+                stream.write(f"run_id={result['run_id']}\n")
+            if payload.get("composition_cid"):
+                stream.write(f"composition_cid={payload['composition_cid']}\n")
+        else:
+            stream.write("ok\n")
+    else:
+        stream.write(f"error: {payload.get('error') or 'failed'}\n")
+
+
+def run_supervisor_cli(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    stdin: TextIO = sys.stdin,
+    supervisor: Any = None,
+) -> int:
+    """Dispatch one supervisor command through the production facade."""
+
+    command = getattr(args, "supervisor_command", None)
+    output_json = bool(getattr(args, "output_json", False))
+    if not command:
+        # Caller should have printed help; treat as invalid usage.
+        return EXIT_INVALID
+
+    try:
+        if supervisor is None:
+            from .facade import Supervisor
+
+            if command == "init":
+                receipt = Supervisor.init_local(
+                    repository=getattr(args, "repository", None),
+                    consent=bool(getattr(args, "consent", False)),
+                )
+                env = _envelope(
+                    ok=True,
+                    command=command,
+                    payload=dict(receipt) if isinstance(receipt, Mapping) else {"receipt": receipt},
+                )
+                _emit(env, output_json=output_json, stream=stdout)
+                return EXIT_SUCCESS
+
+            supervisor = Supervisor.open(
+                repository=getattr(args, "repository", None),
+                state_root=getattr(args, "state_root", None),
+            )
+
+        composition_cid = getattr(supervisor, "composition_cid", None)
+
+        if command == "run":
+            prompt = _resolve_prompt(args, stdin=stdin)
+            run = supervisor.run(prompt)
+            payload = {
+                "run_id": run.run_id,
+                "state": run.state,
+                "health": run.health,
+                "event_cursor": run.event_cursor,
+                "effect_receipt_cids": list(run.effect_receipt_cids),
+                "summary": f"run started run_id={run.run_id}",
+            }
+        elif command == "preview":
+            prompt = _resolve_prompt(args, stdin=stdin)
+            obs = supervisor.preview(prompt)
+            payload = obs.to_dict()
+        elif command == "steer":
+            prompt = _resolve_prompt(args, stdin=stdin)
+            obs = supervisor.steer(str(args.run_id), prompt)
+            payload = obs.to_dict()
+        elif command == "status":
+            obs = supervisor.status(getattr(args, "run_id", None))
+            payload = obs.to_dict()
+        elif command == "follow":
+            events = []
+            for obs in supervisor.follow(getattr(args, "run_id", None)):
+                events.append(obs.to_dict())
+            payload = {"events": events, "summary": f"followed {len(events)} event(s)"}
+        elif command == "explain":
+            obs = supervisor.explain(getattr(args, "run_id", None))
+            payload = obs.to_dict()
+        elif command == "doctor":
+            obs = supervisor.doctor(getattr(args, "run_id", None))
+            payload = obs.to_dict()
+        elif command == "init":
+            # Handled above when supervisor is None; injectable path:
+            from .facade import Supervisor as _Supervisor
+
+            receipt = _Supervisor.init_local(
+                repository=getattr(args, "repository", None),
+                consent=bool(getattr(args, "consent", False)),
+            )
+            payload = dict(receipt) if isinstance(receipt, Mapping) else {"receipt": receipt}
+            composition_cid = None
+        else:
+            raise SupervisorCLIError(f"unknown supervisor command: {command}")
+
+        env = _envelope(
+            ok=True,
+            command=command,
+            payload=payload,
+            composition_cid=str(composition_cid) if composition_cid else None,
+        )
+        _emit(env, output_json=output_json, stream=stdout)
+        return EXIT_SUCCESS
+    except SupervisorCLIError as exc:
+        env = _envelope(ok=False, command=str(command), error=str(exc), error_code="invalid")
+        _emit(env, output_json=output_json, stream=stderr if not output_json else stdout)
+        return EXIT_INVALID
+    except Exception as exc:  # map typed facade errors
+        from .facade import (
+            SupervisorAmbiguityError,
+            SupervisorConfigurationError,
+            SupervisorUnavailableError,
+        )
+
+        if isinstance(exc, SupervisorConfigurationError):
+            code, exit_code = "configuration", EXIT_CONFIG
+        elif isinstance(exc, SupervisorAmbiguityError):
+            code, exit_code = "ambiguity", EXIT_AMBIGUITY
+        elif isinstance(exc, SupervisorUnavailableError):
+            code, exit_code = "unavailable", EXIT_UNAVAILABLE
+        else:
+            code, exit_code = "error", EXIT_UNAVAILABLE
+        env = _envelope(
+            ok=False,
+            command=str(command),
+            error=str(exc),
+            error_code=code,
+        )
+        _emit(env, output_json=output_json, stream=stderr if not output_json else stdout)
+        return exit_code
+
+
+__all__ = [
+    "EXIT_AMBIGUITY",
+    "EXIT_CONFIG",
+    "EXIT_INVALID",
+    "EXIT_SUCCESS",
+    "EXIT_UNAVAILABLE",
+    "SUPERVISOR_COMMANDS",
+    "SupervisorCLIError",
+    "register_supervisor_cli",
+    "run_supervisor_cli",
+    "supervisor_cli_discovery_manifest",
+]

--- a/ipfs_accelerate_py/cli.py
+++ b/ipfs_accelerate_py/cli.py
@@ -2586,6 +2586,8 @@ def main(argv=None, *, agent_control_service=None, agent_service_factory=None):
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog="""
 Examples:
+  ipfs-accelerate supervisor run "Improve validation gates"
+  ipfs-accelerate supervisor status --run-id RUN --output-json
   ipfs-accelerate agent capabilities --request-file request.json --output-json
   ipfs-accelerate agent status --request-file request.json --watch-count 5
   ipfs-accelerate agent pause --request-file authorized-pause.json --output-json
@@ -2609,6 +2611,13 @@ Examples:
         # starts no process until a command is actually dispatched.
         from ipfs_accelerate_py.agent_supervisor.control.control_cli import register_agent_cli
         agent_parser = register_agent_cli(subparsers)
+
+        # Prompt-first product supervisor group (ASE3-010). Parser-only at
+        # discovery time; facade loads only when a command is dispatched.
+        from ipfs_accelerate_py.agent_supervisor.entrypoints.cli import (
+            register_supervisor_cli,
+        )
+        supervisor_parser = register_supervisor_cli(subparsers)
         
         # MCP commands
         mcp_parser = subparsers.add_parser('mcp', help='MCP server management')
@@ -2866,6 +2875,15 @@ Examples:
                 service=agent_control_service,
                 service_factory=agent_service_factory,
             )
+
+        if args.command == 'supervisor':
+            if not getattr(args, 'supervisor_command', None):
+                supervisor_parser.print_help()
+                return 1
+            from ipfs_accelerate_py.agent_supervisor.entrypoints.cli import (
+                run_supervisor_cli,
+            )
+            return run_supervisor_cli(args)
 
         cli = IPFSAccelerateCLI()
 

--- a/ipfs_accelerate_py/mcp_server/server.py
+++ b/ipfs_accelerate_py/mcp_server/server.py
@@ -160,10 +160,11 @@ def configure_agent_supervisor_tools(manager: HierarchicalToolManager) -> None:
 
     def load_agent_supervisor_tools(value: HierarchicalToolManager) -> None:
         from .tools.agent_supervisor_tools import (  # noqa: PLC0415
-            register_native_agent_supervisor_tools,
+            register_all_agent_supervisor_tools,
         )
 
-        register_native_agent_supervisor_tools(value)
+        # Control-plane operations + ASE3-011 prompt-lifecycle facade tools.
+        register_all_agent_supervisor_tools(value)
 
     manager.register_category_loader(
         "agent_supervisor",

--- a/ipfs_accelerate_py/mcp_server/tools/agent_supervisor_tools/__init__.py
+++ b/ipfs_accelerate_py/mcp_server/tools/agent_supervisor_tools/__init__.py
@@ -19,9 +19,30 @@ from .native_agent_supervisor_tools import (
     validate_agent_supervisor_mcp_catalog,
 )
 from . import native_agent_supervisor_tools as _native
+from .prompt_entrypoints import (
+    PROMPT_LIFECYCLE_TOOLS,
+    agent_supervisor_doctor,
+    agent_supervisor_explain,
+    agent_supervisor_follow,
+    agent_supervisor_preview,
+    agent_supervisor_run,
+    agent_supervisor_status,
+    agent_supervisor_steer,
+    configure_prompt_lifecycle_supervisor,
+    prompt_lifecycle_discovery_manifest,
+    register_prompt_lifecycle_tools,
+)
 
 for _operation, _tool in AGENT_SUPERVISOR_OPERATION_TOOLS.items():
     globals()[_tool.__name__] = getattr(_native, _tool.__name__)
+
+
+def register_all_agent_supervisor_tools(manager: object) -> None:
+    """Register control-plane tools and prompt-lifecycle facade tools."""
+
+    register_native_agent_supervisor_tools(manager)
+    register_prompt_lifecycle_tools(manager)
+
 
 __all__ = [
     "AGENT_SUPERVISOR_MCP_DISPATCH_MODE",
@@ -29,16 +50,28 @@ __all__ = [
     "AGENT_SUPERVISOR_OPERATION_TOOLS",
     "AGENT_SUPERVISOR_REPOSITORY_ALLOWLIST_ENV",
     "AGENT_SUPERVISOR_STATE_ALLOWLIST_ENV",
+    "PROMPT_LIFECYCLE_TOOLS",
     "AgentSupervisorMCPConfigurationError",
     "agent_supervisor_control",
     "agent_supervisor_discovery_manifest",
+    "agent_supervisor_doctor",
+    "agent_supervisor_explain",
+    "agent_supervisor_follow",
+    "agent_supervisor_preview",
+    "agent_supervisor_run",
+    "agent_supervisor_status",
+    "agent_supervisor_steer",
     "agent_supervisor_v2_discovery_manifest",
     "agent_supervisor_service_resolution_count",
     "configure_agent_supervisor_control",
+    "configure_prompt_lifecycle_supervisor",
     "execute_agent_supervisor_operation",
     "mcp_control_surface_publication",
     "mcp_v2_control_surface_publication",
+    "prompt_lifecycle_discovery_manifest",
+    "register_all_agent_supervisor_tools",
     "register_native_agent_supervisor_tools",
+    "register_prompt_lifecycle_tools",
     "validate_agent_supervisor_mcp_catalog",
     *[_tool.__name__ for _tool in AGENT_SUPERVISOR_OPERATION_TOOLS.values()],
 ]

--- a/ipfs_accelerate_py/mcp_server/tools/agent_supervisor_tools/prompt_entrypoints.py
+++ b/ipfs_accelerate_py/mcp_server/tools/agent_supervisor_tools/prompt_entrypoints.py
@@ -1,0 +1,352 @@
+"""MCP / MCP++ prompt-lifecycle tools for the production Supervisor facade (ASE3-011).
+
+Normal run/preview input is a prompt. Tools never accept raw client filesystem
+authority as authorization; repository roots must be server-configured aliases
+or already-authorized context. Listing tools is cold and side-effect free.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from threading import RLock
+from typing import Any, Final
+
+PROMPT_LIFECYCLE_CATEGORY: Final = "agent_supervisor"
+PROMPT_LIFECYCLE_TOOL_PREFIX: Final = "agent_supervisor_"
+REPOSITORY_ALLOWLIST_ENV: Final = "IPFS_ACCELERATE_AGENT_REPOSITORY_ALLOWLIST"
+STATE_ALLOWLIST_ENV: Final = "IPFS_ACCELERATE_AGENT_STATE_ALLOWLIST"
+
+PROMPT_LIFECYCLE_TOOLS: Final[tuple[str, ...]] = (
+    "agent_supervisor_run",
+    "agent_supervisor_preview",
+    "agent_supervisor_steer",
+    "agent_supervisor_status",
+    "agent_supervisor_follow",
+    "agent_supervisor_explain",
+    "agent_supervisor_doctor",
+)
+
+_lock = RLock()
+_injected_supervisor: Any = None
+
+
+class PromptEntrypointError(RuntimeError):
+    """Typed MCP prompt-lifecycle failure."""
+
+
+class PathInjectionDenied(PromptEntrypointError):
+    """Client-supplied path is not on the server allowlist."""
+
+
+def configure_prompt_lifecycle_supervisor(supervisor: Any | None) -> None:
+    """Inject a Supervisor instance for later tool invocations (tests/embedders)."""
+
+    global _injected_supervisor
+    with _lock:
+        _injected_supervisor = supervisor
+
+
+def prompt_lifecycle_discovery_manifest() -> dict[str, Any]:
+    """Static tool vocabulary without constructing a Supervisor."""
+
+    return {
+        "schema": "ipfs_accelerate_py.agent_supervisor.prompt-lifecycle-mcp@1",
+        "category": PROMPT_LIFECYCLE_CATEGORY,
+        "tools": list(PROMPT_LIFECYCLE_TOOLS),
+        "normal_input": "prompt",
+        "path_authority": "server_allowlist_only",
+        "cold_registration": True,
+    }
+
+
+def _allowlist(env_name: str) -> tuple[Path, ...]:
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return ()
+    paths: list[Path] = []
+    for item in raw.split(os.pathsep):
+        item = item.strip()
+        if not item:
+            continue
+        paths.append(Path(item).resolve())
+    return tuple(paths)
+
+
+def _authorize_repository(repository: str | None) -> Path | None:
+    if repository is None or repository == "":
+        return None
+    if not isinstance(repository, str):
+        raise PathInjectionDenied("repository must be a string path")
+    candidate = Path(repository).resolve()
+    # Reject path traversal / symlink escape attempts by requiring allowlist hit.
+    allowed = _allowlist(REPOSITORY_ALLOWLIST_ENV)
+    if not allowed:
+        # Without an explicit server allowlist, refuse client-supplied paths.
+        raise PathInjectionDenied(
+            "client repository paths require server allowlist "
+            f"({REPOSITORY_ALLOWLIST_ENV})"
+        )
+    for root in allowed:
+        try:
+            candidate.relative_to(root)
+            return candidate
+        except ValueError:
+            continue
+    raise PathInjectionDenied(f"repository path not allowlisted: {candidate}")
+
+
+def _open_supervisor(*, repository: str | None = None) -> Any:
+    with _lock:
+        if _injected_supervisor is not None:
+            return _injected_supervisor
+    from ipfs_accelerate_py.agent_supervisor.entrypoints.facade import Supervisor
+
+    root = _authorize_repository(repository)
+    return Supervisor.open(repository=root)
+
+
+def _prompt_schema(*, require_prompt: bool = True) -> dict[str, Any]:
+    props: dict[str, Any] = {
+        "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Intent prompt (never authority).",
+        },
+        "repository": {
+            "type": "string",
+            "description": "Optional server-allowlisted repository alias/path.",
+        },
+        "run_id": {
+            "type": "string",
+            "description": "Exact run identifier when required or ambiguous.",
+        },
+    }
+    required = ["prompt"] if require_prompt else []
+    return {
+        "type": "object",
+        "properties": props,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _result_ok(payload: Mapping[str, Any], *, composition_cid: str | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "ok": True,
+        "result": dict(payload),
+    }
+    if composition_cid:
+        body["composition_cid"] = composition_cid
+    return body
+
+
+def _result_err(error: str, *, code: str) -> dict[str, Any]:
+    return {"ok": False, "error": error, "error_code": code}
+
+
+async def agent_supervisor_run(
+    prompt: str,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    """Start or resume a durable run from a prompt."""
+
+    try:
+        if not isinstance(prompt, str) or not prompt.strip():
+            return _result_err("prompt must be a non-empty string", code="invalid")
+        supervisor = _open_supervisor(repository=repository)
+        run = supervisor.run(prompt)
+        return _result_ok(
+            {
+                "run_id": run.run_id,
+                "state": run.state,
+                "health": run.health,
+                "event_cursor": run.event_cursor,
+                "effect_receipt_cids": list(run.effect_receipt_cids),
+            },
+            composition_cid=supervisor.composition_cid,
+        )
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:  # typed facade failures
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_preview(
+    prompt: str,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        if not isinstance(prompt, str) or not prompt.strip():
+            return _result_err("prompt must be a non-empty string", code="invalid")
+        supervisor = _open_supervisor(repository=repository)
+        obs = supervisor.preview(prompt)
+        payload = obs.to_dict()
+        # Ensure prompt body does not leak.
+        blob = str(payload)
+        if prompt in blob:
+            return _result_err("prompt body leak denied", code="prompt_leak")
+        return _result_ok(payload, composition_cid=supervisor.composition_cid)
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_steer(
+    prompt: str,
+    run_id: str,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        if not isinstance(prompt, str) or not prompt.strip():
+            return _result_err("prompt must be a non-empty string", code="invalid")
+        if not isinstance(run_id, str) or not run_id.strip():
+            return _result_err("run_id is required", code="invalid")
+        supervisor = _open_supervisor(repository=repository)
+        obs = supervisor.steer(run_id, prompt)
+        return _result_ok(obs.to_dict(), composition_cid=supervisor.composition_cid)
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_status(
+    run_id: str | None = None,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        supervisor = _open_supervisor(repository=repository)
+        obs = supervisor.status(run_id)
+        return _result_ok(obs.to_dict(), composition_cid=supervisor.composition_cid)
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_follow(
+    run_id: str | None = None,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        supervisor = _open_supervisor(repository=repository)
+        events = [obs.to_dict() for obs in supervisor.follow(run_id)]
+        return _result_ok(
+            {"events": events, "count": len(events)},
+            composition_cid=supervisor.composition_cid,
+        )
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_explain(
+    run_id: str | None = None,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        supervisor = _open_supervisor(repository=repository)
+        obs = supervisor.explain(run_id)
+        return _result_ok(obs.to_dict(), composition_cid=supervisor.composition_cid)
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+async def agent_supervisor_doctor(
+    run_id: str | None = None,
+    repository: str | None = None,
+    **_ignored: Any,
+) -> dict[str, Any]:
+    try:
+        supervisor = _open_supervisor(repository=repository)
+        obs = supervisor.doctor(run_id)
+        return _result_ok(obs.to_dict(), composition_cid=supervisor.composition_cid)
+    except PathInjectionDenied as exc:
+        return _result_err(str(exc), code="path_denied")
+    except Exception as exc:
+        return _result_err(str(exc), code=type(exc).__name__)
+
+
+_TOOL_FUNCS: Final[Mapping[str, Any]] = {
+    "agent_supervisor_run": agent_supervisor_run,
+    "agent_supervisor_preview": agent_supervisor_preview,
+    "agent_supervisor_steer": agent_supervisor_steer,
+    "agent_supervisor_status": agent_supervisor_status,
+    "agent_supervisor_follow": agent_supervisor_follow,
+    "agent_supervisor_explain": agent_supervisor_explain,
+    "agent_supervisor_doctor": agent_supervisor_doctor,
+}
+
+_TOOL_SCHEMAS: Final[Mapping[str, dict[str, Any]]] = {
+    "agent_supervisor_run": _prompt_schema(require_prompt=True),
+    "agent_supervisor_preview": _prompt_schema(require_prompt=True),
+    "agent_supervisor_steer": {
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string", "minLength": 1},
+            "run_id": {"type": "string", "minLength": 1},
+            "repository": {"type": "string"},
+        },
+        "required": ["prompt", "run_id"],
+        "additionalProperties": False,
+    },
+    "agent_supervisor_status": _prompt_schema(require_prompt=False),
+    "agent_supervisor_follow": _prompt_schema(require_prompt=False),
+    "agent_supervisor_explain": _prompt_schema(require_prompt=False),
+    "agent_supervisor_doctor": _prompt_schema(require_prompt=False),
+}
+
+
+def register_prompt_lifecycle_tools(manager: Any) -> None:
+    """Register prompt-lifecycle tools without resolving a Supervisor."""
+
+    for name in PROMPT_LIFECYCLE_TOOLS:
+        manager.register_tool(
+            category=PROMPT_LIFECYCLE_CATEGORY,
+            name=name,
+            func=_TOOL_FUNCS[name],
+            description=(
+                f"Prompt-first supervisor {name.removeprefix(PROMPT_LIFECYCLE_TOOL_PREFIX)} "
+                "via the shared production facade (ASE3-011)."
+            ),
+            input_schema=_TOOL_SCHEMAS[name],
+            runtime="fastapi",
+            tags=[
+                "native",
+                "agent-supervisor",
+                "prompt-lifecycle",
+                "policy-controlled",
+                "body-free",
+            ],
+        )
+
+
+__all__ = [
+    "PROMPT_LIFECYCLE_CATEGORY",
+    "PROMPT_LIFECYCLE_TOOLS",
+    "PathInjectionDenied",
+    "PromptEntrypointError",
+    "REPOSITORY_ALLOWLIST_ENV",
+    "agent_supervisor_doctor",
+    "agent_supervisor_explain",
+    "agent_supervisor_follow",
+    "agent_supervisor_preview",
+    "agent_supervisor_run",
+    "agent_supervisor_status",
+    "agent_supervisor_steer",
+    "configure_prompt_lifecycle_supervisor",
+    "prompt_lifecycle_discovery_manifest",
+    "register_prompt_lifecycle_tools",
+]

--- a/test/api/test_agent_supervisor_mcplusplus_prompt_entrypoints.py
+++ b/test/api/test_agent_supervisor_mcplusplus_prompt_entrypoints.py
@@ -1,0 +1,28 @@
+"""ASE3-011 MCP++ parity smoke for prompt-lifecycle tools."""
+
+from __future__ import annotations
+
+from ipfs_accelerate_py.mcp_server.tools.agent_supervisor_tools import (
+    PROMPT_LIFECYCLE_TOOLS,
+    prompt_lifecycle_discovery_manifest,
+    register_prompt_lifecycle_tools,
+)
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.names: list[str] = []
+
+    def register_tool(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.names.append(str(kwargs["name"]))
+
+
+def test_mcplusplus_prompt_tools_register_closed_vocabulary() -> None:
+    """MCP++ shares the same closed prompt-lifecycle vocabulary as MCP."""
+
+    manager = _Manager()
+    register_prompt_lifecycle_tools(manager)
+    assert set(manager.names) == set(PROMPT_LIFECYCLE_TOOLS)
+    manifest = prompt_lifecycle_discovery_manifest()
+    assert set(manifest["tools"]) == set(manager.names)
+    assert manifest["path_authority"] == "server_allowlist_only"

--- a/test/api/test_agent_supervisor_prompt_v3_cli.py
+++ b/test/api/test_agent_supervisor_prompt_v3_cli.py
@@ -1,0 +1,198 @@
+"""ASE3-010 prompt-first supervisor CLI tests."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor.entrypoints import cli as supervisor_cli
+from ipfs_accelerate_py.agent_supervisor.entrypoints.facade import (
+    Supervisor,
+    SupervisorAmbiguityError,
+    SupervisorConfigurationError,
+    SupervisorObservation,
+    SupervisorRun,
+    SupervisorUnavailableError,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_discovery_manifest_is_static() -> None:
+    manifest = supervisor_cli.supervisor_cli_discovery_manifest()
+    assert manifest["group"] == "supervisor"
+    assert set(manifest["commands"]) == set(supervisor_cli.SUPERVISOR_COMMANDS)
+    assert manifest["cold_help"] is True
+
+
+def test_register_supervisor_cli_is_parser_only() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    group = supervisor_cli.register_supervisor_cli(sub)
+    assert group.prog.endswith("supervisor") or "supervisor" in group.prog
+    # help should not raise
+    help_io = io.StringIO()
+    group.print_help(help_io)
+    text = help_io.getvalue()
+    assert "run" in text
+    assert "preview" in text
+
+
+def test_cold_help_via_product_cli_subprocess() -> None:
+    env = dict(**{k: v for k, v in __import__("os").environ.items()})
+    env["PYTHONPATH"] = str(REPO_ROOT) + (
+        __import__("os").pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "ipfs_accelerate_py.cli_entry", "supervisor", "--help"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "run" in completed.stdout
+    assert "preview" in completed.stdout
+
+
+class _FakeSupervisor:
+    composition_cid = "cid:composition"
+
+    def run(self, prompt: str) -> SupervisorRun:
+        assert "secret-token" not in prompt or True
+        return SupervisorRun(
+            run_id="run-1",
+            run_revision=1,
+            composition_cid=self.composition_cid,
+            state="running",
+            health="healthy",
+            event_cursor="c1",
+            supervisor=None,
+            effect_receipt_cids=("r1",),
+        )
+
+    def preview(self, prompt: str) -> SupervisorObservation:
+        return SupervisorObservation(
+            run_id="",
+            state="preview",
+            health="unknown",
+            event_cursor="",
+            composition_cid=self.composition_cid,
+            summary="preview-only",
+            values={"effect_applied": False, "prompt_cid": "cid:p"},
+        )
+
+    def status(self, run_id: str | None = None) -> SupervisorObservation:
+        if run_id is None:
+            raise SupervisorAmbiguityError("ambiguous", candidates=("a", "b"))
+        return SupervisorObservation(
+            run_id=run_id,
+            state="running",
+            health="healthy",
+            event_cursor="c1",
+            composition_cid=self.composition_cid,
+            summary="ok",
+        )
+
+    def follow(self, run_id: str | None = None):
+        yield self.status(run_id or "run-1")
+
+    def explain(self, run_id: str | None = None) -> SupervisorObservation:
+        return self.status(run_id or "run-1")
+
+    def doctor(self, run_id: str | None = None) -> SupervisorObservation:
+        return self.status(run_id or "run-1")
+
+    def steer(self, run_id: str, prompt: str) -> SupervisorObservation:
+        return SupervisorObservation(
+            run_id=run_id,
+            state="running",
+            health="healthy",
+            event_cursor="c1",
+            composition_cid=self.composition_cid,
+            summary="steer accepted",
+            values={"effect_applied": False},
+        )
+
+
+def test_run_command_json_envelope() -> None:
+    args = SimpleNamespace(
+        supervisor_command="run",
+        prompt="Improve gates",
+        prompt_file=None,
+        prompt_stdin=False,
+        output_json=True,
+        repository=None,
+        state_root=None,
+    )
+    out = io.StringIO()
+    code = supervisor_cli.run_supervisor_cli(
+        args, stdout=out, supervisor=_FakeSupervisor()
+    )
+    assert code == supervisor_cli.EXIT_SUCCESS
+    payload = json.loads(out.getvalue())
+    assert payload["ok"] is True
+    assert payload["result"]["run_id"] == "run-1"
+    assert payload["composition_cid"] == "cid:composition"
+
+
+def test_missing_prompt_is_invalid() -> None:
+    args = SimpleNamespace(
+        supervisor_command="run",
+        prompt=None,
+        prompt_file=None,
+        prompt_stdin=False,
+        output_json=True,
+        repository=None,
+        state_root=None,
+    )
+    out = io.StringIO()
+    code = supervisor_cli.run_supervisor_cli(
+        args, stdout=out, stderr=out, supervisor=_FakeSupervisor()
+    )
+    assert code == supervisor_cli.EXIT_INVALID
+    payload = json.loads(out.getvalue())
+    assert payload["ok"] is False
+
+
+def test_ambiguity_exit_code() -> None:
+    args = SimpleNamespace(
+        supervisor_command="status",
+        run_id=None,
+        output_json=True,
+        repository=None,
+        state_root=None,
+    )
+    out = io.StringIO()
+    code = supervisor_cli.run_supervisor_cli(
+        args, stdout=out, stderr=out, supervisor=_FakeSupervisor()
+    )
+    assert code == supervisor_cli.EXIT_AMBIGUITY
+
+
+def test_preview_does_not_echo_prompt_body() -> None:
+    secret = "super-secret-prompt-body"
+    args = SimpleNamespace(
+        supervisor_command="preview",
+        prompt=secret,
+        prompt_file=None,
+        prompt_stdin=False,
+        output_json=True,
+        repository=None,
+        state_root=None,
+    )
+    out = io.StringIO()
+    code = supervisor_cli.run_supervisor_cli(
+        args, stdout=out, supervisor=_FakeSupervisor()
+    )
+    assert code == supervisor_cli.EXIT_SUCCESS
+    assert secret not in out.getvalue()

--- a/test/api/test_agent_supervisor_prompt_v3_mcp.py
+++ b/test/api/test_agent_supervisor_prompt_v3_mcp.py
@@ -1,0 +1,173 @@
+"""ASE3-011 MCP prompt-lifecycle tool tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ipfs_accelerate_py.agent_supervisor.entrypoints.facade import (
+    SupervisorObservation,
+    SupervisorRun,
+)
+from ipfs_accelerate_py.mcp_server.tools.agent_supervisor_tools import (
+    PROMPT_LIFECYCLE_TOOLS,
+    configure_prompt_lifecycle_supervisor,
+    prompt_lifecycle_discovery_manifest,
+    register_prompt_lifecycle_tools,
+)
+from ipfs_accelerate_py.mcp_server.tools.agent_supervisor_tools import (
+    prompt_entrypoints as pe,
+)
+
+
+class _RecordingManager:
+    def __init__(self) -> None:
+        self.tools: list[dict[str, Any]] = []
+
+    def register_tool(self, **kwargs: Any) -> None:
+        self.tools.append(kwargs)
+
+
+class _FakeSupervisor:
+    composition_cid = "cid:comp"
+
+    def run(self, prompt: str) -> SupervisorRun:
+        return SupervisorRun(
+            run_id="run-mcp",
+            run_revision=1,
+            composition_cid=self.composition_cid,
+            state="running",
+            health="healthy",
+            event_cursor="e1",
+            effect_receipt_cids=("r1",),
+        )
+
+    def preview(self, prompt: str) -> SupervisorObservation:
+        return SupervisorObservation(
+            run_id="",
+            state="preview",
+            health="unknown",
+            event_cursor="",
+            composition_cid=self.composition_cid,
+            summary="preview",
+            values={"effect_applied": False, "prompt_cid": "cid:p"},
+        )
+
+    def status(self, run_id: str | None = None) -> SupervisorObservation:
+        return SupervisorObservation(
+            run_id=run_id or "run-mcp",
+            state="running",
+            health="healthy",
+            event_cursor="e1",
+            composition_cid=self.composition_cid,
+            summary="ok",
+        )
+
+    def follow(self, run_id: str | None = None):
+        yield self.status(run_id)
+
+    def explain(self, run_id: str | None = None) -> SupervisorObservation:
+        return self.status(run_id)
+
+    def doctor(self, run_id: str | None = None) -> SupervisorObservation:
+        return self.status(run_id)
+
+    def steer(self, run_id: str, prompt: str) -> SupervisorObservation:
+        return SupervisorObservation(
+            run_id=run_id,
+            state="running",
+            health="healthy",
+            event_cursor="e1",
+            composition_cid=self.composition_cid,
+            summary="steer",
+            values={"effect_applied": False},
+        )
+
+
+def test_discovery_manifest_lists_prompt_tools() -> None:
+    manifest = prompt_lifecycle_discovery_manifest()
+    assert set(manifest["tools"]) == set(PROMPT_LIFECYCLE_TOOLS)
+    assert manifest["cold_registration"] is True
+    assert manifest["normal_input"] == "prompt"
+
+
+def test_register_prompt_lifecycle_tools_is_cold() -> None:
+    manager = _RecordingManager()
+    register_prompt_lifecycle_tools(manager)
+    names = {item["name"] for item in manager.tools}
+    assert names == set(PROMPT_LIFECYCLE_TOOLS)
+    for item in manager.tools:
+        assert item["category"] == "agent_supervisor"
+        assert "prompt-lifecycle" in item["tags"]
+        assert item["input_schema"]["type"] == "object"
+
+
+def test_run_tool_reaches_injected_supervisor() -> None:
+    configure_prompt_lifecycle_supervisor(_FakeSupervisor())
+    try:
+        result = asyncio.run(pe.agent_supervisor_run(prompt="Improve gates"))
+    finally:
+        configure_prompt_lifecycle_supervisor(None)
+    assert result["ok"] is True
+    assert result["result"]["run_id"] == "run-mcp"
+    assert result["composition_cid"] == "cid:comp"
+
+
+def test_preview_does_not_leak_prompt_body() -> None:
+    secret = "do-not-leak-this-prompt"
+    configure_prompt_lifecycle_supervisor(_FakeSupervisor())
+    try:
+        result = asyncio.run(pe.agent_supervisor_preview(prompt=secret))
+    finally:
+        configure_prompt_lifecycle_supervisor(None)
+    assert result["ok"] is True
+    assert secret not in str(result)
+
+
+def test_client_repository_path_denied_without_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configure_prompt_lifecycle_supervisor(None)
+    monkeypatch.delenv(pe.REPOSITORY_ALLOWLIST_ENV, raising=False)
+    result = asyncio.run(
+        pe.agent_supervisor_run(
+            prompt="x",
+            repository="/tmp/not-allowlisted",
+        )
+    )
+    assert result["ok"] is False
+    assert result["error_code"] == "path_denied"
+
+
+def test_allowlisted_repository_accepted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv(pe.REPOSITORY_ALLOWLIST_ENV, str(tmp_path.resolve()))
+    configure_prompt_lifecycle_supervisor(_FakeSupervisor())
+    try:
+        result = asyncio.run(
+            pe.agent_supervisor_preview(
+                prompt="Improve gates",
+                repository=str(repo),
+            )
+        )
+    finally:
+        configure_prompt_lifecycle_supervisor(None)
+        monkeypatch.delenv(pe.REPOSITORY_ALLOWLIST_ENV, raising=False)
+    assert result["ok"] is True
+
+
+def test_empty_prompt_invalid() -> None:
+    configure_prompt_lifecycle_supervisor(_FakeSupervisor())
+    try:
+        result = asyncio.run(pe.agent_supervisor_run(prompt="  "))
+    finally:
+        configure_prompt_lifecycle_supervisor(None)
+    assert result["ok"] is False
+    assert result["error_code"] == "invalid"


### PR DESCRIPTION
## Summary
- ASE3-010: `ipfs-accelerate supervisor` run/preview/steer/status/follow/explain/doctor/init (cold help, typed exit codes)
- ASE3-011: MCP/MCP++ `agent_supervisor_*` prompt lifecycle tools with server allowlist path denial
- Mark ASE3-010 and ASE3-011 completed on the board

## Test plan
- [x] pytest test/api/test_agent_supervisor_prompt_v3_cli.py
- [x] pytest test/api/test_agent_supervisor_prompt_v3_mcp.py
- [x] pytest test/api/test_agent_supervisor_mcplusplus_prompt_entrypoints.py