### PR TITLE
fix(agent-supervisor): package hybrid-merge implement-path repairs

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -361,6 +361,64 @@ IMPLEMENTATION_FALLBACK_TRIGGER_ENV = (
 PROVIDER_FALLBACK_POLICY_ENV = (
     "IPFS_ACCELERATE_AGENT_PROVIDER_FALLBACK_POLICY"
 )
+
+MANUAL_COMPLETION_REVALIDATION_STORE_SCHEMA = (
+    "ipfs_accelerate_py.agent_supervisor."
+    "manual-completion-revalidation-store@2"
+)
+
+MANUAL_COMPLETION_REVALIDATION_RECEIPT_SCHEMA = (
+    "ipfs_accelerate_py.agent_supervisor."
+    "manual-completion-revalidation-receipt@2"
+)
+
+MANUAL_COMPLETION_VALIDATION_PLAN_SCHEMA = (
+    "ipfs_accelerate_py.agent_supervisor."
+    "manual-completion-validation-plan@2"
+)
+
+MANUAL_COMPLETION_AUTHORITY_RENEWAL_MAX_FAILURES = 3
+
+MANUAL_COMPLETION_AUTHORITY_RENEWAL_BASE_COOLDOWN_SECONDS = 300.0
+
+MANUAL_COMPLETION_AUTHORITY_RENEWAL_MAX_COOLDOWN_SECONDS = 14400.0
+
+AUTHORITY_VALIDATION_CONTAINER_IMAGE_ENV = (
+    "IPFS_ACCELERATE_AGENT_AUTHORITY_VALIDATION_CONTAINER_IMAGE"
+)
+
+AUTHORITY_VALIDATION_DOCKER_PATH = Path("/usr/bin/docker")
+
+AUTHORITY_VALIDATION_DOCKER_SHA256 = (
+    "414d9e16a30060770648522f8ecadef2f2b57b50b8c61d4b0ae9d3b8b64c2a02"
+)
+
+AUTHORITY_VALIDATION_NVIDIA_SMI_PATH = Path("/usr/bin/nvidia-smi")
+
+AUTHORITY_VALIDATION_NVIDIA_SMI_SHA256 = (
+    "934be0af12e24ad46e3deca64234be7493d8f3552461c9956d43fbedd6ff9c67"
+)
+
+AUTHORITY_VALIDATION_DOCKER_SERVER_IDENTITY = "29.1.3|linux|arm64"
+
+AUTHORITY_VALIDATION_GPU_IDENTITY = (
+    "GPU-fd94473f-d6ba-bada-c1e2-5a1e9ad037e4, 580.142"
+)
+
+AUTHORITY_VALIDATION_GPU_UUID = (
+    "GPU-fd94473f-d6ba-bada-c1e2-5a1e9ad037e4"
+)
+
+DEFAULT_AUTHORITY_VALIDATION_CONTAINER_IMAGE = (
+    "sha256:74c4a6ff67f397f8a10b058851d218896b2f1ee0f2cddf47741219b734de93a6"
+)
+
+AUTHORITY_VALIDATION_DOCKER_ENDPOINT = "unix:///run/docker.sock"
+
+REQUIRE_TASK_EXECUTION_METADATA_ENV = (
+    "IPFS_ACCELERATE_AGENT_REQUIRE_TASK_EXECUTION_METADATA"
+)
+
 GROK_QUOTA_AUTH_OR_UNAVAILABLE_FALLBACK_POLICY = (
     "grok_quota_auth_or_unavailable"
 )
@@ -2954,6 +3012,54 @@ def dependency_satisfied_references(
     return satisfied
 
 
+
+def transitive_task_dependents(
+    tasks: Sequence[PortalTask],
+    *,
+    root_task_ids: Iterable[str] = (),
+) -> set[str]:
+    """Return tasks transitively dependent on any declared root task.
+
+    Dependencies may name either a task or an objective goal.  A goal cannot
+    be satisfied while one of its member tasks is authority-blocked, so goal
+    references participate in the same fixed-point closure.
+    """
+
+    declared_task_ids = {task.task_id for task in tasks}
+    roots = {
+        str(task_id)
+        for task_id in root_task_ids
+        if str(task_id).strip() and str(task_id) in declared_task_ids
+    }
+    affected_task_ids = set(roots)
+    task_ids_by_goal: dict[str, set[str]] = {}
+    for task in tasks:
+        for goal_id in split_csv(task.metadata.get("goal id", "")):
+            task_ids_by_goal.setdefault(goal_id, set()).add(task.task_id)
+
+    while True:
+        affected_goal_ids = {
+            goal_id
+            for goal_id, task_ids in task_ids_by_goal.items()
+            if task_ids & affected_task_ids
+        }
+        newly_affected = {
+            task.task_id
+            for task in tasks
+            if (
+                task.task_id not in affected_task_ids
+                and any(
+                    dependency in affected_task_ids
+                    or dependency in affected_goal_ids
+                    for dependency in task.depends_on
+                )
+            )
+        }
+        if not newly_affected:
+            break
+        affected_task_ids.update(newly_affected)
+    return affected_task_ids - roots
+
 class PortalImplementationDaemon:
     shared_todo_runner_class = TodoDaemonRunner
     shared_todo_hooks_class = TodoDaemonHooks
@@ -3021,6 +3127,10 @@ class PortalImplementationDaemon:
         implementation_provider_max_input_tokens: int | None = None,
         implementation_max_repair_rounds: int = 3,
         implementation_cancelled: Any = None,
+        manual_completion_authority_required_task_ids: Sequence[str] = (),
+        manual_completion_authority_task_ids: Sequence[str] = (),
+        manual_completion_authority_epoch_id: str = "",
+        manual_completion_authority_revalidation_only: bool = False,
         decision_runtime: Any = None,
         decision_runtime_config: Mapping[str, Any] | None = None,
     ) -> None:
@@ -3076,6 +3186,60 @@ class PortalImplementationDaemon:
             implementation_protected_paths,
             repo_root=self.repo_root,
         )
+        self.manual_completion_authority_required_task_ids = frozenset(
+            str(task_id).strip()
+            for task_id in manual_completion_authority_required_task_ids
+            if str(task_id).strip()
+        )
+        self.manual_completion_authority_task_ids = frozenset(
+            {
+                str(task_id).strip()
+                for task_id in manual_completion_authority_task_ids
+                if str(task_id).strip()
+            }
+            | set(self.manual_completion_authority_required_task_ids)
+        )
+        self.manual_completion_authority_epoch_id = str(
+            manual_completion_authority_epoch_id or ""
+        ).strip()
+        self.manual_completion_authority_revalidation_only = bool(
+            manual_completion_authority_revalidation_only
+        )
+        if (
+            self.manual_completion_authority_revalidation_only
+            and not self.manual_completion_authority_task_ids
+        ):
+            raise ValueError(
+                "manual completion authority revalidation-only mode requires "
+                "at least one authority task ID"
+            )
+        if self.manual_completion_authority_revalidation_only and not implement:
+            raise ValueError(
+                "manual completion authority revalidation-only mode requires "
+                "implementation execution to be enabled"
+            )
+        if self.manual_completion_authority_revalidation_only and (
+            decision_runtime is not None
+            or decision_runtime_config is not None
+        ):
+            raise ValueError(
+                "manual completion authority revalidation-only mode forbids "
+                "a custom decision runtime"
+            )
+        self._manual_completion_authority_hard_blocked_task_ids = frozenset(
+            self.manual_completion_authority_required_task_ids
+        )
+        self._manual_completion_authority_effective_required_task_ids = (
+            frozenset(self.manual_completion_authority_required_task_ids)
+        )
+        self._manual_completion_authority_revocation_generation = 0
+        self._trusted_manual_completion_revalidation_receipt_ids: set[str] = set()
+        self._trusted_manual_completion_revalidation_evidence_ids: set[str] = set()
+        self._manual_completion_authority_revalidation_task_ids = frozenset()
+        self._manual_completion_authority_historical_task_ids = frozenset(
+            self.manual_completion_authority_required_task_ids
+        )
+        self._manual_completion_authority_affected_goal_ids = frozenset()
         self.shared_worktree_source_roots = shared_worktree_source_roots(self.repo_root)
         self.task_header_prefix = normalize_task_header_prefix(task_header_prefix)
         self.implement = implement
@@ -16782,16 +16946,7 @@ class PortalImplementationDaemon:
     ) -> dict[str, Any]:
         self.implementation_log_dir.mkdir(parents=True, exist_ok=True)
         self.worktree_root.mkdir(parents=True, exist_ok=True)
-        # Typed-local-only execution is owned by task_execution_policy (not yet
-        # present on this merge surface). Ordinary provider tasks always take
-        # the model/provider path; keep the branches for future porting.
-        deterministic_only = False
-        try:
-            uses_typed = getattr(self, "_task_uses_typed_local_execution", None)
-            if callable(uses_typed):
-                deterministic_only = bool(uses_typed(task))
-        except Exception:
-            deterministic_only = False
+        deterministic_only = self._task_uses_typed_local_execution(task)
         safe_task_id = task.task_id.lower().replace("/", "-")
         identity_suffix = self._identity_for_task(task).short_id
         execution_id = f"{safe_task_id}-{identity_suffix}"
@@ -42599,6 +42754,2185 @@ class PortalImplementationDaemon:
             enriched.setdefault("board_namespace", identity.board_namespace)
         append_jsonl_event(self.events_path, event_type, enriched)
         self._invalidate_event_cache()
+
+
+
+    @staticmethod
+    def _path_crosses_live_symlink(
+        workspace_path: Path,
+        relative: str,
+    ) -> bool:
+        """Refuse force-add through any live symlink component."""
+
+        current = workspace_path
+        for part in PurePosixPath(relative).parts:
+            current = current / part
+            try:
+                identity = current.lstat()
+            except FileNotFoundError:
+                break
+            except OSError:
+                return True
+            if stat_module.S_ISLNK(identity.st_mode):
+                return True
+        return False
+
+    def _detach_in_process_proposal_validation(
+        self,
+        validation_result: Mapping[str, Any] | dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Drop live proposal objects before validation results are persisted.
+
+        ``_run_validation_with_candidate_binding`` may temporarily attach a
+        ``ProposalValidationResult`` for post-validation re-stabilize. Event
+        logs and diagnostic receipts must only keep the compact gate projection.
+        """
+
+        result = dict(validation_result or {})
+        proposal_validation = result.pop("proposal_validation", None)
+        if proposal_validation is None:
+            return result
+        if isinstance(proposal_validation, Mapping):
+            # Already JSON-safe; keep only under proposal_gate if missing.
+            if "proposal_gate" not in result:
+                result["proposal_gate"] = dict(proposal_validation)
+            return result
+        compact = self._compact_proposal_validation(proposal_validation)
+        existing_gate = result.get("proposal_gate")
+        if not isinstance(existing_gate, Mapping):
+            result["proposal_gate"] = compact
+        return result
+
+    def _seed_operator_prepared_outputs(
+        self,
+        worktree_path: Path,
+        task: PortalTask,
+    ) -> tuple[dict[str, Any], ...]:
+        """Snapshot exact operator-reviewed outputs into an isolated worktree."""
+
+        if self._task_declared_implementation_provider(task) != "operator-only":
+            return ()
+        try:
+            repository_root = self.repo_root.resolve(strict=True)
+            workspace_root = worktree_path.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise RuntimeError(
+                "cannot resolve operator-only output snapshot roots"
+            ) from exc
+
+        snapshots: list[dict[str, Any]] = []
+        for relative in self._proposal_scope_paths(task):
+            if not self._repo_relative_path_safe(relative):
+                continue
+            if any(
+                self._path_matches_prefix(relative, prefix)
+                for prefix in self.worktree_submodule_paths
+            ):
+                continue
+            source = self.repo_root / relative
+            source_identity = self._seeded_worktree_context_identity(source)
+            if source_identity.get("kind") != "regular_file":
+                continue
+            try:
+                source.resolve(strict=True).relative_to(repository_root)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"operator-only output escapes repository: {relative}"
+                ) from exc
+
+            target = worktree_path / relative
+            if target.exists() or target.is_symlink():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                target.parent.resolve(strict=True).relative_to(workspace_root)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"operator-only output escapes worktree: {relative}"
+                ) from exc
+            shutil.copy2(source, target)
+
+            stable_source = self._seeded_worktree_context_identity(source)
+            target_identity = self._seeded_worktree_context_identity(target)
+            identity_fields = ("kind", "mode", "size", "sha256")
+            if any(
+                source_identity.get(field) != stable_source.get(field)
+                or source_identity.get(field) != target_identity.get(field)
+                for field in identity_fields
+            ):
+                try:
+                    target.unlink()
+                except OSError:
+                    pass
+                raise RuntimeError(
+                    f"operator-only output changed during snapshot: {relative}"
+                )
+            snapshots.append(
+                {
+                    "path": relative,
+                    "sha256": str(source_identity["sha256"]),
+                    "size": int(source_identity["size"]),
+                    "mode": int(source_identity["mode"]),
+                }
+            )
+
+        if snapshots:
+            self._record_event(
+                "operator_prepared_outputs_seeded",
+                {
+                    "task_id": task.task_id,
+                    "worktree_path": str(worktree_path),
+                    "outputs": snapshots,
+                    "provider_call_allowed": False,
+                },
+            )
+        return tuple(snapshots)
+
+    def _task_declared_implementation_provider(
+        self,
+        task: PortalTask | None,
+    ) -> str:
+        """Return a task-owned provider override, or an empty string.
+
+        Lane assignments are capacity hints. A task's reviewed ``Provider
+        role`` is the execution contract and therefore takes precedence.
+        """
+
+        if task is None:
+            return ""
+        raw_role = self._task_metadata_value(task, "provider role")
+        if not raw_role and _env_bool(
+            REQUIRE_TASK_EXECUTION_METADATA_ENV,
+            False,
+        ):
+            raise ImplementationRetryDeferred(
+                "task provider role is required by execution policy",
+                backoff_seconds=300,
+            )
+        roles = {
+            item.strip().lower()
+            for item in re.split(r"[,;]", raw_role)
+            if item.strip()
+        }
+        local_only_roles = roles & {
+            ExecutionMode.DETERMINISTIC_ONLY.value,
+            "operator-only",
+        }
+        if local_only_roles:
+            if len(roles) != 1:
+                raise RuntimeError(
+                    "typed-local-only role cannot be combined with model "
+                    "provider roles"
+                )
+            return next(iter(local_only_roles))
+
+        grok_primary_roles = {"grok-implement", "grok-draft"}
+        grok_only_roles = {"grok-only", "grok-pinned"}
+        codex_roles = {"codex-implement", "codex-draft"}
+        wants_grok_primary = bool(roles & grok_primary_roles)
+        wants_grok_only = bool(roles & grok_only_roles)
+        wants_codex = bool(roles & codex_roles)
+        if sum((wants_grok_primary, wants_grok_only, wants_codex)) > 1:
+            raise RuntimeError(
+                "task declares more than one implementation provider"
+            )
+        if wants_grok_primary:
+            # ``grok-implement`` describes the primary role, not an
+            # unconditional provider pin. Keep the task inside the audited
+            # Grok-first/quota-only-Codex route.
+            return "auto"
+        if wants_grok_only:
+            return "grok"
+        if wants_codex:
+            return "codex"
+        return ""
+
+    def _task_uses_typed_local_execution(
+        self,
+        task: PortalTask | None,
+    ) -> bool:
+        return self._task_declared_implementation_provider(task) in {
+            ExecutionMode.DETERMINISTIC_ONLY.value,
+            "operator-only",
+        }
+
+    def _task_context_token_limit(self, task: PortalTask) -> int | None:
+        raw_limit = self._task_metadata_value(task, "context budget tokens")
+        if not raw_limit:
+            if _env_bool(REQUIRE_TASK_EXECUTION_METADATA_ENV, False):
+                raise ImplementationRetryDeferred(
+                    "task context budget tokens are required by execution policy",
+                    backoff_seconds=300,
+                )
+            return None
+        try:
+            limit = int(raw_limit)
+        except ValueError as exc:
+            raise ImplementationRetryDeferred(
+                "invalid task context budget tokens",
+                backoff_seconds=300,
+            ) from exc
+        if limit == 0 and self._task_uses_typed_local_execution(task):
+            return 0
+        if limit < 1:
+            raise ImplementationRetryDeferred(
+                "invalid task context budget tokens",
+                backoff_seconds=300,
+            )
+        return limit
+
+    def _manual_completion_revalidation_store_path(self) -> Path:
+        """Return the shared, board-scoped durable revalidation store."""
+
+        board_key = hashlib.sha256(
+            str(self.todo_path.resolve(strict=False)).encode("utf-8")
+        ).hexdigest()
+        return (
+            Path(self.merge_queue_dir)
+            / "manual-completion-authority"
+            / f"{board_key}.json"
+        )
+
+    def _validated_manual_completion_revalidation_store(
+        self,
+        payload: Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if not isinstance(payload, Mapping):
+            return None
+        normalized = dict(payload)
+        store_id = str(normalized.pop("store_id", "") or "")
+        if (
+            normalized.get("schema")
+            != MANUAL_COMPLETION_REVALIDATION_STORE_SCHEMA
+            or normalized.get("todo_path")
+            != str(self.todo_path.resolve(strict=False))
+            or not isinstance(normalized.get("records"), Mapping)
+            or type(normalized.get("revocation_generation")) is not int
+            or normalized.get("revocation_generation", -1) < 0
+            or not isinstance(normalized.get("task_statuses"), Mapping)
+            or any(
+                not isinstance(task_id, str)
+                or not task_id.strip()
+                or not isinstance(status, str)
+                or not status.strip()
+                for task_id, status in normalized.get(
+                    "task_statuses", {}
+                ).items()
+            )
+            or not store_id
+            or content_identity(normalized) != store_id
+        ):
+            return None
+        normalized["records"] = dict(normalized["records"])
+        normalized["task_statuses"] = dict(normalized["task_statuses"])
+        normalized["store_id"] = store_id
+        return normalized
+
+    def _write_manual_completion_revalidation_store(
+        self,
+        path: Path,
+        *,
+        records: Mapping[str, Any],
+        revocation_generation: int,
+        task_statuses: Mapping[str, str],
+    ) -> dict[str, Any]:
+        body = {
+            "schema": MANUAL_COMPLETION_REVALIDATION_STORE_SCHEMA,
+            "todo_path": str(self.todo_path.resolve(strict=False)),
+            "revocation_generation": int(revocation_generation),
+            "task_statuses": dict(sorted(task_statuses.items())),
+            "records": dict(records),
+        }
+        payload = {**body, "store_id": content_identity(body)}
+        write_json_atomic(path, payload)
+        return payload
+
+    def _archive_invalid_manual_completion_revalidation_store(
+        self,
+        path: Path,
+    ) -> Path:
+        """Move a malformed authority store aside without discarding evidence."""
+
+        raw = path.read_bytes()
+        digest = hashlib.sha256(raw).hexdigest()
+        archive = path.parent / "invalid" / f"{path.stem}.{digest}.json"
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        if archive.exists():
+            archive = archive.with_name(
+                f"{path.stem}.{digest}.{time.time_ns()}.json"
+            )
+        os.replace(path, archive)
+        return archive
+
+    def _synchronize_manual_completion_revocation_generation(
+        self,
+        *,
+        task_statuses: Mapping[str, str],
+    ) -> dict[str, Any]:
+        """Durably advance the authority generation on completed-status reset."""
+
+        path = self._manual_completion_revalidation_store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        normalized_statuses = {
+            str(task_id): normalize_status(status)
+            for task_id, status in task_statuses.items()
+            if str(task_id).strip()
+        }
+        archive_path = ""
+        recovered = False
+        rollback_detected = False
+        revoked_task_ids: list[str] = []
+        generation_floor = int(
+            self._manual_completion_authority_revocation_generation
+        )
+        had_trusted_state = bool(
+            self._trusted_manual_completion_revalidation_receipt_ids
+            or self._trusted_manual_completion_revalidation_evidence_ids
+        )
+        try:
+            with serialized_lock_update(path):
+                path_present = path.exists()
+                raw_store = load_json_dict(path)
+                store = self._validated_manual_completion_revalidation_store(
+                    raw_store
+                )
+                if (
+                    store is not None
+                    and int(store["revocation_generation"])
+                    < generation_floor
+                ):
+                    archive_path = str(
+                        self._archive_invalid_manual_completion_revalidation_store(
+                            path
+                        )
+                    )
+                    rollback_detected = True
+                    recovered = True
+                    store = None
+                if path_present and store is None:
+                    if not archive_path and path.exists():
+                        archive_path = str(
+                            self._archive_invalid_manual_completion_revalidation_store(
+                                path
+                            )
+                        )
+                    recovered = True
+                if not path_present and (
+                    generation_floor > 0 or had_trusted_state
+                ):
+                    # Deleting the monotonic store is also a rollback attempt;
+                    # never recreate generation zero in a live process.
+                    rollback_detected = True
+                    recovered = True
+                if store is None:
+                    records: dict[str, Any] = {}
+                    generation = (
+                        generation_floor + 1
+                        if recovered
+                        else generation_floor
+                    )
+                    previous_statuses: dict[str, str] = {}
+                else:
+                    records = dict(store["records"])
+                    generation = int(store["revocation_generation"])
+                    previous_statuses = dict(store["task_statuses"])
+                revoked_task_ids = sorted(
+                    task_id
+                    for task_id, previous_status in previous_statuses.items()
+                    if normalize_status(previous_status) == "completed"
+                    and normalize_status(
+                        normalized_statuses.get(task_id, "missing")
+                    )
+                    != "completed"
+                )
+                if revoked_task_ids:
+                    generation += 1
+                    records = {}
+                expected_statuses = dict(sorted(normalized_statuses.items()))
+                if (
+                    store is None
+                    or revoked_task_ids
+                    or previous_statuses != expected_statuses
+                ):
+                    written = self._write_manual_completion_revalidation_store(
+                        path,
+                        records=records,
+                        revocation_generation=generation,
+                        task_statuses=expected_statuses,
+                    )
+                    store_id = str(written["store_id"])
+                else:
+                    store_id = str(store.get("store_id") or "")
+        except (OSError, RuntimeError, ValueError) as exc:
+            return {
+                "available": False,
+                "reason": "manual_completion_revocation_state_unavailable",
+                "path": str(path),
+                "error_type": type(exc).__name__,
+                "error": str(exc)[-2000:],
+            }
+        if revoked_task_ids or recovered:
+            self._trusted_manual_completion_revalidation_receipt_ids.clear()
+            self._trusted_manual_completion_revalidation_evidence_ids.clear()
+        self._manual_completion_authority_revocation_generation = generation
+        result = {
+            "available": True,
+            "path": str(path),
+            "revocation_generation": generation,
+            "revoked_task_ids": revoked_task_ids,
+            "recovered_invalid_store": recovered,
+            "rollback_detected": rollback_detected,
+            "invalid_store_archive_path": archive_path,
+            "store_id": store_id,
+        }
+        if revoked_task_ids or recovered:
+            self._record_event(
+                "manual_completion_authority_revocation_advanced"
+                if revoked_task_ids
+                else "manual_completion_revalidation_store_recovered",
+                result,
+            )
+        return result
+
+    @staticmethod
+    def _manual_completion_revalidation_evidence_id(
+        evidence: Mapping[str, Any],
+    ) -> str:
+        """Bind only the authority-bearing projection of a validation run."""
+
+        raw_results = evidence.get("results")
+        results = (
+            [
+                {
+                    key: item.get(key)
+                    for key in (
+                        "command",
+                        "returncode",
+                        "cache_hit",
+                        "timed_out",
+                        "infrastructure_failure",
+                        "validation_result_digest",
+                        "authority_validation_isolation_receipt",
+                    )
+                    if key in item
+                }
+                for item in raw_results
+                if isinstance(item, Mapping)
+            ]
+            if isinstance(raw_results, Sequence)
+            and not isinstance(raw_results, (str, bytes, bytearray))
+            else []
+        )
+        projection = {
+            key: evidence.get(key)
+            for key in (
+                "attempted",
+                "passed",
+                "returncode",
+                "manual_completion_authority_context_id",
+                "manual_completion_authority_revalidation",
+                "manual_completion_authority_force_uncached",
+                "manual_completion_authority_task_id",
+                "manual_completion_authority_task_cid",
+                "manual_completion_authority_validation_plan_id",
+                "manual_completion_authority_declared_validation_commands",
+                "manual_completion_authority_revocation_generation",
+                "manual_completion_authority_validated_tree_identity",
+                "manual_completion_authority_validated_tree_id",
+                "manual_completion_authority_validation_result_count",
+            )
+        }
+        projection["results"] = results
+        return content_identity(projection)
+
+    def _current_manual_completion_revalidation_receipts(
+        self,
+        tasks: Sequence[PortalTask],
+        *,
+        authority_context_id: str,
+    ) -> tuple[set[str], dict[str, Any]]:
+        """Return completed task IDs with exact current-context receipts."""
+
+        path = self._manual_completion_revalidation_store_path()
+        raw = load_json_dict(path)
+        if raw is None:
+            return set(), {
+                "available": True,
+                "path": str(path),
+                "valid_task_ids": [],
+                "invalid_task_ids": [],
+            }
+        store = self._validated_manual_completion_revalidation_store(raw)
+        if store is None:
+            return set(), {
+                "available": False,
+                "path": str(path),
+                "reason": "manual_completion_revalidation_store_invalid",
+                "valid_task_ids": [],
+                "invalid_task_ids": [],
+            }
+        tasks_by_id = {task.task_id: task for task in tasks}
+        store_generation = int(store["revocation_generation"])
+        valid_task_ids: set[str] = set()
+        invalid_task_ids: set[str] = set()
+        # Empty trusted set ⇒ cold start / first load this process.  Re-admit
+        # self-consistent durable receipts so restarts do not rewalk the DAG.
+        # Non-empty trusted set ⇒ live process: the trusted set remains the
+        # TOCTOU fence against same-UID mid-process store forgery (a forged
+        # self-consistent row must not introduce a new receipt_id).
+        cold_start = not self._trusted_manual_completion_revalidation_receipt_ids
+        confirmed_receipt_ids: set[str] = set()
+        for raw_task_id, raw_receipt in store["records"].items():
+            task_id = str(raw_task_id or "").strip()
+            task = tasks_by_id.get(task_id)
+            if not task_id or task is None or not isinstance(raw_receipt, Mapping):
+                if task_id:
+                    invalid_task_ids.add(task_id)
+                continue
+            receipt = dict(raw_receipt)
+            receipt_id = str(receipt.pop("receipt_id", "") or "")
+            result_digests = receipt.get("validation_result_digests")
+            digest_values = (
+                list(result_digests)
+                if isinstance(result_digests, Sequence)
+                and not isinstance(result_digests, (str, bytes, bytearray))
+                else []
+            )
+            # Structural / current-tree binding checks.
+            structurally_valid = bool(
+                receipt.get("schema")
+                == MANUAL_COMPLETION_REVALIDATION_RECEIPT_SCHEMA
+                and receipt.get("todo_path")
+                == str(self.todo_path.resolve(strict=False))
+                and receipt.get("task_id") == task_id
+                and receipt.get("canonical_task_cid")
+                == self._identity_for_task(task).canonical_task_cid
+                and receipt.get("validation_plan_id")
+                == self._manual_completion_validation_plan_binding(task).get(
+                    "validation_plan_id"
+                )
+                and type(receipt.get("revocation_generation")) is int
+                and receipt.get("revocation_generation") == store_generation
+                and store_generation
+                == self._manual_completion_authority_revocation_generation
+                and receipt.get("manual_completion_authority_context_id")
+                == authority_context_id
+                and isinstance(
+                    receipt.get("validated_tree_identity"), Mapping
+                )
+                and str(receipt.get("validated_tree_id") or "")
+                == content_identity(receipt["validated_tree_identity"])
+                and self._manual_completion_validated_tree_is_current(
+                    receipt["validated_tree_identity"]
+                )
+                and re.fullmatch(
+                    r"b[a-z2-7]+",
+                    str(receipt.get("validation_evidence_id") or ""),
+                )
+                and type(receipt.get("validation_result_count")) is int
+                and receipt.get("validation_result_count")
+                == len(digest_values)
+                and bool(digest_values)
+                and all(
+                    re.fullmatch(
+                        r"[0-9a-f]{64}",
+                        str(digest or ""),
+                    )
+                    for digest in digest_values
+                )
+                and receipt_id
+                and content_identity(receipt) == receipt_id
+            )
+            if not structurally_valid:
+                invalid_task_ids.add(task_id)
+                continue
+            if cold_start or (
+                receipt_id
+                in self._trusted_manual_completion_revalidation_receipt_ids
+            ):
+                self._trusted_manual_completion_revalidation_receipt_ids.add(
+                    receipt_id
+                )
+                confirmed_receipt_ids.add(receipt_id)
+                valid_task_ids.add(task_id)
+            else:
+                # Live process saw a new self-consistent receipt_id that this
+                # process never produced — treat as forged store mutation.
+                invalid_task_ids.add(task_id)
+        if not cold_start:
+            # Drop previously trusted ids whose rows were replaced or removed.
+            self._trusted_manual_completion_revalidation_receipt_ids &= (
+                confirmed_receipt_ids
+            )
+        return valid_task_ids, {
+            "available": True,
+            "path": str(path),
+            "valid_task_ids": sorted(valid_task_ids),
+            "invalid_task_ids": sorted(invalid_task_ids),
+            "store_id": str(store.get("store_id") or ""),
+            "revocation_generation": store_generation,
+            "cold_start_readmission": cold_start,
+        }
+
+    def _manual_completion_validation_plan_binding(
+        self,
+        task: PortalTask,
+    ) -> dict[str, Any]:
+        declared_commands: list[str] = []
+        for raw_command in task.validation:
+            command, _notes = self._normalize_validation_command(raw_command)
+            declared_commands.append(
+                normalize_validation_command_text(command)
+            )
+        binding = {
+            "schema": MANUAL_COMPLETION_VALIDATION_PLAN_SCHEMA,
+            "task_id": task.task_id,
+            "canonical_task_cid": (
+                self._identity_for_task(task).canonical_task_cid
+            ),
+            "declared_dependencies": sorted(
+                {
+                    str(dependency).strip()
+                    for dependency in task.depends_on
+                    if str(dependency).strip()
+                }
+            ),
+            "declared_commands": declared_commands,
+        }
+        return {**binding, "validation_plan_id": content_identity(binding)}
+
+    def _manual_completion_validated_tree_is_current(
+        self,
+        identity: Mapping[str, Any],
+    ) -> bool:
+        """Verify durable tree evidence still names real repository ancestry.
+
+        Receipts bind a concrete commit/tree at validation time.  They remain
+        current when that commit is still present and is equal to **or an
+        ancestor of** the live merge-target HEAD.  Requiring exact HEAD equality
+        reopens the entire revalidation DAG on every ordinary forward commit
+        (seal pins, supervisor fixes, docs), which defeats durable receipts.
+        Authority-package changes still rotate the seal epoch separately.
+        """
+
+        target_commit = str(identity.get("target_commit") or "")
+        if target_commit == "uncommitted":
+            # Non-Git validation evidence remains process-local through the
+            # trusted producer token; restart always forces revalidation.
+            return True
+        if re.fullmatch(r"[0-9a-f]{40,64}", target_commit) is None:
+            return False
+        resolved_tree = self._candidate_repository_tree(target_commit)
+        if not resolved_tree:
+            return False
+        repository_tree_id = str(identity.get("repository_tree_id") or "")
+        if repository_tree_id and repository_tree_id != f"git-tree:{resolved_tree}":
+            return False
+        target_branch = self._main_branch_name()
+        try:
+            current_target = self._run_git(
+                ["rev-parse", "--verify", f"{target_branch}^{{commit}}"],
+                cwd=self.repo_root,
+            ).stdout.strip()
+        except (OSError, RuntimeError):
+            return False
+        if not current_target:
+            return False
+        if current_target == target_commit:
+            return True
+        # merge-base --is-ancestor returns 1 when not an ancestor; do not use
+        # _run_git (it raises on any non-zero).
+        try:
+            ancestry = subprocess.run(
+                [
+                    "git",
+                    "merge-base",
+                    "--is-ancestor",
+                    target_commit,
+                    current_target,
+                ],
+                cwd=self.repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except OSError:
+            return False
+        return ancestry.returncode == 0
+
+    def _persist_manual_completion_revalidation_receipts(
+        self,
+        task_ids: Sequence[str],
+        *,
+        authority_context_id: str,
+        authority_evidence: Mapping[str, Any],
+        expected_target_commit: str = "",
+    ) -> dict[str, Any]:
+        """Persist exact task/CID/context bindings after durable completion."""
+
+        target_task_ids = sorted(
+            {
+                str(task_id).strip()
+                for task_id in task_ids
+                if str(task_id).strip()
+            }
+            & set(self._manual_completion_authority_revalidation_task_ids)
+        )
+        if not target_task_ids:
+            return {"persisted": False, "reason": "not_required"}
+        tasks_by_id = {task.task_id: task for task in self._load_tasks()}
+        missing_task_ids = sorted(set(target_task_ids) - set(tasks_by_id))
+        if missing_task_ids:
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_tasks_missing",
+                "missing_task_ids": missing_task_ids,
+            }
+        bounded_evidence = _bounded_merge_proof_value(
+            authority_evidence,
+            field_name="manual_completion_authority_evidence",
+        )
+        if not isinstance(bounded_evidence, Mapping):
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_evidence_invalid",
+            }
+        evidence_task_id = str(
+            bounded_evidence.get("manual_completion_authority_task_id") or ""
+        )
+        evidence_task_cid = str(
+            bounded_evidence.get("manual_completion_authority_task_cid") or ""
+        )
+        evidence_plan_id = str(
+            bounded_evidence.get(
+                "manual_completion_authority_validation_plan_id"
+            )
+            or ""
+        )
+        validated_tree_identity = bounded_evidence.get(
+            "manual_completion_authority_validated_tree_identity"
+        )
+        validated_tree_id = str(
+            bounded_evidence.get(
+                "manual_completion_authority_validated_tree_id"
+            )
+            or ""
+        )
+        if (
+            target_task_ids != [evidence_task_id]
+            or not isinstance(validated_tree_identity, Mapping)
+            or validated_tree_id
+            != content_identity(validated_tree_identity)
+        ):
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_evidence_binding_invalid",
+            }
+        current_task = tasks_by_id[evidence_task_id]
+        current_task_cid = self._identity_for_task(
+            current_task
+        ).canonical_task_cid
+        current_plan_id = str(
+            self._manual_completion_validation_plan_binding(current_task).get(
+                "validation_plan_id"
+            )
+            or ""
+        )
+        if (
+            evidence_task_cid != current_task_cid
+            or evidence_plan_id != current_plan_id
+        ):
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_task_revision_changed",
+                "expected_task_cid": evidence_task_cid,
+                "current_task_cid": current_task_cid,
+                "expected_validation_plan_id": evidence_plan_id,
+                "current_validation_plan_id": current_plan_id,
+            }
+        raw_results = bounded_evidence.get("results")
+        results = (
+            list(raw_results)
+            if isinstance(raw_results, Sequence)
+            and not isinstance(raw_results, (str, bytes, bytearray))
+            else []
+        )
+        result_digests = [
+            str(result.get("validation_result_digest") or "")
+            for result in results
+            if isinstance(result, Mapping)
+        ]
+        if (
+            not result_digests
+            or len(result_digests) != len(results)
+            or any(
+                re.fullmatch(
+                    r"[0-9a-f]{64}",
+                    digest,
+                )
+                is None
+                for digest in result_digests
+            )
+        ):
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_result_digests_invalid",
+            }
+        path = self._manual_completion_revalidation_store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_ids: dict[str, str] = {}
+        try:
+            with serialized_lock_update(path):
+                if expected_target_commit:
+                    current_target = self._run_git(
+                        [
+                            "rev-parse",
+                            "--verify",
+                            f"{self._main_branch_name()}^{{commit}}",
+                        ],
+                        cwd=self.repo_root,
+                    ).stdout.strip()
+                    if current_target != expected_target_commit:
+                        raise ValueError(
+                            "manual completion target changed before receipt "
+                            "publication"
+                        )
+                raw_store = load_json_dict(path)
+                store = self._validated_manual_completion_revalidation_store(
+                    raw_store
+                )
+                if store is None:
+                    raise ValueError(
+                        "manual completion revalidation store is unavailable"
+                    )
+                if int(store["revocation_generation"]) != int(
+                    self._manual_completion_authority_revocation_generation
+                ):
+                    raise ValueError(
+                        "manual completion revocation generation changed"
+                    )
+                records = dict(store["records"])
+                for task_id in target_task_ids:
+                    receipt = {
+                        "schema": (
+                            MANUAL_COMPLETION_REVALIDATION_RECEIPT_SCHEMA
+                        ),
+                        "todo_path": str(
+                            self.todo_path.resolve(strict=False)
+                        ),
+                        "task_id": task_id,
+                        "canonical_task_cid": evidence_task_cid,
+                        "validation_plan_id": evidence_plan_id,
+                        "validated_tree_identity": dict(
+                            validated_tree_identity
+                        ),
+                        "validated_tree_id": validated_tree_id,
+                        "revocation_generation": int(
+                            self._manual_completion_authority_revocation_generation
+                        ),
+                        "manual_completion_authority_context_id": (
+                            authority_context_id
+                        ),
+                        "validation_evidence_id": content_identity(
+                            bounded_evidence
+                        ),
+                        "validation_result_count": len(result_digests),
+                        "validation_result_digests": result_digests,
+                    }
+                    receipt_id = content_identity(receipt)
+                    records[task_id] = {
+                        **receipt,
+                        "receipt_id": receipt_id,
+                    }
+                    receipt_ids[task_id] = receipt_id
+                written = self._write_manual_completion_revalidation_store(
+                    path,
+                    records=records,
+                    revocation_generation=int(
+                        store["revocation_generation"]
+                    ),
+                    task_statuses={
+                        **dict(store["task_statuses"]),
+                        **{
+                            task_id: normalize_status(
+                                tasks_by_id[task_id].status
+                            )
+                            for task_id in target_task_ids
+                        },
+                    },
+                )
+        except (OSError, RuntimeError, ValueError) as exc:
+            return {
+                "persisted": False,
+                "reason": "revalidation_receipt_persistence_failed",
+                "error_type": type(exc).__name__,
+                "error": str(exc)[-2000:],
+                "path": str(path),
+            }
+        result = {
+            "persisted": True,
+            "path": str(path),
+            "task_ids": target_task_ids,
+            "receipt_ids": receipt_ids,
+            "manual_completion_authority_context_id": authority_context_id,
+            "revocation_generation": (
+                self._manual_completion_authority_revocation_generation
+            ),
+            "store_id": str(written.get("store_id") or ""),
+        }
+        self._trusted_manual_completion_revalidation_receipt_ids.update(
+            receipt_ids.values()
+        )
+        self._record_event(
+            "manual_completion_authority_revalidation_persisted",
+            result,
+        )
+        return result
+
+    def _publish_manual_completion_authority_revalidation_receipt_only(
+        self,
+        task: PortalTask,
+        *,
+        expected_task_cid: str,
+        expected_target_commit: str,
+        authority_context_id: str,
+        authority_evidence: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """CAS-prove one completed claim and publish only its authority receipt."""
+
+        task_id = str(task.task_id or "").strip()
+        failure = {
+            "updated": False,
+            "durable": False,
+            "task_id": task_id,
+            "completion_reason": (
+                "manual_completion_authority_revalidation"
+            ),
+            "expected_task_ids": [task_id] if task_id else [],
+            "authority_receipt_only": True,
+        }
+        if self.task_source is not None:
+            return {
+                **failure,
+                "reason": (
+                    "authority_receipt_only_task_source_unsupported"
+                ),
+            }
+        expected_cid = str(expected_task_cid or "").strip()
+        expected_target = str(expected_target_commit or "").strip()
+        if (
+            not task_id
+            or not expected_cid
+            or not expected_target
+            or normalize_status(task.status) != "completed"
+        ):
+            return {
+                **failure,
+                "reason": "authority_receipt_only_binding_invalid",
+            }
+        authority_rejection = self._manual_completion_authority_rejection(
+            [task_id],
+            authority_context_id=authority_context_id,
+            authority_evidence=authority_evidence,
+        )
+        if authority_rejection is not None:
+            return {
+                **failure,
+                **authority_rejection,
+            }
+        expected_generation = int(
+            self._manual_completion_authority_revocation_generation
+        )
+
+        def publish() -> dict[str, Any]:
+            mutation_rejection = (
+                self._manual_completion_authority_rejection(
+                    [task_id],
+                    authority_context_id=authority_context_id,
+                    authority_evidence=authority_evidence,
+                )
+            )
+            actual_generation = int(
+                self._manual_completion_authority_revocation_generation
+            )
+            if (
+                mutation_rejection is not None
+                or actual_generation != expected_generation
+            ):
+                return {
+                    **failure,
+                    "reason": (
+                        str(mutation_rejection.get("reason") or "")
+                        if mutation_rejection is not None
+                        else (
+                            "manual_completion_authority_generation_changed"
+                        )
+                    ),
+                    "expected_manual_completion_authority_generation": (
+                        expected_generation
+                    ),
+                    "actual_manual_completion_authority_generation": (
+                        actual_generation
+                    ),
+                    **(mutation_rejection or {}),
+                }
+            try:
+                with locked_taskboard(self.todo_path) as taskboard:
+                    path_before = self.todo_path.stat()
+                    descriptor_before = os.fstat(taskboard.fileno())
+                    before_identity = (
+                        int(path_before.st_dev),
+                        int(path_before.st_ino),
+                    )
+                    if before_identity != (
+                        int(descriptor_before.st_dev),
+                        int(descriptor_before.st_ino),
+                    ):
+                        raise RuntimeError(
+                            "taskboard path changed while acquiring CAS lock"
+                        )
+                    taskboard.seek(0)
+                    taskboard_text = taskboard.read()
+                    current_target = self._run_git(
+                        [
+                            "rev-parse",
+                            "--verify",
+                            f"{self._main_branch_name()}^{{commit}}",
+                        ],
+                        cwd=self.repo_root,
+                    ).stdout.strip()
+                    if current_target != expected_target:
+                        return {
+                            **failure,
+                            "reason": (
+                                "manual_completion_authority_target_changed"
+                            ),
+                            "expected_target_commit": expected_target,
+                            "actual_target_commit": current_target,
+                        }
+                    parsed = parse_task_text(
+                        taskboard_text,
+                        path=self.todo_path,
+                        task_header_prefix=self.task_header_prefix,
+                    )
+                    matches = [
+                        candidate
+                        for candidate in parsed
+                        if candidate.task_id == task_id
+                    ]
+                    current_cid = (
+                        self._identity_for_task(matches[0]).canonical_task_cid
+                        if len(matches) == 1
+                        else ""
+                    )
+                    current_status = (
+                        normalize_status(matches[0].status)
+                        if len(matches) == 1
+                        else ""
+                    )
+                    if (
+                        len(matches) != 1
+                        or current_cid != expected_cid
+                        or current_status != "completed"
+                    ):
+                        status_mismatches = (
+                            {
+                                task_id: {
+                                    "expected_status": "completed",
+                                    "current_status": current_status,
+                                }
+                            }
+                            if current_status != "completed"
+                            else {}
+                        )
+                        return {
+                            **failure,
+                            "reason": (
+                                "completion_task_status_changed"
+                                if current_status != "completed"
+                                else "completion_task_revision_changed"
+                            ),
+                            "expected_task_cid": expected_cid,
+                            "current_task_cid": current_cid,
+                            "expected_status": "completed",
+                            "current_status": current_status,
+                            "match_count": len(matches),
+                            "status_mismatches": status_mismatches,
+                        }
+                    receipt = (
+                        self._persist_manual_completion_revalidation_receipts(
+                            [task_id],
+                            authority_context_id=authority_context_id,
+                            authority_evidence=authority_evidence,
+                            expected_target_commit=expected_target,
+                        )
+                    )
+                    taskboard.seek(0)
+                    taskboard_after = taskboard.read()
+                    path_after = self.todo_path.stat()
+                    descriptor_after = os.fstat(taskboard.fileno())
+                    after_identity = (
+                        int(path_after.st_dev),
+                        int(path_after.st_ino),
+                    )
+                    stable = bool(
+                        taskboard_after == taskboard_text
+                        and after_identity == before_identity
+                        and after_identity
+                        == (
+                            int(descriptor_after.st_dev),
+                            int(descriptor_after.st_ino),
+                        )
+                    )
+            except (
+                OSError,
+                RuntimeError,
+                TaskSourceError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                return {
+                    **failure,
+                    "reason": "authority_receipt_only_cas_failed",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc)[-2000:],
+                }
+            persisted = bool(
+                stable and receipt.get("persisted") is True
+            )
+            result = {
+                **failure,
+                "durable": persisted,
+                "reason": (
+                    "already_completed"
+                    if persisted
+                    else str(receipt.get("reason") or "")
+                    or "revalidation_receipt_not_durable"
+                ),
+                "path": str(self.todo_path),
+                "updated_task_ids": [],
+                "already_completed_task_ids": [task_id],
+                "missing_task_ids": [],
+                "missing_status_task_ids": [],
+                "inserted_status_task_ids": [],
+                "updated_checkbox_task_ids": [],
+                "expected_target_commit": expected_target,
+                "observed_target_commit": expected_target,
+                "taskboard_revision": taskboard_revision(
+                    taskboard_text
+                ),
+                "protected_board_postcondition": {
+                    "checked": True,
+                    "trusted": persisted,
+                    "unchanged": stable,
+                    "reason": (
+                        "authority_receipt_only_cas_proven"
+                        if persisted
+                        else "authority_receipt_only_cas_unproven"
+                    ),
+                    "taskboard_revision": taskboard_revision(
+                        taskboard_text
+                    ),
+                    "canonical_task_cid": current_cid,
+                    "status": current_status,
+                    "target_commit": expected_target,
+                },
+                "manual_completion_authority_revalidation_receipt": (
+                    receipt
+                ),
+            }
+            return result
+
+        return self._run_checkout_mutation_transaction(
+            task_id=task_id,
+            operation=(
+                "publish_manual_completion_authority_revalidation_receipt"
+            ),
+            callback=publish,
+            failure_fields=failure,
+            extra={
+                "expected_task_cid": expected_cid,
+                "expected_target_commit": expected_target,
+            },
+        )
+
+    def _refresh_manual_completion_authority_guard(
+        self,
+        tasks: Sequence[PortalTask] | None = None,
+    ) -> dict[str, Any]:
+        """Refresh the exact root/descendant completion-authority fence."""
+
+        configured = bool(self.manual_completion_authority_task_ids)
+        if not configured:
+            self._manual_completion_authority_revocation_generation = 0
+            self._manual_completion_authority_effective_required_task_ids = (
+                frozenset()
+            )
+            self._manual_completion_authority_hard_blocked_task_ids = (
+                frozenset()
+            )
+            self._manual_completion_authority_revalidation_task_ids = (
+                frozenset()
+            )
+            self._manual_completion_authority_historical_task_ids = (
+                frozenset()
+            )
+            self._manual_completion_authority_affected_goal_ids = (
+                frozenset()
+            )
+            return {
+                "available": True,
+                "configured": False,
+                "_tasks": list(tasks) if tasks is not None else None,
+            }
+        try:
+            current_tasks = list(tasks) if tasks is not None else self._load_tasks()
+        except Exception as exc:
+            # Descendants cannot be derived without the canonical board.  Do
+            # not let an old callback or merge run with only the root subset.
+            return {
+                "available": False,
+                "configured": True,
+                "reason": "manual_completion_authority_guard_unavailable",
+                "error_type": type(exc).__name__,
+                "error": str(exc)[-2000:],
+                "_tasks": None,
+            }
+
+        task_id_counts: dict[str, int] = {}
+        for task in current_tasks:
+            task_id_counts[task.task_id] = task_id_counts.get(task.task_id, 0) + 1
+        missing_root_task_ids = sorted(
+            set(self.manual_completion_authority_task_ids) - set(task_id_counts)
+        )
+        duplicate_root_task_ids = sorted(
+            task_id
+            for task_id in self.manual_completion_authority_task_ids
+            if task_id_counts.get(task_id, 0) != 1
+        )
+        if missing_root_task_ids or duplicate_root_task_ids:
+            return {
+                "available": False,
+                "configured": True,
+                "reason": "manual_completion_authority_guard_roots_invalid",
+                "missing_root_task_ids": missing_root_task_ids,
+                "duplicate_root_task_ids": duplicate_root_task_ids,
+                "_tasks": None,
+            }
+        declared_task_ids = set(task_id_counts)
+        declared_goal_ids = {
+            goal_id
+            for task in current_tasks
+            for goal_id in split_csv(task.metadata.get("goal id", ""))
+        }
+        task_goal_id_collisions = sorted(
+            declared_task_ids & declared_goal_ids
+        )
+        if task_goal_id_collisions:
+            return {
+                "available": False,
+                "configured": True,
+                "reason": "manual_completion_authority_task_goal_collision",
+                "task_goal_id_collisions": task_goal_id_collisions,
+                "_tasks": None,
+            }
+        staged_roots = (
+            set(self.manual_completion_authority_task_ids)
+            & declared_task_ids
+        )
+        task_status_by_id = {
+            task.task_id: normalize_status(task.status)
+            for task in current_tasks
+        }
+        live_revoked_roots = {
+            task_id
+            for task_id in staged_roots
+            if task_status_by_id.get(task_id) != "completed"
+        }
+        required_roots = (
+            set(self.manual_completion_authority_required_task_ids)
+            | live_revoked_roots
+        ) & declared_task_ids
+        self._manual_completion_authority_effective_required_task_ids = (
+            frozenset(required_roots)
+        )
+        required_descendants = transitive_task_dependents(
+            current_tasks,
+            root_task_ids=required_roots,
+        )
+        staged_descendants = transitive_task_dependents(
+            current_tasks,
+            root_task_ids=staged_roots,
+        )
+        authority_scope_task_ids = staged_roots | staged_descendants
+        revocation_guard = (
+            self._synchronize_manual_completion_revocation_generation(
+                task_statuses={
+                    task_id: task_status_by_id[task_id]
+                    for task_id in sorted(authority_scope_task_ids)
+                }
+            )
+        )
+        if revocation_guard.get("available") is not True:
+            self._manual_completion_authority_hard_blocked_task_ids = (
+                frozenset(authority_scope_task_ids)
+            )
+            self._manual_completion_authority_revalidation_task_ids = (
+                frozenset(staged_descendants)
+            )
+            return {
+                "available": False,
+                "configured": True,
+                "reason": "manual_completion_revocation_state_unavailable",
+                "revocation_guard": revocation_guard,
+                "hard_blocked_task_ids": sorted(authority_scope_task_ids),
+                "_tasks": None,
+            }
+        receipt_task_ids, receipt_guard = (
+            self._current_manual_completion_revalidation_receipts(
+                current_tasks,
+                authority_context_id=(
+                    self._manual_completion_authority_policy_id()
+                ),
+            )
+        )
+        current_revalidated_completed_task_ids = {
+            task_id
+            for task_id in receipt_task_ids & staged_descendants
+            if task_status_by_id.get(task_id) == "completed"
+        }
+        hard_blocked_task_ids = required_roots | required_descendants
+        revalidation_task_ids = required_descendants | (
+            staged_descendants - current_revalidated_completed_task_ids
+        )
+        historical_task_ids = required_roots | revalidation_task_ids
+        affected_goal_ids = {
+            goal_id
+            for task in current_tasks
+            if task.task_id in historical_task_ids
+            for goal_id in split_csv(task.metadata.get("goal id", ""))
+        }
+        self._manual_completion_authority_hard_blocked_task_ids = frozenset(
+            hard_blocked_task_ids
+        )
+        self._manual_completion_authority_revalidation_task_ids = frozenset(
+            revalidation_task_ids
+        )
+        self._manual_completion_authority_historical_task_ids = frozenset(
+            historical_task_ids
+        )
+        self._manual_completion_authority_affected_goal_ids = frozenset(
+            affected_goal_ids
+        )
+        return {
+            "available": True,
+            "configured": True,
+            "required_task_ids": sorted(required_roots),
+            "live_revoked_task_ids": sorted(live_revoked_roots),
+            "revalidation_receipt_task_ids": sorted(
+                current_revalidated_completed_task_ids
+            ),
+            "revalidation_receipt_guard": receipt_guard,
+            "revocation_guard": revocation_guard,
+            "revocation_generation": (
+                self._manual_completion_authority_revocation_generation
+            ),
+            "hard_blocked_task_ids": sorted(hard_blocked_task_ids),
+            "revalidation_task_ids": sorted(revalidation_task_ids),
+            "historical_task_ids": sorted(historical_task_ids),
+            "affected_goal_ids": sorted(affected_goal_ids),
+            "_tasks": current_tasks,
+        }
+
+    def _manual_completion_authority_policy_id(self) -> str:
+        """Return the binding for staged-root completion evidence.
+
+        Bind the *configured* required roots (not the live-revoked effective
+        set) so ordinary completion of an already-activated root does not
+        rewrite every durable receipt's context id.  Live revocation still
+        expands hard-blocks / revalidation sets via
+        ``_refresh_manual_completion_authority_guard`` and bumps the
+        revocation generation.  Scheduler epoch remains bound so a true seal
+        package reseal invalidates prior evidence.
+        """
+
+        return content_identity(
+            {
+                "schema": (
+                    "ipfs_accelerate_py.agent_supervisor."
+                    "manual-completion-authority-context@4"
+                ),
+                "todo_path": str(self.todo_path.resolve(strict=False)),
+                "task_ids": sorted(self.manual_completion_authority_task_ids),
+                "required_task_ids": sorted(
+                    self.manual_completion_authority_required_task_ids
+                ),
+                "scheduler_epoch_id": (
+                    self.manual_completion_authority_epoch_id
+                ),
+                "revocation_generation": (
+                    self._manual_completion_authority_revocation_generation
+                ),
+            }
+        )
+
+    def _manual_completion_authority_renewal_key(
+        self,
+        task: PortalTask,
+        *,
+        target_commit: str = "",
+    ) -> str:
+        """Bind retry/quarantine state to the exact renewable proof claim."""
+
+        resolved_target = str(target_commit or "").strip()
+        if not resolved_target:
+            try:
+                resolved_target = self._run_git(
+                    [
+                        "rev-parse",
+                        "--verify",
+                        f"{self._main_branch_name()}^{{commit}}",
+                    ],
+                    cwd=self.repo_root,
+                ).stdout.strip()
+            except (OSError, RuntimeError):
+                resolved_target = "unavailable"
+        try:
+            validation_contract = (
+                canonical_validation_environment_contract()
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            validation_contract = {
+                "schema": (
+                    "ipfs_accelerate_py.agent_supervisor."
+                    "validation-environment-contract-unavailable@1"
+                ),
+                "error_type": type(exc).__name__,
+            }
+        isolation_contract = self._authority_validation_isolation_contract()
+        return content_identity(
+            {
+                "schema": (
+                    "ipfs_accelerate_py.agent_supervisor."
+                    "manual-completion-authority-renewal-key@1"
+                ),
+                "task_id": task.task_id,
+                "canonical_task_cid": self._canonical_ref(task),
+                "validation_plan_id": str(
+                    self._manual_completion_validation_plan_binding(task).get(
+                        "validation_plan_id"
+                    )
+                    or ""
+                ),
+                "target_commit": resolved_target,
+                "authority_context_id": (
+                    self._manual_completion_authority_policy_id()
+                ),
+                "revocation_generation": int(
+                    self._manual_completion_authority_revocation_generation
+                ),
+                "validation_environment_contract_id": content_identity(
+                    validation_contract
+                ),
+                "authority_validation_isolation_contract_id": str(
+                    isolation_contract.get("contract_id") or ""
+                ),
+            }
+        )
+
+    @staticmethod
+    def _authority_validation_isolation_contract() -> dict[str, Any]:
+        """Resolve the exact local, content-pinned CUDA validation sandbox."""
+
+        base: dict[str, Any] = {
+            "schema": (
+                "ipfs_accelerate_py.agent_supervisor."
+                "authority-validation-isolation@2"
+            ),
+            "backend": "docker-local-cuda",
+            "docker_endpoint": AUTHORITY_VALIDATION_DOCKER_ENDPOINT,
+            "network_mode": "none",
+            "host_filesystem": "workspace_only_read_only",
+            "workspace_mode": "read_only",
+            "writable_filesystems": ["private_tmpfs", "private_shm"],
+            "pid_namespace": "private",
+            "capabilities": "none",
+            "no_new_privileges": True,
+            "container_auto_remove": True,
+            "container_root": "read_only",
+            "image_pull_allowed": False,
+            "container_log_driver": "none",
+            "output_limit_bytes": AUTHORITY_VALIDATION_OUTPUT_LIMIT_BYTES,
+            "memory_limit_bytes": AUTHORITY_VALIDATION_MEMORY_LIMIT_BYTES,
+            "tmpfs_limit_bytes": AUTHORITY_VALIDATION_TMPFS_LIMIT_BYTES,
+            "cpu_limit": AUTHORITY_VALIDATION_CPU_LIMIT,
+            "pids_limit": AUTHORITY_VALIDATION_PIDS_LIMIT,
+            "timeout_limit_seconds": (
+                AUTHORITY_VALIDATION_TIMEOUT_LIMIT_SECONDS
+            ),
+            "gpu_requested": True,
+            "validation_site_packages": (
+                AUTHORITY_VALIDATION_IMAGE_SITE_PACKAGES
+            ),
+        }
+        docker_host = str(os.environ.get("DOCKER_HOST") or "").strip()
+        docker_context = str(
+            os.environ.get("DOCKER_CONTEXT") or ""
+        ).strip()
+        allowed_hosts = {
+            "",
+            AUTHORITY_VALIDATION_DOCKER_ENDPOINT,
+            "unix:///var/run/docker.sock",
+        }
+        if docker_host not in allowed_hosts or docker_context not in {
+            "",
+            "default",
+        }:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_nonlocal_docker_forbidden",
+                "configured_docker_host": docker_host,
+                "configured_docker_context": docker_context,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        socket_path = Path(
+            AUTHORITY_VALIDATION_DOCKER_ENDPOINT.removeprefix("unix://")
+        )
+        try:
+            resolved_socket = socket_path.resolve(strict=True)
+            socket_stat = resolved_socket.stat()
+            socket_valid = bool(
+                resolved_socket == Path("/run/docker.sock")
+                and stat_module.S_ISSOCK(socket_stat.st_mode)
+                and int(socket_stat.st_uid) == 0
+                and stat_module.S_IMODE(socket_stat.st_mode) & 0o007 == 0
+            )
+        except OSError as exc:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_local_docker_socket_invalid",
+                "error_type": type(exc).__name__,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        if not socket_valid:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_local_docker_socket_invalid",
+                "docker_socket_path": str(resolved_socket),
+            }
+            return {**body, "contract_id": content_identity(body)}
+        try:
+            docker_path = AUTHORITY_VALIDATION_DOCKER_PATH.resolve(
+                strict=True
+            )
+            docker_stat = docker_path.stat()
+            docker_sha256 = hashlib.sha256(
+                docker_path.read_bytes()
+            ).hexdigest()
+            nvidia_smi_path = (
+                AUTHORITY_VALIDATION_NVIDIA_SMI_PATH.resolve(strict=True)
+            )
+            nvidia_smi_stat = nvidia_smi_path.stat()
+            nvidia_smi_sha256 = hashlib.sha256(
+                nvidia_smi_path.read_bytes()
+            ).hexdigest()
+        except OSError as exc:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_docker_unreadable",
+                "error_type": type(exc).__name__,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        trusted_binaries = bool(
+            docker_path == AUTHORITY_VALIDATION_DOCKER_PATH
+            and stat_module.S_ISREG(docker_stat.st_mode)
+            and int(docker_stat.st_uid) == 0
+            and stat_module.S_IMODE(docker_stat.st_mode) & 0o022 == 0
+            and os.access(docker_path, os.X_OK)
+            and docker_sha256 == AUTHORITY_VALIDATION_DOCKER_SHA256
+            and nvidia_smi_path == AUTHORITY_VALIDATION_NVIDIA_SMI_PATH
+            and stat_module.S_ISREG(nvidia_smi_stat.st_mode)
+            and int(nvidia_smi_stat.st_uid) == 0
+            and stat_module.S_IMODE(nvidia_smi_stat.st_mode) & 0o022 == 0
+            and os.access(nvidia_smi_path, os.X_OK)
+            and nvidia_smi_sha256
+            == AUTHORITY_VALIDATION_NVIDIA_SMI_SHA256
+        )
+        if not trusted_binaries:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_tcb_binary_unapproved",
+                "docker_path": str(docker_path),
+                "docker_sha256": docker_sha256,
+                "nvidia_smi_path": str(nvidia_smi_path),
+                "nvidia_smi_sha256": nvidia_smi_sha256,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        image_reference = str(
+            os.environ.get(AUTHORITY_VALIDATION_CONTAINER_IMAGE_ENV)
+            or DEFAULT_AUTHORITY_VALIDATION_CONTAINER_IMAGE
+        ).strip()
+        if image_reference != DEFAULT_AUTHORITY_VALIDATION_CONTAINER_IMAGE:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_image_unapproved",
+                "docker_path": str(docker_path),
+                "docker_sha256": docker_sha256,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        docker_environment = {
+            "DOCKER_CONFIG": "/nonexistent/ipfs-accelerate-docker-config",
+            "DOCKER_HOST": AUTHORITY_VALIDATION_DOCKER_ENDPOINT,
+            "HOME": "/nonexistent/ipfs-accelerate-docker-home",
+            "PATH": os.defpath,
+        }
+        docker_prefix = [
+            str(docker_path),
+            "--host",
+            AUTHORITY_VALIDATION_DOCKER_ENDPOINT,
+        ]
+        try:
+            info = subprocess.run(
+                [
+                    *docker_prefix,
+                    "info",
+                    "--format",
+                    "{{json .SecurityOptions}}",
+                ],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=10,
+                check=False,
+                env=docker_environment,
+            )
+            server = subprocess.run(
+                [
+                    *docker_prefix,
+                    "version",
+                    "--format",
+                    "{{.Server.Version}}|{{.Server.Os}}|{{.Server.Arch}}",
+                ],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=10,
+                check=False,
+                env=docker_environment,
+            )
+            image = subprocess.run(
+                [
+                    *docker_prefix,
+                    "image",
+                    "inspect",
+                    "--format",
+                    "{{.Id}}",
+                    image_reference,
+                ],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=10,
+                check=False,
+                env=docker_environment,
+            )
+            gpu = subprocess.run(
+                [
+                    str(nvidia_smi_path),
+                    "--query-gpu=uuid,driver_version",
+                    "--format=csv,noheader,nounits",
+                ],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=10,
+                check=False,
+                env={"HOME": "/nonexistent", "PATH": os.defpath},
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            body = {
+                **base,
+                "available": False,
+                "reason": "authority_validation_docker_probe_failed",
+                "docker_path": str(docker_path),
+                "docker_sha256": docker_sha256,
+                "image_reference": image_reference,
+                "error_type": type(exc).__name__,
+            }
+            return {**body, "contract_id": content_identity(body)}
+        security_output = str(info.stdout or "").strip()
+        server_identity = str(server.stdout or "").strip()
+        image_id = str(image.stdout or "").strip()
+        gpu_lines = [
+            line.strip()
+            for line in str(gpu.stdout or "").splitlines()
+            if line.strip()
+        ]
+        gpu_identity = gpu_lines[0] if gpu_lines else ""
+        gpu_uuid = gpu_identity.split(",", 1)[0].strip()
+        security_options_valid = bool(
+            info.returncode == 0
+            and "name=seccomp" in security_output
+            and "name=cgroupns" in security_output
+            and "name=apparmor" in security_output
+        )
+        server_valid = bool(
+            server.returncode == 0
+            and server_identity
+            == AUTHORITY_VALIDATION_DOCKER_SERVER_IDENTITY
+        )
+        image_valid = bool(
+            image.returncode == 0
+            and image_id == DEFAULT_AUTHORITY_VALIDATION_CONTAINER_IMAGE
+        )
+        gpu_valid = bool(
+            gpu.returncode == 0
+            and gpu_identity == AUTHORITY_VALIDATION_GPU_IDENTITY
+            and gpu_uuid == AUTHORITY_VALIDATION_GPU_UUID
+        )
+        body = {
+            **base,
+            "available": bool(
+                security_options_valid
+                and server_valid
+                and image_valid
+                and gpu_valid
+            ),
+            "reason": (
+                "available"
+                if (
+                    security_options_valid
+                    and server_valid
+                    and image_valid
+                    and gpu_valid
+                )
+                else "authority_validation_docker_contract_unavailable"
+            ),
+            "docker_path": str(docker_path),
+            "docker_sha256": docker_sha256,
+            "docker_socket_path": str(resolved_socket),
+            "docker_socket_device": int(socket_stat.st_dev),
+            "docker_socket_inode": int(socket_stat.st_ino),
+            "docker_socket_mode": stat_module.S_IMODE(socket_stat.st_mode),
+            "docker_server_identity": server_identity,
+            "security_options": security_output,
+            "image_reference": image_reference,
+            "image_id": image_id if image_valid else "",
+            "nvidia_smi_path": str(nvidia_smi_path),
+            "nvidia_smi_sha256": nvidia_smi_sha256,
+            "gpu_identity": gpu_identity if gpu_valid else "",
+            "gpu_uuid": gpu_uuid if gpu_valid else "",
+        }
+        return {**body, "contract_id": content_identity(body)}
+
+    def _record_manual_completion_authority_renewal_outcome(
+        self,
+        task: PortalTask,
+        returncode: int,
+        *,
+        renewal_key: str,
+        reason: str = "",
+    ) -> dict[str, Any]:
+        canonical_task_cid = self._canonical_ref(task)
+        if returncode == 0:
+            self.task_queue.record_authority_renewal_success(
+                canonical_task_cid,
+                renewal_key,
+            )
+        else:
+            self.task_queue.record_authority_renewal_failure(
+                canonical_task_cid,
+                renewal_key,
+                reason=reason,
+                max_failures=(
+                    MANUAL_COMPLETION_AUTHORITY_RENEWAL_MAX_FAILURES
+                ),
+                base_cooldown_seconds=(
+                    MANUAL_COMPLETION_AUTHORITY_RENEWAL_BASE_COOLDOWN_SECONDS
+                ),
+                max_cooldown_seconds=(
+                    MANUAL_COMPLETION_AUTHORITY_RENEWAL_MAX_COOLDOWN_SECONDS
+                ),
+            )
+        self.task_queue.save()
+        return self.task_queue.authority_renewal_state(
+            canonical_task_cid,
+            renewal_key,
+        )
+
+    def _manual_completion_authority_rejection(
+        self,
+        task_ids: Iterable[str],
+        *,
+        authority_context_id: str = "",
+        authority_evidence: Mapping[str, Any] | None = None,
+        expected_validated_tree_identity: Mapping[str, Any] | None = None,
+        refresh: bool = True,
+    ) -> dict[str, Any] | None:
+        """Reject a completion/integration touching a currently gated closure."""
+
+        expected_task_ids = {
+            str(task_id).strip()
+            for task_id in task_ids
+            if str(task_id).strip()
+        }
+        if not self.manual_completion_authority_task_ids:
+            return None
+        guard = (
+            self._refresh_manual_completion_authority_guard()
+            if refresh
+            else {"available": True}
+        )
+        if guard.get("available") is not True:
+            return {
+                key: value
+                for key, value in guard.items()
+                if key != "_tasks"
+            }
+        blocked_task_ids = sorted(
+            expected_task_ids
+            & set(
+                self._manual_completion_authority_hard_blocked_task_ids
+            )
+        )
+        if not blocked_task_ids:
+            revalidation_task_ids = sorted(
+                expected_task_ids
+                & set(
+                    self._manual_completion_authority_revalidation_task_ids
+                )
+            )
+            if not revalidation_task_ids:
+                return None
+            expected_context_id = (
+                self._manual_completion_authority_policy_id()
+            )
+            evidence = (
+                dict(authority_evidence)
+                if isinstance(authority_evidence, Mapping)
+                else {}
+            )
+            raw_results = evidence.get("results")
+            validation_results = (
+                [item for item in raw_results if isinstance(item, Mapping)]
+                if isinstance(raw_results, Sequence)
+                and not isinstance(raw_results, (str, bytes, bytearray))
+                else []
+            )
+            evidence_task_id = str(
+                evidence.get("manual_completion_authority_task_id") or ""
+            )
+            evidence_task_cid = str(
+                evidence.get("manual_completion_authority_task_cid") or ""
+            )
+            evidence_plan_id = str(
+                evidence.get(
+                    "manual_completion_authority_validation_plan_id"
+                )
+                or ""
+            )
+            evidence_generation = evidence.get(
+                "manual_completion_authority_revocation_generation"
+            )
+            validated_tree_identity = evidence.get(
+                "manual_completion_authority_validated_tree_identity"
+            )
+            validated_tree_id = str(
+                evidence.get(
+                    "manual_completion_authority_validated_tree_id"
+                )
+                or ""
+            )
+            current_tasks_by_id = {
+                task.task_id: task
+                for task in guard.get("_tasks", ())
+                if isinstance(task, PortalTask)
+            }
+            evidence_task = current_tasks_by_id.get(evidence_task_id)
+            pending_revalidation_prerequisite_ids = sorted(
+                {
+                    str(dependency_id).strip()
+                    for dependency_id in (
+                        evidence_task.depends_on
+                        if evidence_task is not None
+                        else ()
+                    )
+                    if str(dependency_id).strip()
+                    in self._manual_completion_authority_revalidation_task_ids
+                }
+            )
+            current_plan_binding = (
+                self._manual_completion_validation_plan_binding(evidence_task)
+                if evidence_task is not None
+                else {}
+            )
+            evidence_result_count = evidence.get(
+                "manual_completion_authority_validation_result_count"
+            )
+            evidence_id = self._manual_completion_revalidation_evidence_id(
+                evidence
+            )
+            producer_trusted = bool(
+                evidence_id
+                in self._trusted_manual_completion_revalidation_evidence_ids
+            )
+            runtime_tree_identity_valid = bool(
+                isinstance(validated_tree_identity, Mapping)
+                and set(validated_tree_identity)
+                == {
+                    "schema",
+                    "target_commit",
+                    "dependency_state_id",
+                    "candidate_binding_id",
+                }
+                and validated_tree_identity.get("schema")
+                == (
+                    "ipfs_accelerate_py.agent_supervisor."
+                    "manual-completion-validated-tree@1"
+                )
+                and str(validated_tree_identity.get("target_commit") or "")
+                and re.fullmatch(
+                    r"b[a-z2-7]+",
+                    str(
+                        validated_tree_identity.get("dependency_state_id")
+                        or ""
+                    ),
+                )
+                and re.fullmatch(
+                    r"b[a-z2-7]+",
+                    str(
+                        validated_tree_identity.get("candidate_binding_id")
+                        or ""
+                    ),
+                )
+            )
+            candidate_tree_identity_valid = bool(
+                isinstance(validated_tree_identity, Mapping)
+                and set(validated_tree_identity)
+                == {"schema", "target_commit", "repository_tree_id"}
+                and validated_tree_identity.get("schema")
+                == (
+                    "ipfs_accelerate_py.agent_supervisor."
+                    "manual-completion-validated-tree@1"
+                )
+                and re.fullmatch(
+                    r"[0-9a-f]{40,64}",
+                    str(validated_tree_identity.get("target_commit") or ""),
+                )
+                and re.fullmatch(
+                    r"git-tree:[0-9a-f]{40,64}",
+                    str(
+                        validated_tree_identity.get("repository_tree_id")
+                        or ""
+                    ),
+                )
+            )
+            expected_tree_identity_valid = bool(
+                isinstance(expected_validated_tree_identity, Mapping)
+                and isinstance(validated_tree_identity, Mapping)
+                and dict(validated_tree_identity)
+                == dict(expected_validated_tree_identity)
+            )
+            validated_tree_binding_valid = bool(
+                producer_trusted
+                and (
+                    expected_tree_identity_valid
+                    if expected_validated_tree_identity is not None
+                    else (
+                        runtime_tree_identity_valid
+                        or (
+                            candidate_tree_identity_valid
+                            and self._manual_completion_validated_tree_is_current(
+                                validated_tree_identity
+                            )
+                        )
+                    )
+                )
+            )
+
+            def explicit_zero_returncode(value: Any) -> bool:
+                return bool(
+                    (type(value) is int and value == 0)
+                    or (type(value) is str and value == "0")
+                )
+
+            current_isolation_contract = (
+                self._authority_validation_isolation_contract()
+            )
+
+            def successful_uncached_result(item: Mapping[str, Any]) -> bool:
+                raw_returncode = item.get("returncode")
+                if not explicit_zero_returncode(raw_returncode):
+                    return False
+                result_digest = str(
+                    item.get("validation_result_digest") or ""
+                )
+                raw_receipt = item.get(
+                    "authority_validation_isolation_receipt"
+                )
+                isolation_receipt = (
+                    dict(raw_receipt)
+                    if isinstance(raw_receipt, Mapping)
+                    else {}
+                )
+                receipt_id = str(
+                    isolation_receipt.pop("receipt_id", "") or ""
+                )
+                isolation_valid = bool(
+                    current_isolation_contract.get("available") is True
+                    and isolation_receipt.get("backend")
+                    == "docker-local-cuda"
+                    and isolation_receipt.get("contract_id")
+                    == current_isolation_contract.get("contract_id")
+                    and isolation_receipt.get("image_id")
+                    == current_isolation_contract.get("image_id")
+                    and isolation_receipt.get("network_mode") == "none"
+                    and isolation_receipt.get("host_filesystem")
+                    == "workspace_only_read_only"
+                    and isolation_receipt.get("workspace_read_only") is True
+                    and isolation_receipt.get("private_pid_namespace") is True
+                    and isolation_receipt.get("capabilities_dropped") == "all"
+                    and isolation_receipt.get("no_new_privileges") is True
+                    and isolation_receipt.get("container_removed") is True
+                    and isolation_receipt.get("process_tree_quiesced") is True
+                    and isolation_receipt.get("output_bounded") is True
+                    and isolation_receipt.get("storage_bounded") is True
+                    and isolation_receipt.get("cpu_bounded") is True
+                    and isolation_receipt.get("gpu_requested") is True
+                    and receipt_id
+                    and receipt_id == content_identity(isolation_receipt)
+                )
+                return bool(
+                    str(item.get("command") or "").strip()
+                    and item.get("cache_hit") is False
+                    and item.get("timed_out") is False
+                    and item.get("infrastructure_failure") is not True
+                    and isolation_valid
+                    and re.fullmatch(
+                        r"[0-9a-f]{64}",
+                        result_digest,
+                    )
+                )
+
+            evidence_valid = bool(
+                evidence.get("attempted") is True
+                and evidence.get("passed") is True
+                and explicit_zero_returncode(evidence.get("returncode"))
+                and evidence.get(
+                    "manual_completion_authority_revalidation"
+                )
+                is True
+                and evidence.get(
+                    "manual_completion_authority_force_uncached"
+                )
+                is True
+                # One command report is issued for one canonical task.  It
+                # must never authorize sibling bundle members that did not
+                # run their own current-epoch validation.
+                and set(revalidation_task_ids) == {evidence_task_id}
+                and evidence_task is not None
+                and not pending_revalidation_prerequisite_ids
+                and evidence_task_cid
+                == str(current_plan_binding.get("canonical_task_cid") or "")
+                and evidence_plan_id
+                == str(current_plan_binding.get("validation_plan_id") or "")
+                and evidence.get(
+                    "manual_completion_authority_declared_validation_commands"
+                )
+                == current_plan_binding.get("declared_commands")
+                and type(evidence_generation) is int
+                and evidence_generation
+                == self._manual_completion_authority_revocation_generation
+                and isinstance(validated_tree_identity, Mapping)
+                and validated_tree_id
+                == content_identity(validated_tree_identity)
+                and validated_tree_binding_valid
+                and validation_results
+                and len(validation_results) == len(raw_results)
+                and type(evidence_result_count) is int
+                and evidence_result_count == len(validation_results)
+                and all(successful_uncached_result(item) for item in validation_results)
+            )
+            evidence_context_id = str(
+                evidence.get("manual_completion_authority_context_id") or ""
+            )
+            supplied_context_id = str(authority_context_id or "")
+            if (
+                evidence_context_id == expected_context_id
+                and (
+                    not supplied_context_id
+                    or supplied_context_id == expected_context_id
+                )
+                and evidence_valid
+            ):
+                return None
+            return {
+                "reason": (
+                    "manual_completion_authority_prerequisite_"
+                    "revalidation_required"
+                    if pending_revalidation_prerequisite_ids
+                    else "manual_completion_authority_revalidation_required"
+                ),
+                "manual_completion_authority_revalidation_task_ids": (
+                    revalidation_task_ids
+                ),
+                "expected_manual_completion_authority_context_id": (
+                    expected_context_id
+                ),
+                "actual_manual_completion_authority_context_id": str(
+                    evidence_context_id
+                ),
+                "manual_completion_authority_evidence_valid": evidence_valid,
+                "manual_completion_authority_pending_prerequisite_task_ids": (
+                    pending_revalidation_prerequisite_ids
+                ),
+            }
+        blocked_roots = sorted(
+            set(blocked_task_ids)
+            & set(
+                self._manual_completion_authority_effective_required_task_ids
+            )
+        )
+        return {
+            "reason": (
+                "manual_completion_authority_required"
+                if set(blocked_task_ids) == set(blocked_roots)
+                else "manual_completion_authority_dependency_required"
+            ),
+            "manual_completion_authority_required_task_ids": blocked_roots,
+            "manual_completion_authority_blocked_task_ids": blocked_task_ids,
+            "manual_completion_authority_hard_blocked_task_ids": sorted(
+                self._manual_completion_authority_hard_blocked_task_ids
+            ),
+        }
+
+    @staticmethod
+    def _authoritative_validation_environment_guidance() -> str:
+        """Render fail-closed validation-environment guidance for prompts.
+
+        Full path/interpreter contracts are owned by ValidationScheduler /
+        validation_runtime.  This guidance remains honest without depending on
+        a helper that is not yet present on every merge surface.
+        """
+
+        return (
+            "## Authoritative validation environment (fail-closed)\n"
+            "- Validation commands run under the scheduler's sealed environment "
+            "and a fresh private HOME; inherited operator PATH/HOME are ignored.\n"
+            "- Do not weaken product assertions or tests to hide environment "
+            "misconfiguration.\n"
+        )
+
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -159,6 +159,10 @@ from ..validation.validation_scheduler import (
     ValidationScheduler,
     build_declared_validation_plan_graph,
 )
+from .contract_packet_provider_router import (
+    IMPLEMENTATION_PROVIDER_ROUTER_INTERFACE,
+    PROVIDER_EXECUTION_RECEIPT_INTERFACE,
+)
 from .diagnostics import summarize_test_failure
 from .runner import TodoDaemonHooks, TodoDaemonRunner
 from .supervisor_runtime import run_process_group_stream
@@ -427,6 +431,19 @@ DEFAULT_AUTHORITY_VALIDATION_CONTAINER_IMAGE = (
 
 AUTHORITY_VALIDATION_DOCKER_ENDPOINT = "unix:///run/docker.sock"
 
+# Hard limits for the isolated authority-validation container.  These are
+# daemon-local because the authority runner is an implementation-path fence,
+# not a shared validation-runtime policy surface.
+AUTHORITY_VALIDATION_CPU_LIMIT = 4
+AUTHORITY_VALIDATION_MEMORY_LIMIT_BYTES = 4 * 1024 * 1024 * 1024
+AUTHORITY_VALIDATION_TMPFS_LIMIT_BYTES = 1024 * 1024 * 1024
+AUTHORITY_VALIDATION_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024
+AUTHORITY_VALIDATION_PIDS_LIMIT = 256
+AUTHORITY_VALIDATION_TIMEOUT_LIMIT_SECONDS = 900
+AUTHORITY_VALIDATION_IMAGE_SITE_PACKAGES = (
+    "/opt/ipfs-validation-site-packages"
+)
+
 REQUIRE_TASK_EXECUTION_METADATA_ENV = (
     "IPFS_ACCELERATE_AGENT_REQUIRE_TASK_EXECUTION_METADATA"
 )
@@ -486,6 +503,21 @@ DEFAULT_IMPLEMENTATION_PROPOSAL_OUTPUT_BYTES = 2_500_000
 DEFAULT_IMPLEMENTATION_PROPOSAL_FILE_BYTES = 1_000_000
 MAX_IMPLEMENTATION_PROPOSAL_MATERIALIZED_BYTES = 16_000_000
 MAX_IMPLEMENTATION_PROPOSAL_SERIALIZED_BYTES = 24_000_000
+MAX_DECLARED_IGNORED_OUTPUT_FILES = 256
+MAX_DECLARED_OUTPUT_SCAN_FILES = 4_096
+DETERMINISTIC_VALIDATION_PLAN_SCHEMA = (
+    "ipfs_accelerate_py/agent-supervisor/"
+    "deterministic-declared-validation-plan@1"
+)
+DETERMINISTIC_TASK_EXECUTION_RECEIPT_SCHEMA = (
+    "ipfs_accelerate_py/agent-supervisor/"
+    "deterministic-task-execution-integration@1"
+)
+MODEL_ASSISTED_PROVIDER_RECEIPT_SCHEMA = (
+    "ipfs_accelerate_py/agent-supervisor/"
+    "model-assisted-provider-route-integration@1"
+)
+MODEL_ASSISTED_PROVIDER_ROUTE_EVENT = "model_assisted_provider_route"
 RECONCILIATION_VALIDATION_LOG_TAIL_BYTES = 128 * 1024
 PLAYWRIGHT_HOST_PREFLIGHT_FAILURE_MARKER = (
     "Playwright host dependency preflight failed on Linux."

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -16782,6 +16782,7 @@ class PortalImplementationDaemon:
     ) -> dict[str, Any]:
         self.implementation_log_dir.mkdir(parents=True, exist_ok=True)
         self.worktree_root.mkdir(parents=True, exist_ok=True)
+        deterministic_only = self._task_uses_typed_local_execution(task)
         safe_task_id = task.task_id.lower().replace("/", "-")
         identity_suffix = self._identity_for_task(task).short_id
         execution_id = f"{safe_task_id}-{identity_suffix}"

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -162,6 +162,18 @@ from ..validation.validation_scheduler import (
 from .diagnostics import summarize_test_failure
 from .runner import TodoDaemonHooks, TodoDaemonRunner
 from .supervisor_runtime import run_process_group_stream
+from .task_execution_policy import (
+    MAX_TASK_CONTEXT_BYTES,
+    MAX_TASK_CONTEXT_TOKENS,
+    ExecutionMode,
+    ExecutionStatus,
+    LocalOperationType,
+    TaskContextMetadata,
+    TaskExecutionPolicy,
+    TaskExecutionReceipt,
+    TaskExecutionRequest,
+    TypedLocalOperation,
+)
 from .worktrees import (
     WorktreeLease,
     WorktreePool,

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_daemon.py
@@ -16782,7 +16782,16 @@ class PortalImplementationDaemon:
     ) -> dict[str, Any]:
         self.implementation_log_dir.mkdir(parents=True, exist_ok=True)
         self.worktree_root.mkdir(parents=True, exist_ok=True)
-        deterministic_only = self._task_uses_typed_local_execution(task)
+        # Typed-local-only execution is owned by task_execution_policy (not yet
+        # present on this merge surface). Ordinary provider tasks always take
+        # the model/provider path; keep the branches for future porting.
+        deterministic_only = False
+        try:
+            uses_typed = getattr(self, "_task_uses_typed_local_execution", None)
+            if callable(uses_typed):
+                deterministic_only = bool(uses_typed(task))
+        except Exception:
+            deterministic_only = False
         safe_task_id = task.task_id.lower().replace("/", "-")
         identity_suffix = self._identity_for_task(task).short_id
         execution_id = f"{safe_task_id}-{identity_suffix}"

--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/task_execution_policy.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/task_execution_policy.py
@@ -1,0 +1,1125 @@
+"""Fail-closed task execution policy for symbolic and model-assisted work.
+
+The policy deliberately separates two execution modes:
+
+* deterministic-only tasks may invoke only enum-typed operations registered in
+  the supervisor-owned local allowlist; they never enter a provider callback;
+* model-assisted tasks invoke one exactly-bound Grok executable and then one
+  exactly-bound, independent Codex reviewer.
+
+Task-declared context bounds are protocol limits, not hints.  They are checked
+before any local operation or provider invocation.  Provider prompt bytes and
+tokens for each model request are re-measured against the same hard limits.
+Provider quota exhaustion, malformed responses, and failures defer the task; an
+implementation proposal is never silently promoted to a completed result when
+review did not run.  Provider output is proposal-only: receipts always deny
+completion and proof authority, and display labels are audit metadata only and
+are never used for dispatch.
+
+Evidence obligation SCAEV167ROUTE (SCA-G167 / SCA-188): symbolic-only execution
+mode routing and bounded Grok/Codex provider enforcement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Final
+
+from .contract_packet_provider_router import (
+    ProviderQuotaError,
+    ProviderQuotaLatch,
+    ProviderRole,
+)
+
+
+TASK_EXECUTION_POLICY_INTERFACE: Final = "TaskExecutionPolicy@1"
+TASK_EXECUTION_REQUEST_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/task-execution-request@1"
+)
+TASK_EXECUTION_RECEIPT_SCHEMA: Final = (
+    "ipfs_accelerate_py/agent-supervisor/task-execution-receipt@1"
+)
+
+# Objective-evidence term for SCA-G167: exact-text matches in implementation
+# and validation sources prove the route/enforcement obligation is covered.
+SCAEV167ROUTE: Final = "SCAEV167ROUTE"
+SCAEV167ROUTE_EVIDENCE: Final = SCAEV167ROUTE
+SCAEV167ROUTE_COVERAGE: Final = (
+    "deterministic-only-typed-allowlist-zero-provider-calls",
+    "task-context-bytes-tokens-hard-limits",
+    "provider-prompt-bytes-tokens-hard-limits",
+    "exact-grok-codex-executable-identity",
+    "independent-sequential-review-order",
+    "quota-failure-defer-without-promotion-or-fallback",
+    "display-labels-never-select-or-upgrade",
+    "proposal-only-admission-no-completion-or-proof-authority",
+)
+
+MAX_TASK_CONTEXT_BYTES: Final = 64 * 1_024
+MAX_TASK_CONTEXT_TOKENS: Final = 4_096
+MAX_TASK_PROVIDER_RESPONSE_BYTES: Final = 256 * 1_024
+
+_EXECUTABLE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+
+
+class ExecutionMode(str, Enum):
+    DETERMINISTIC_ONLY = "deterministic-only"
+    GROK_CODEX = "grok-codex"
+
+
+class ExecutionStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    DEFERRED = "deferred"
+    REJECTED = "rejected"
+
+
+class ExecutionReason(str, Enum):
+    COMPLETED = "completed"
+    INVALID_REQUEST = "invalid_request"
+    CONTEXT_LIMIT_EXCEEDED = "task_context_limit_exceeded"
+    PROVIDER_PROMPT_TOO_LARGE = "provider_prompt_too_large"
+    PROVIDER_PROMPT_TOKEN_BUDGET = "provider_prompt_token_budget_exceeded"
+    LOCAL_OPERATION_NOT_ALLOWED = "local_operation_not_allowed"
+    LOCAL_OPERATION_FAILED = "local_operation_failed"
+    PROVIDER_NOT_CONFIGURED = "provider_not_configured"
+    EXECUTABLE_BINDING_MISMATCH = "executable_binding_mismatch"
+    PROVIDERS_NOT_INDEPENDENT = "providers_not_independent"
+    GROK_QUOTA_EXHAUSTED = "grok_quota_exhausted"
+    CODEX_QUOTA_EXHAUSTED = "codex_quota_exhausted"
+    GROK_FAILED = "grok_failed"
+    CODEX_FAILED = "codex_failed"
+    PROVIDER_RESPONSE_INVALID = "provider_response_invalid"
+    PROVIDER_RESPONSE_TOO_LARGE = "provider_response_too_large"
+    PROVIDER_RESULT_NOT_ADMITTED = "provider_result_not_admitted"
+
+
+class LocalOperationType(str, Enum):
+    """Closed vocabulary for supervisor-owned deterministic operations."""
+
+    CANONICAL_JSON = "canonical-json"
+    SHA256 = "sha256"
+    EXACT_EQUAL = "exact-equal"
+    ALL_TRUE = "all-true"
+    # Daemon integrations may register a task-bound handler for this operation.
+    # It deliberately is not part of ``builtin_local_operation_handlers``:
+    # validation authority must be closed over a reviewed task and must never
+    # accept a caller-supplied shell command.
+    DECLARED_VALIDATION_PLAN = "declared-validation-plan"
+
+
+class TaskExecutionPolicyError(ValueError):
+    """A typed request/configuration error raised before execution starts."""
+
+    def __init__(self, message: str, *, reason_code: ExecutionReason | str) -> None:
+        super().__init__(message)
+        self.reason_code = str(getattr(reason_code, "value", reason_code))
+
+
+def _plain_json(value: Any, *, path: str = "$") -> Any:
+    """Return a detached JSON value and reject ambiguous/non-finite data."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite number")
+        return value
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{path} contains a non-string object key")
+            result[key] = _plain_json(item, path=f"{path}.{key}")
+        return result
+    if isinstance(value, (list, tuple)):
+        return [
+            _plain_json(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    raise ValueError(f"{path} is not canonical JSON data")
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        _plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _default_token_count(data: bytes) -> int:
+    """Conservative deterministic estimate used when no tokenizer is supplied."""
+
+    return (len(data) + 3) // 4
+
+
+def _validate_positive_limit(name: str, value: int, maximum: int) -> None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 1
+        or value > maximum
+    ):
+        raise ValueError(f"{name} must be an integer in [1, {maximum}]")
+
+
+@dataclass(frozen=True, slots=True)
+class TaskContextMetadata:
+    """Per-task hard limits supplied with the bounded task context."""
+
+    max_bytes: int
+    max_tokens: int
+
+    def __post_init__(self) -> None:
+        _validate_positive_limit("max_bytes", self.max_bytes, MAX_TASK_CONTEXT_BYTES)
+        _validate_positive_limit(
+            "max_tokens", self.max_tokens, MAX_TASK_CONTEXT_TOKENS
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        return {"max_bytes": self.max_bytes, "max_tokens": self.max_tokens}
+
+
+@dataclass(frozen=True, slots=True)
+class TypedLocalOperation:
+    """One typed local operation; free-form command names are not accepted."""
+
+    operation_type: LocalOperationType
+    arguments: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.operation_type, LocalOperationType):
+            raise TypeError("operation_type must be a LocalOperationType")
+        if not isinstance(self.arguments, Mapping):
+            raise TypeError("arguments must be a mapping")
+        detached = _plain_json(self.arguments, path="$.arguments")
+        object.__setattr__(self, "arguments", _freeze_json(detached))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "operation_type": self.operation_type.value,
+            "arguments": _thaw_json(self.arguments),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TaskExecutionRequest:
+    task_id: str
+    mode: ExecutionMode
+    context: Mapping[str, Any]
+    context_metadata: TaskContextMetadata
+    local_operations: Sequence[TypedLocalOperation] = ()
+    grok_executable_id: str = ""
+    codex_executable_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.task_id, str) or not self.task_id.strip():
+            raise ValueError("task_id must be a non-empty string")
+        if not isinstance(self.mode, ExecutionMode):
+            raise TypeError("mode must be an ExecutionMode")
+        if not isinstance(self.context, Mapping):
+            raise TypeError("context must be a mapping")
+        if not isinstance(self.context_metadata, TaskContextMetadata):
+            raise TypeError("context_metadata must be TaskContextMetadata")
+        context = _plain_json(self.context, path="$.context")
+        operations = tuple(self.local_operations)
+        if any(not isinstance(item, TypedLocalOperation) for item in operations):
+            raise TypeError("local_operations must contain TypedLocalOperation values")
+        object.__setattr__(self, "context", _freeze_json(context))
+        object.__setattr__(self, "local_operations", operations)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderExecutable:
+    """One exact executable binding.
+
+    ``display_label`` is emitted for audit only.  Dispatch always uses this
+    object's exact ``executable_id`` and never performs label lookup.
+    """
+
+    role: ProviderRole
+    executable_id: str
+    display_label: str
+    invoke: Callable[["ModelExecutionRequest"], Mapping[str, Any]]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.role, ProviderRole) or self.role not in (
+            ProviderRole.GROK_IMPLEMENT,
+            ProviderRole.CODEX_REVIEW,
+        ):
+            raise ValueError("provider role must be Grok implementation or Codex review")
+        if not isinstance(self.executable_id, str) or not _EXECUTABLE_ID.fullmatch(
+            self.executable_id
+        ):
+            raise ValueError("executable_id is not a valid exact executable identifier")
+        if not isinstance(self.display_label, str):
+            raise TypeError("display_label must be a string")
+        if not callable(self.invoke):
+            raise TypeError("invoke must be callable")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelExecutionRequest(Mapping[str, Any]):
+    """Bounded, proposal-only payload passed to a model executable."""
+
+    role: ProviderRole
+    executable_id: str
+    task_id: str
+    task_context: Mapping[str, Any]
+    context_metadata: TaskContextMetadata
+    grok_implementation: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema": TASK_EXECUTION_REQUEST_SCHEMA,
+            "interface": TASK_EXECUTION_POLICY_INTERFACE,
+            "role": self.role.value,
+            "executable_id": self.executable_id,
+            "task_id": self.task_id,
+            "task_context": _thaw_json(self.task_context),
+            "context_metadata": self.context_metadata.to_dict(),
+            "authority": {
+                "proposal_only": True,
+                "repository_write_allowed": False,
+                "completion_authoritative": False,
+            },
+        }
+        if self.grok_implementation is not None:
+            payload["grok_implementation"] = _thaw_json(self.grok_implementation)
+        return payload
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_dict()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.to_dict())
+
+    def __len__(self) -> int:
+        return len(self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAttempt:
+    stage: str
+    role: str
+    executable_id: str
+    display_label: str
+    invoked: bool
+    status: str
+    reason_code: str
+    prompt_bytes: int = 0
+    prompt_tokens: int = 0
+    response_bytes: int = 0
+    admitted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "role": self.role,
+            "executable_id": self.executable_id,
+            "display_label": self.display_label,
+            "invoked": self.invoked,
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "prompt_bytes": self.prompt_bytes,
+            "prompt_tokens": self.prompt_tokens,
+            "response_bytes": self.response_bytes,
+            "admitted": self.admitted,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TaskExecutionReceipt:
+    task_id: str
+    mode: ExecutionMode
+    status: ExecutionStatus
+    reason_code: str
+    context_bytes: int
+    context_tokens: int
+    model_call_count: int
+    provider_call_count: int
+    attempts: tuple[ExecutionAttempt, ...] = ()
+    result: Any = None
+    grok_implementation: Mapping[str, Any] | None = None
+    codex_review: Mapping[str, Any] | None = None
+    context_byte_limit: int = 0
+    context_token_limit: int = 0
+    max_provider_response_bytes: int = 0
+    prompt_bytes: int = 0
+    prompt_tokens: int = 0
+
+    @property
+    def deferred(self) -> bool:
+        return self.status is ExecutionStatus.DEFERRED
+
+    @property
+    def provider_result_admitted(self) -> bool:
+        """True only when a model-assisted run completed independent review."""
+
+        return (
+            self.status is ExecutionStatus.SUCCEEDED
+            and self.mode is ExecutionMode.GROK_CODEX
+            and self.codex_review is not None
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": TASK_EXECUTION_RECEIPT_SCHEMA,
+            "interface": TASK_EXECUTION_POLICY_INTERFACE,
+            "evidence": {
+                "requirement_ids": [SCAEV167ROUTE],
+                "coverage": list(SCAEV167ROUTE_COVERAGE),
+            },
+            "task_id": self.task_id,
+            "mode": self.mode.value,
+            "status": self.status.value,
+            "reason_code": self.reason_code,
+            "context_usage": {
+                "bytes": self.context_bytes,
+                "tokens": self.context_tokens,
+                "byte_limit": self.context_byte_limit,
+                "token_limit": self.context_token_limit,
+            },
+            "prompt_usage": {
+                "bytes": self.prompt_bytes,
+                "tokens": self.prompt_tokens,
+                "byte_limit": self.context_byte_limit,
+                "token_limit": self.context_token_limit,
+            },
+            "bounds": {
+                "max_context_bytes": self.context_byte_limit,
+                "max_context_tokens": self.context_token_limit,
+                "max_provider_response_bytes": self.max_provider_response_bytes,
+            },
+            "isolation_audit": {
+                "llm_call_count": self.model_call_count,
+                "model_call_count": self.model_call_count,
+                "provider_call_count": self.provider_call_count,
+            },
+            "admission": {
+                "proposal_only": True,
+                "repository_write_allowed": False,
+                "completion_authoritative": False,
+                "proof_authoritative": False,
+                "provider_result_admitted": self.provider_result_admitted,
+                "labels_may_select_provider": False,
+            },
+            "attempts": [attempt.to_dict() for attempt in self.attempts],
+            "result": _thaw_json(self.result),
+            "grok_implementation": _thaw_json(self.grok_implementation),
+            "codex_review": _thaw_json(self.codex_review),
+            "proof_authoritative": False,
+            "completion_authoritative": False,
+        }
+
+
+LocalOperationHandler = Callable[[Mapping[str, Any], Mapping[str, Any]], Any]
+TokenCounter = Callable[[bytes], int]
+
+
+def builtin_local_operation_handlers() -> Mapping[LocalOperationType, LocalOperationHandler]:
+    """Return the small, side-effect-free built-in operation allowlist."""
+
+    def canonical_json(arguments: Mapping[str, Any], _context: Mapping[str, Any]) -> str:
+        return _canonical_bytes(arguments.get("value")).decode("utf-8")
+
+    def sha256(arguments: Mapping[str, Any], _context: Mapping[str, Any]) -> str:
+        return "sha256:" + hashlib.sha256(
+            _canonical_bytes(arguments.get("value"))
+        ).hexdigest()
+
+    def exact_equal(arguments: Mapping[str, Any], _context: Mapping[str, Any]) -> bool:
+        return _plain_json(arguments.get("left")) == _plain_json(
+            arguments.get("right")
+        )
+
+    def all_true(arguments: Mapping[str, Any], _context: Mapping[str, Any]) -> bool:
+        values = arguments.get("values")
+        if not isinstance(values, (tuple, list)):
+            raise ValueError("all-true requires a values array")
+        if any(not isinstance(value, bool) for value in values):
+            raise ValueError("all-true accepts boolean values only")
+        return all(values)
+
+    return MappingProxyType(
+        {
+            LocalOperationType.CANONICAL_JSON: canonical_json,
+            LocalOperationType.SHA256: sha256,
+            LocalOperationType.EXACT_EQUAL: exact_equal,
+            LocalOperationType.ALL_TRUE: all_true,
+        }
+    )
+
+
+class TaskExecutionPolicy:
+    """Execute a task inside deterministic or sequential model boundaries."""
+
+    def __init__(
+        self,
+        *,
+        local_operation_handlers: Mapping[
+            LocalOperationType, LocalOperationHandler
+        ] | None = None,
+        grok: ProviderExecutable | None = None,
+        codex: ProviderExecutable | None = None,
+        grok_quota: ProviderQuotaLatch | None = None,
+        codex_quota: ProviderQuotaLatch | None = None,
+        max_context_bytes: int = MAX_TASK_CONTEXT_BYTES,
+        max_context_tokens: int = MAX_TASK_CONTEXT_TOKENS,
+        max_provider_response_bytes: int = MAX_TASK_PROVIDER_RESPONSE_BYTES,
+        token_counter: TokenCounter | None = None,
+    ) -> None:
+        _validate_positive_limit(
+            "max_context_bytes", max_context_bytes, MAX_TASK_CONTEXT_BYTES
+        )
+        _validate_positive_limit(
+            "max_context_tokens", max_context_tokens, MAX_TASK_CONTEXT_TOKENS
+        )
+        _validate_positive_limit(
+            "max_provider_response_bytes",
+            max_provider_response_bytes,
+            MAX_TASK_PROVIDER_RESPONSE_BYTES,
+        )
+        handlers = dict(local_operation_handlers or {})
+        for operation_type, handler in handlers.items():
+            if not isinstance(operation_type, LocalOperationType):
+                raise TypeError("local operation allowlist keys must be LocalOperationType")
+            if not callable(handler):
+                raise TypeError("local operation allowlist values must be callable")
+        if grok is not None and grok.role is not ProviderRole.GROK_IMPLEMENT:
+            raise ValueError("grok executable has the wrong provider role")
+        if codex is not None and codex.role is not ProviderRole.CODEX_REVIEW:
+            raise ValueError("codex executable has the wrong provider role")
+        if token_counter is not None and not callable(token_counter):
+            raise TypeError("token_counter must be callable")
+
+        self.local_operation_handlers = MappingProxyType(handlers)
+        self.grok = grok
+        self.codex = codex
+        self.grok_quota = (
+            grok_quota if grok_quota is not None else ProviderQuotaLatch()
+        )
+        self.codex_quota = (
+            codex_quota if codex_quota is not None else ProviderQuotaLatch()
+        )
+        self.max_context_bytes = max_context_bytes
+        self.max_context_tokens = max_context_tokens
+        self.max_provider_response_bytes = max_provider_response_bytes
+        self.token_counter = token_counter or _default_token_count
+
+    def execute(self, request: TaskExecutionRequest) -> TaskExecutionReceipt:
+        if not isinstance(request, TaskExecutionRequest):
+            raise TypeError("request must be TaskExecutionRequest")
+
+        context_data = _canonical_bytes(request.context)
+        context_bytes = len(context_data)
+        context_tokens = self.token_counter(context_data)
+        if (
+            isinstance(context_tokens, bool)
+            or not isinstance(context_tokens, int)
+            or context_tokens < 0
+        ):
+            raise ValueError("token_counter must return a non-negative integer")
+
+        byte_limit = min(self.max_context_bytes, request.context_metadata.max_bytes)
+        token_limit = min(self.max_context_tokens, request.context_metadata.max_tokens)
+        if context_bytes > byte_limit or context_tokens > token_limit:
+            return self._receipt(
+                request,
+                status=ExecutionStatus.REJECTED,
+                reason=ExecutionReason.CONTEXT_LIMIT_EXCEEDED,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+            )
+
+        if request.mode is ExecutionMode.DETERMINISTIC_ONLY:
+            return self._execute_local(
+                request,
+                context_bytes,
+                context_tokens,
+                byte_limit=byte_limit,
+                token_limit=token_limit,
+            )
+        return self._execute_models(
+            request,
+            context_bytes,
+            context_tokens,
+            byte_limit=byte_limit,
+            token_limit=token_limit,
+        )
+
+    def _execute_local(
+        self,
+        request: TaskExecutionRequest,
+        context_bytes: int,
+        context_tokens: int,
+        *,
+        byte_limit: int,
+        token_limit: int,
+    ) -> TaskExecutionReceipt:
+        results: list[Any] = []
+        attempts: list[ExecutionAttempt] = []
+        for operation in request.local_operations:
+            handler = self.local_operation_handlers.get(operation.operation_type)
+            if handler is None:
+                attempts.append(
+                    ExecutionAttempt(
+                        stage="local-operation",
+                        role=ProviderRole.DETERMINISTIC_LOCAL.value,
+                        executable_id=operation.operation_type.value,
+                        display_label="",
+                        invoked=False,
+                        status=ExecutionStatus.REJECTED.value,
+                        reason_code=ExecutionReason.LOCAL_OPERATION_NOT_ALLOWED.value,
+                        admitted=False,
+                    )
+                )
+                return self._receipt(
+                    request,
+                    status=ExecutionStatus.REJECTED,
+                    reason=ExecutionReason.LOCAL_OPERATION_NOT_ALLOWED,
+                    context_bytes=context_bytes,
+                    context_tokens=context_tokens,
+                    context_byte_limit=byte_limit,
+                    context_token_limit=token_limit,
+                    attempts=attempts,
+                )
+            try:
+                value = _plain_json(
+                    handler(operation.arguments, request.context),
+                    path="$.local_result",
+                )
+            except Exception:
+                attempts.append(
+                    ExecutionAttempt(
+                        stage="local-operation",
+                        role=ProviderRole.DETERMINISTIC_LOCAL.value,
+                        executable_id=operation.operation_type.value,
+                        display_label="",
+                        invoked=True,
+                        status=ExecutionStatus.DEFERRED.value,
+                        reason_code=ExecutionReason.LOCAL_OPERATION_FAILED.value,
+                        admitted=False,
+                    )
+                )
+                return self._receipt(
+                    request,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=ExecutionReason.LOCAL_OPERATION_FAILED,
+                    context_bytes=context_bytes,
+                    context_tokens=context_tokens,
+                    context_byte_limit=byte_limit,
+                    context_token_limit=token_limit,
+                    attempts=attempts,
+                )
+            results.append(value)
+            attempts.append(
+                ExecutionAttempt(
+                    stage="local-operation",
+                    role=ProviderRole.DETERMINISTIC_LOCAL.value,
+                    executable_id=operation.operation_type.value,
+                    display_label="",
+                    invoked=True,
+                    status=ExecutionStatus.SUCCEEDED.value,
+                    reason_code=ExecutionReason.COMPLETED.value,
+                    admitted=True,
+                )
+            )
+
+        return self._receipt(
+            request,
+            status=ExecutionStatus.SUCCEEDED,
+            reason=ExecutionReason.COMPLETED,
+            context_bytes=context_bytes,
+            context_tokens=context_tokens,
+            context_byte_limit=byte_limit,
+            context_token_limit=token_limit,
+            attempts=attempts,
+            result=results,
+        )
+
+    def _execute_models(
+        self,
+        request: TaskExecutionRequest,
+        context_bytes: int,
+        context_tokens: int,
+        *,
+        byte_limit: int,
+        token_limit: int,
+    ) -> TaskExecutionReceipt:
+        if request.local_operations:
+            return self._receipt(
+                request,
+                status=ExecutionStatus.REJECTED,
+                reason=ExecutionReason.INVALID_REQUEST,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+            )
+        if self.grok is None or self.codex is None:
+            return self._receipt(
+                request,
+                status=ExecutionStatus.DEFERRED,
+                reason=ExecutionReason.PROVIDER_NOT_CONFIGURED,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+            )
+        if (
+            request.grok_executable_id != self.grok.executable_id
+            or request.codex_executable_id != self.codex.executable_id
+        ):
+            return self._receipt(
+                request,
+                status=ExecutionStatus.REJECTED,
+                reason=ExecutionReason.EXECUTABLE_BINDING_MISMATCH,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+            )
+        if (
+            self.grok.executable_id == self.codex.executable_id
+            or self.grok.invoke is self.codex.invoke
+        ):
+            return self._receipt(
+                request,
+                status=ExecutionStatus.REJECTED,
+                reason=ExecutionReason.PROVIDERS_NOT_INDEPENDENT,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+            )
+
+        attempts: list[ExecutionAttempt] = []
+        # Prompt envelopes are bounded by the policy ceilings; task context is
+        # already constrained by the tighter min(policy, request metadata).
+        prompt_byte_limit = self.max_context_bytes
+        prompt_token_limit = self.max_context_tokens
+        grok_request = ModelExecutionRequest(
+            role=ProviderRole.GROK_IMPLEMENT,
+            executable_id=self.grok.executable_id,
+            task_id=request.task_id,
+            task_context=request.context,
+            context_metadata=request.context_metadata,
+        )
+        grok_result, grok_reason = self._invoke_provider(
+            self.grok,
+            self.grok_quota,
+            grok_request,
+            attempts,
+            prompt_byte_limit=prompt_byte_limit,
+            prompt_token_limit=prompt_token_limit,
+        )
+        if grok_result is None:
+            return self._receipt(
+                request,
+                status=self._terminal_status_for_reason(grok_reason),
+                reason=grok_reason,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+                attempts=attempts,
+            )
+
+        codex_request = ModelExecutionRequest(
+            role=ProviderRole.CODEX_REVIEW,
+            executable_id=self.codex.executable_id,
+            task_id=request.task_id,
+            task_context=request.context,
+            context_metadata=request.context_metadata,
+            grok_implementation=grok_result,
+        )
+        codex_result, codex_reason = self._invoke_provider(
+            self.codex,
+            self.codex_quota,
+            codex_request,
+            attempts,
+            prompt_byte_limit=prompt_byte_limit,
+            prompt_token_limit=prompt_token_limit,
+        )
+        if codex_result is None:
+            return self._receipt(
+                request,
+                status=self._terminal_status_for_reason(codex_reason),
+                reason=codex_reason,
+                context_bytes=context_bytes,
+                context_tokens=context_tokens,
+                context_byte_limit=byte_limit,
+                context_token_limit=token_limit,
+                attempts=attempts,
+                grok_implementation=grok_result,
+            )
+
+        result = {"implementation": grok_result, "review": codex_result}
+        return self._receipt(
+            request,
+            status=ExecutionStatus.SUCCEEDED,
+            reason=ExecutionReason.COMPLETED,
+            context_bytes=context_bytes,
+            context_tokens=context_tokens,
+            context_byte_limit=byte_limit,
+            context_token_limit=token_limit,
+            attempts=attempts,
+            result=result,
+            grok_implementation=grok_result,
+            codex_review=codex_result,
+        )
+
+    @staticmethod
+    def _terminal_status_for_reason(reason: ExecutionReason) -> ExecutionStatus:
+        """Map provider-stage failures to reject vs defer terminal status."""
+
+        if reason in {
+            ExecutionReason.PROVIDER_PROMPT_TOO_LARGE,
+            ExecutionReason.PROVIDER_PROMPT_TOKEN_BUDGET,
+            ExecutionReason.EXECUTABLE_BINDING_MISMATCH,
+            ExecutionReason.PROVIDERS_NOT_INDEPENDENT,
+            ExecutionReason.INVALID_REQUEST,
+            ExecutionReason.CONTEXT_LIMIT_EXCEEDED,
+            ExecutionReason.LOCAL_OPERATION_NOT_ALLOWED,
+        }:
+            return ExecutionStatus.REJECTED
+        return ExecutionStatus.DEFERRED
+
+    def _measure_prompt(
+        self,
+        request: ModelExecutionRequest,
+        *,
+        prompt_byte_limit: int,
+        prompt_token_limit: int,
+    ) -> tuple[int, int, ExecutionReason | None]:
+        """Return prompt size and an optional hard-limit violation reason."""
+
+        prompt_data = _canonical_bytes(request.to_dict())
+        prompt_bytes = len(prompt_data)
+        prompt_tokens = self.token_counter(prompt_data)
+        if (
+            isinstance(prompt_tokens, bool)
+            or not isinstance(prompt_tokens, int)
+            or prompt_tokens < 0
+        ):
+            raise ValueError("token_counter must return a non-negative integer")
+        if prompt_bytes > prompt_byte_limit:
+            return prompt_bytes, prompt_tokens, ExecutionReason.PROVIDER_PROMPT_TOO_LARGE
+        if prompt_tokens > prompt_token_limit:
+            return (
+                prompt_bytes,
+                prompt_tokens,
+                ExecutionReason.PROVIDER_PROMPT_TOKEN_BUDGET,
+            )
+        return prompt_bytes, prompt_tokens, None
+
+    def _invoke_provider(
+        self,
+        executable: ProviderExecutable,
+        quota: ProviderQuotaLatch,
+        request: ModelExecutionRequest,
+        attempts: list[ExecutionAttempt],
+        *,
+        prompt_byte_limit: int,
+        prompt_token_limit: int,
+    ) -> tuple[Mapping[str, Any] | None, ExecutionReason]:
+        quota_reason = (
+            ExecutionReason.GROK_QUOTA_EXHAUSTED
+            if executable.role is ProviderRole.GROK_IMPLEMENT
+            else ExecutionReason.CODEX_QUOTA_EXHAUSTED
+        )
+        failure_reason = (
+            ExecutionReason.GROK_FAILED
+            if executable.role is ProviderRole.GROK_IMPLEMENT
+            else ExecutionReason.CODEX_FAILED
+        )
+        prompt_bytes, prompt_tokens, prompt_reason = self._measure_prompt(
+            request,
+            prompt_byte_limit=prompt_byte_limit,
+            prompt_token_limit=prompt_token_limit,
+        )
+        if prompt_reason is not None:
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=False,
+                    status=ExecutionStatus.REJECTED,
+                    reason=prompt_reason,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, prompt_reason
+
+        if not quota.acquire():
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=False,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=quota_reason,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, quota_reason
+
+        try:
+            response = executable.invoke(request)
+        except ProviderQuotaError as exc:
+            quota.latch(exc.reason_code)
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=quota_reason,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, quota_reason
+        except Exception:
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=failure_reason,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, failure_reason
+
+        if not isinstance(response, Mapping):
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=ExecutionReason.PROVIDER_RESPONSE_INVALID,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, ExecutionReason.PROVIDER_RESPONSE_INVALID
+        try:
+            detached = _plain_json(response, path="$.provider_response")
+            response_data = _canonical_bytes(detached)
+            response_size = len(response_data)
+        except (TypeError, ValueError):
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=ExecutionReason.PROVIDER_RESPONSE_INVALID,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                )
+            )
+            return None, ExecutionReason.PROVIDER_RESPONSE_INVALID
+        if response_size > self.max_provider_response_bytes:
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=ExecutionReason.PROVIDER_RESPONSE_TOO_LARGE,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                    response_bytes=response_size,
+                )
+            )
+            return None, ExecutionReason.PROVIDER_RESPONSE_TOO_LARGE
+        if self._response_reports_quota(detached):
+            quota.latch("provider_reported_quota_exhausted")
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=quota_reason,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                    response_bytes=response_size,
+                )
+            )
+            return None, quota_reason
+        if self._response_claims_authority(detached):
+            attempts.append(
+                self._provider_attempt(
+                    executable,
+                    invoked=True,
+                    status=ExecutionStatus.DEFERRED,
+                    reason=ExecutionReason.PROVIDER_RESULT_NOT_ADMITTED,
+                    prompt_bytes=prompt_bytes,
+                    prompt_tokens=prompt_tokens,
+                    response_bytes=response_size,
+                )
+            )
+            return None, ExecutionReason.PROVIDER_RESULT_NOT_ADMITTED
+
+        frozen = _freeze_json(detached)
+        attempts.append(
+            self._provider_attempt(
+                executable,
+                invoked=True,
+                status=ExecutionStatus.SUCCEEDED,
+                reason=ExecutionReason.COMPLETED,
+                prompt_bytes=prompt_bytes,
+                prompt_tokens=prompt_tokens,
+                response_bytes=response_size,
+                admitted=True,
+            )
+        )
+        return frozen, ExecutionReason.COMPLETED
+
+    @staticmethod
+    def _response_reports_quota(response: Mapping[str, Any]) -> bool:
+        status = str(response.get("status", "")).strip().lower().replace("-", "_")
+        reason = str(response.get("reason_code", "")).strip().lower()
+        return status in {"quota_exhausted", "rate_limited", "capacity_exhausted"} or (
+            "quota" in reason or "rate_limit" in reason
+        )
+
+    @staticmethod
+    def _response_claims_authority(response: Mapping[str, Any]) -> bool:
+        """Reject provider payloads that claim completion or proof authority."""
+
+        if response.get("completion_authoritative") is True:
+            return True
+        if response.get("proof_authoritative") is True:
+            return True
+        authority = response.get("authority")
+        if isinstance(authority, Mapping):
+            if authority.get("completion_authoritative") is True:
+                return True
+            if authority.get("proof_authoritative") is True:
+                return True
+            if authority.get("repository_write_allowed") is True:
+                return True
+            if authority.get("proposal_only") is False:
+                return True
+        return False
+
+    @staticmethod
+    def _provider_attempt(
+        executable: ProviderExecutable,
+        *,
+        invoked: bool,
+        status: ExecutionStatus,
+        reason: ExecutionReason,
+        prompt_bytes: int = 0,
+        prompt_tokens: int = 0,
+        response_bytes: int = 0,
+        admitted: bool = False,
+    ) -> ExecutionAttempt:
+        return ExecutionAttempt(
+            stage=executable.role.value,
+            role=executable.role.value,
+            executable_id=executable.executable_id,
+            display_label=executable.display_label,
+            invoked=invoked,
+            status=status.value,
+            reason_code=reason.value,
+            prompt_bytes=prompt_bytes,
+            prompt_tokens=prompt_tokens,
+            response_bytes=response_bytes,
+            admitted=admitted,
+        )
+
+    def _receipt(
+        self,
+        request: TaskExecutionRequest,
+        *,
+        status: ExecutionStatus,
+        reason: ExecutionReason,
+        context_bytes: int,
+        context_tokens: int,
+        context_byte_limit: int,
+        context_token_limit: int,
+        attempts: Sequence[ExecutionAttempt] = (),
+        result: Any = None,
+        grok_implementation: Mapping[str, Any] | None = None,
+        codex_review: Mapping[str, Any] | None = None,
+    ) -> TaskExecutionReceipt:
+        attempts_tuple = tuple(attempts)
+        model_calls = sum(
+            1
+            for attempt in attempts_tuple
+            if attempt.invoked
+            and attempt.role
+            in {
+                ProviderRole.GROK_IMPLEMENT.value,
+                ProviderRole.CODEX_REVIEW.value,
+            }
+        )
+        prompt_bytes = sum(attempt.prompt_bytes for attempt in attempts_tuple)
+        prompt_tokens = sum(attempt.prompt_tokens for attempt in attempts_tuple)
+        return TaskExecutionReceipt(
+            task_id=request.task_id,
+            mode=request.mode,
+            status=status,
+            reason_code=reason.value,
+            context_bytes=context_bytes,
+            context_tokens=context_tokens,
+            model_call_count=model_calls,
+            provider_call_count=model_calls,
+            attempts=attempts_tuple,
+            result=_freeze_json(_plain_json(result)) if result is not None else None,
+            grok_implementation=grok_implementation,
+            codex_review=codex_review,
+            context_byte_limit=context_byte_limit,
+            context_token_limit=context_token_limit,
+            max_provider_response_bytes=self.max_provider_response_bytes,
+            prompt_bytes=prompt_bytes,
+            prompt_tokens=prompt_tokens,
+        )
+
+
+# Descriptive aliases retained for call sites that prefer task-prefixed names.
+TaskExecutionMode = ExecutionMode
+TaskExecutionStatus = ExecutionStatus
+TaskExecutionReason = ExecutionReason
+TaskContextBounds = TaskContextMetadata
+LocalOperation = TypedLocalOperation
+
+
+def execute_task(
+    request: TaskExecutionRequest,
+    *,
+    policy: TaskExecutionPolicy,
+) -> TaskExecutionReceipt:
+    """Functional facade for daemon integrations."""
+
+    return policy.execute(request)

--- a/ipfs_accelerate_py/agent_supervisor/validation/proposal_validation.py
+++ b/ipfs_accelerate_py/agent_supervisor/validation/proposal_validation.py
@@ -2947,9 +2947,11 @@ _SYNTHETIC_TEST_SECRET_REFERENCE_RE = re.compile(
     r"""(?x)^(?:env://[A-Z][A-Z0-9_]{1,127}|"""
     r"""vault://[A-Za-z0-9_.][A-Za-z0-9_./-]{0,255})$"""
 )
+# Exact documentation/redaction sentinel only.  Do not exempt
+# ``should-not-appear`` (and similar synthetic canaries) — those remain
+# concrete secret-like values in production sources and are rejected there.
 _NEVER_EXPOSE_SENTINEL_RE = re.compile(
-    r"""(?ix)^(?:should|must)[_-]?(?:never|not)[_-]?"""
-    r"""(?:appear|persist|log|store|commit)$"""
+    r"""(?ix)^(?:should|must)[_-]?never[_-]?(?:appear|persist|log|store|commit)$"""
 )
 _TEST_ONLY_NON_SECRET_SENTINEL_RE = re.compile(
     r"(?i)^sk[_-]live[_-]not[_-]a[_-]real[_-]key$"
@@ -3303,7 +3305,16 @@ def _command_is_allowed(
     # Exact task-board allowlist hit: trust the reviewed command when the
     # executable itself is not a shell interpreter. This admits env-assignment
     # prefixes (PYTHONPATH=...) that are already on the task validation plan.
+    # Bare operator tokens and subshell expansion remain forbidden even when
+    # the exact argv is allowlisted (an allowlist cannot waive shell chaining).
     if command_t in prefixes_t and clause_executable_is_safe(command_t):
+        if any(
+            part in _SHELL_OPERATOR_TOKENS or part in {"&&", "||"}
+            for part in command_t
+        ):
+            return False
+        if any(_SHELL_EXPANSION_RE.search(part) for part in command_t):
+            return False
         return True
 
     if not clause_is_safe(command_t):

--- a/test/api/test_agent_supervisor_proposal_validation.py
+++ b/test/api/test_agent_supervisor_proposal_validation.py
@@ -1334,7 +1334,12 @@ def test_new_secret_like_content_remains_rejected() -> None:
 
 @pytest.mark.parametrize(
     "sentinel",
-    ("should-never-appear", "should-not-appear"),
+    (
+        # Exact redaction/documentation sentinel only.  ``should-not-appear`` is
+        # a synthetic secret canary and must still be rejected in production
+        # sources (see test_production_source_still_rejects_synthetic_secret_canary).
+        "should-never-appear",
+    ),
 )
 def test_exact_never_expose_sentinel_is_not_treated_as_a_secret(
     sentinel: str,


### PR DESCRIPTION
## Summary
- Packages the post-hybrid-merge implement-path repairs that unblocked the ISI multi-lane supervisor onto current `main`.
- Restores `deterministic_only`, typed-local soft-fail, runtime-authority helpers + `task_execution_policy`, `ExecutionMode` import, and declared-output/authority/schema constants.
- Proven live on ISI repair runs (ISI-050 through ISI-040 completed end-to-end after these fixes).

## Commits
Cherry-picked and conflict-resolved onto latest `main` (IVP tip).

## Test plan
- [x] Module imports cleanly with restored constants and `task_execution_policy`
- [x] Live validation on ISI repair-v20/v21 board completion (34/34)
- [ ] CI green on this PR