### PR TITLE
fix(agent-supervisor): seal-pin proposal validation guards for DSS-000

### DIFF
--- a/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
+++ b/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
@@ -30,27 +30,33 @@ is also not assumed here.
 
 `SCH-000` must be completed manually before any implementation supervisor is
 launched. It must replace the two unresolved values below with exact 40-hex
-commits after the phase-one semantic-index closeout and the `ipfs_kit_py`
-state-root/CAS closeout:
+commits after the repaired `ipfs_datasets_py` semantic-state/Merkle/capsule
+closeout and the repaired `ipfs_kit_py` versioned state-root/CAS closeout:
 
 ```text
-IPFS_DATASETS_SEMANTIC_INDEX_COMMIT = UNRESOLVED
-IPFS_KIT_DURABLE_ROOT_COMMIT        = UNRESOLVED
+IPFS_DATASETS_SEMANTIC_STATE_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT
+IPFS_KIT_DURABLE_ROOT_COMMIT        = UNRESOLVED_FINAL_REPAIRED_COMMIT
 ```
 
 The gate fails closed if either value is unresolved, is not a commit reachable
 from the intended repository, or does not pass its producer's contract tests.
-Workers may not infer a pin from a mutable branch, current checkout, editable
-install, submodule pointer, or ambient `PYTHONPATH` ordering.
+The dependency seal also records the exact accelerate baseline and MCP++ wire
+commit, repository origins, interface/schema fingerprints, and Python 3.12
+toolchain. A deterministic seal validator must check those values; `git
+rev-parse` alone is not validation. Workers may not infer a pin from a mutable
+branch, current checkout, editable install, submodule pointer, or ambient
+`PYTHONPATH` ordering.
 
 ## 2. Scope and completion outcome
 
 The release is a complete local loop over a controlled Python fixture repository
 or a deliberately selected stable kernel in `ipfs_datasets_py`. It must:
 
-1. obtain a deterministic repository state from the phase-one scanner;
-2. consume its symbol-level Merkle graph and confidence classifications;
-3. compile and reuse semantic capsules for unchanged dependencies;
+1. obtain a deterministic repository state from the repaired phase-one scanner;
+2. consume the datasets-owned symbol-level Merkle DAG and confidence
+   classifications;
+3. request and reuse datasets-owned semantic capsules for unchanged
+   dependencies;
 4. consume state deltas and propagate explicit invalidation obligations;
 5. select affected pytest tests and configured proof obligations;
 6. build a minimum-sufficient, assurance-aware `ContextPack`;
@@ -83,16 +89,19 @@ commands, environment bindings, and selected inputs have been recorded.
 
 | Concern | Existing authority | Decision |
 |---|---|---|
-| Python repository state, symbols, typed graph, deltas, invalidation, explanations | Final pinned `ipfs_datasets_py.logic.software_contracts.semantic_index` public API | Consume through `SemanticStateProvider`; never reconstruct AST identity or graph semantics in accelerate. |
+| Python repository state, symbols, typed graph, Merkle manifest, capsules, deltas, invalidation, explanations, exact source retrieval | Final pinned repaired `ipfs_datasets_py.logic.software_contracts` semantic-state public API | Consume through `SemanticStateProvider`; never reconstruct AST identity, graph semantics, capsule facts, or source identity in accelerate. |
 | Semantic content identity | Final pinned semantic-index records and their `software_contracts.content` CIDs | Preserve supplied CIDs and verify round trips; never translate them into a second identity. |
 | MCP++ wire shapes | MCP-IDL Profile A, CID-native artifacts Profile B, and Event DAG Profile F at `dc316465…` | Encode a local interface descriptor and conformance vectors against those profiles. No semantic-specific upstream schema was found, so local payload schemas remain namespaced extensions carried by the MCP++ envelope. |
 | MCP++ artifact bytes and real CIDv1 | `ipfs_accelerate_py.mcp_server.mcplusplus.artifacts.canonicalize_artifact` plus `ipfs_accelerate_py.mcp_server.mcplusplus.kubo_cid.cid_for_bytes` | Use this pair for harness wire artifacts. Do not use the SHA-256 string returned by `artifacts.compute_artifact_cid`. Add vectors proving Kubo-compatible CIDv1. |
 | Immutable coordination storage | Lazy `ipfs_kit_py.mcp_server.mcplusplus.coordination_storage.DurableCoordinationStore`, `BlockBackend`, and `IPFSHeliaBlockBackend` | Inject through a small protocol. Local store is hermetic; remote block transport is optional. Do not use Iroh/bucket CAS or the accelerate `VerifiedIPLDBackend` as the semantic root authority. |
-| Mutable current-root CAS and WAL | Generic root-CAS surface delivered at the final `ipfs_kit_py` pin | `SCH-003` binds only to `put`, `get`, `get_bytes`, `read_root`, `compare_and_swap_root`, and `recover`; its concrete import path is sealed in `SCH-000`. |
+| Mutable current-root CAS and WAL | Generic generation-bearing root-CAS surface delivered at the final `ipfs_kit_py` pin | `SCH-003` binds only to `put`, `get`, `get_bytes`, `has`, `read_root`, `compare_and_swap_root`, and `recover`; its concrete import path is sealed in `SCH-000`. |
+| Context budgeting and provider-visible source coverage | `agent_supervisor.context.context_compiler.ContextCompiler`, `context_contracts`, and `todo_daemon.production_context_slice` | Project semantic capsules/raw source into existing context references and production slices; do not build a second generic context optimizer. |
 | Resource admission and cancellation | `agent_supervisor.runtime.resource_scheduler.ResourceScheduler` and cancellation-aware work contracts | Wrap these types rather than introducing a scheduler. |
 | Provider execution | `agent_supervisor.runtime.provider_execution.ProviderExecutionGateway` | Use its reservation/idempotency path, with a stricter harness promotion gate that rejects simulated/degraded/replayed-as-new results in production. |
 | Worktree ownership and fencing | `merge.worktree_lifecycle.WorktreeLifecycleStore` and `merge.lease_coordination.LeaseCoordinator` | Acquire before `git worktree add`, fence every mutation/publication, and recover by durable attempt identity. |
-| Validation command parsing | `validation.validation_commands` | Reuse command classification and scope rules; execute only explicit argv in the worktree with bounded output/time. |
+| Proposal and patch admission | `validation.proposal_validation` plus `todo_daemon.production_context_slice.assert_proposal_covered_by_context` | Reuse strict parsing, immutable scope, preimage coverage, and rejection receipts before Git application. |
+| Validation execution | `validation.validation_commands`, `validation.validation_runtime`, and `validation.validation_scheduler.ValidationScheduler.run_staged` | The semantic selector supplies explicit commands; do not invoke the legacy `run_impact_selected` selector or add a subprocess scheduler. |
+| Proof execution | `proof.proof_scheduler.ProofScheduler` and formal-verification capability records | Reuse capability probing and typed unavailable results; do not build a prover. |
 | Restart/replay journal | `runtime.event_log` | Append bounded semantic-session events and checkpoint replay cursors. It is a journal, not a task-queue or semantic-state authority. |
 
 `PersistentTaskQueue` is deliberately not an authority or dependency of this
@@ -127,12 +136,14 @@ ipfs_accelerate_py/agent_supervisor/semantic_state/
 ```
 
 Names may be combined only where doing so reduces surface without mixing
-authorities. Tests live in `tests/agent_supervisor/semantic_state/`, the
-controlled repository in `tests/fixtures/semantic_state_harness/controlled_repo/`,
+authorities. Tests live in the pytest-discovered `test/api/semantic_state/`, the
+controlled repository in `test/fixtures/semantic_state_harness/controlled_repo/`,
 and the exactly-40-task corpus in `benchmarks/semantic_state/tasks/`.
 
 The root `pyproject.toml` and `setup.py` receive only the matching
-`semantic-state` console entry. No legacy CLI or MCP server is expanded.
+`semantic-state` console entry and package the closed interface schema for
+`importlib.resources` access. A built-wheel smoke test must prove both the
+schema and console entry are present. No legacy CLI or MCP server is expanded.
 
 ## 5. Architecture and data flow
 
@@ -141,9 +152,10 @@ Git/tree snapshot
       |
       v
 SemanticStateProvider ------------------------------+
-  state + graph + delta + invalidation              |
+  state + Merkle DAG + capsules + delta             |
+  + invalidation + exact tree-bound source          |
       |                                              |
-      +--> CapsuleCompiler --> TestSelector          |
+      +--> CapsuleAdmission --> TestSelector         |
       |           |                 |                |
       +-----------+--> ContextPacker                 |
                           |                           |
@@ -177,9 +189,10 @@ are rejected. At minimum:
 - `Availability`: `available`, `unavailable`;
 - `UnavailableResult`: operation, provider/adapter ID, stable reason code,
   retryable flag, and bounded diagnostic text;
-- `SemanticCapsule`: stable symbol ID, version CID, source CID, confidence,
-  authoritative facts, hint-only facts, dependencies, tests, proofs,
-  validity/binding CIDs, and raw-source requirement;
+- `SemanticCapsuleRef`: the datasets-owned capsule CID, stable symbol ID,
+  version/source CIDs, confidence, validity bindings, and raw-source
+  requirement; authoritative semantic facts remain in the referenced datasets
+  capsule;
 - `ContextPack`: objective, exact raw target/surrounding/test code, dependency
   capsules, obligations/counterexamples/delta/interfaces/assumptions,
   exclusions, token accounting, risk, route, and escalation recommendation;
@@ -194,6 +207,11 @@ are rejected. At minimum:
   simulation flag, freshness, and acceptance eligibility;
 - `HarnessResult`: accepted/rejected/unavailable, old/new roots, patch, receipts,
   obligations, event head, and stable reasons.
+- `RootRef`: root CID plus monotonic generation used as the complete CAS token;
+- `SemanticStateRootManifest`: repository identity, base/candidate Git tree,
+  datasets state and Merkle-root CIDs, capsule-index/delta/invalidation/
+  obligation/selection/receipt CIDs, dependency/configuration/policy/interface/
+  toolchain bindings, event head, versions, and acceptance disposition.
 
 Timestamps, local paths, process IDs, wall-clock durations, and provider billing
 observations may appear in operational receipts but never alter a deterministic
@@ -214,14 +232,20 @@ class SemanticStateProvider(Protocol):
     def explain_symbol(self, repository_state, symbol_id): ...
     def explain_impact(self, repository_state, changed_symbol_ids): ...
     def watch_repository(self, repo_path, callback, *, debounce_ms): ...
+    def compile_semantic_capsule(self, repository_state, symbol_id): ...
+    def read_source_blob(self, repository_state, path, *, expected_source_cid): ...
+    def read_source_span(self, repository_state, symbol_id): ...
 ```
 
-The adapter validates returned state/root/version CIDs and closed confidence
+The adapter validates returned state/Merkle/capsule/version CIDs and closed confidence
 values (`exact`, `conservative`, `heuristic`, `opaque`). It does not reach into
 the semantic-index implementation to recover facts absent from its public
 records. Missing capabilities produce `UnavailableResult`, never empty/exact
 state. Git/tree or deterministic filesystem snapshots remain authoritative;
-watch notifications never become mutations or state.
+watch notifications never become mutations or state. Source retrieval reads the
+exact scanned Git tree/blob and verifies the expected source CID. Reading the
+current filesystem after a scan is forbidden; a source race produces typed
+staleness and a rescan request.
 
 The harness consumes the scanner's modules, imports, symbols, signatures,
 annotations, decorators, exceptions, state reads/writes, calls, inheritance,
@@ -234,10 +258,11 @@ CID change invalidates descriptor receipts and client-adapter obligations. These
 are harness bindings layered on the phase-one delta; they do not mutate the
 phase-one graph authority.
 
-## 8. Semantic capsule compiler
+## 8. Semantic capsule authority and admission
 
-`capsules.py` compiles one capsule per requested symbol version from exact
-semantic-index records:
+The datasets semantic-state producer compiles one capsule per requested symbol
+version. Accelerate's `capsules.py` verifies, binds, caches, and projects those
+capsules without re-extracting or restating authoritative semantic facts:
 
 - normalized AST facts and stable/version identities;
 - public signature, annotations, defaults, decorators, and explicit contracts;
@@ -252,11 +277,13 @@ summaries are stored only in `heuristic_annotations`, bind the exact input
 capsule CID and model/provider version, and can never raise confidence or
 satisfy a verification obligation.
 
-Capsule reuse requires equality of symbol-version CID, extractor/schema
+Capsule reuse requires equality of capsule CID, symbol-version CID, extractor/schema
 versions, dependency/policy/interface/configuration bindings, and non-stale
 status. `exact` and `conservative` capsules may substitute for unchanged
 dependency code with visible caveats. `heuristic`, `opaque`, missing,
-invalidated, or unknown capsules force raw source retrieval.
+invalidated, or unknown capsules force raw source retrieval. `CapsuleCache` is
+only an index over `DurableSemanticStatePort`; it does not introduce another
+filesystem, database, block, CID, or mutable-root authority.
 
 ## 9. Incremental invalidation and obligations
 
@@ -313,8 +340,11 @@ a typed unavailable obligation/receipt; it is never reported as a passed proof.
 
 ## 11. Assurance-aware context packing
 
-`context_pack.py` optimizes minimum context subject to coverage and assurance
-constraints. It always contains:
+`context_pack.py` adapts semantic inputs into
+`ContextCompiler`/`ContextReference` records and a verified
+`ProductionContextSliceManifest`. The existing compiler optimizes minimum
+context subject to the additional semantic coverage and assurance constraints.
+The resulting pack always contains:
 
 - task/objective;
 - exact raw target code and exact surrounding edit context;
@@ -340,6 +370,8 @@ packer recommends escalation or human review instead of silently truncating.
 `ProviderExecutionGateway`, `LeaseCoordinator`, `WorktreeLifecycleStore`, and
 `runtime.event_log`:
 
+- deterministic task parsing and datasets capsule/summary projection are
+  explicit scheduled work kinds; optional model summaries remain heuristic;
 - resource admission occurs before parsing batches, capsule compilation, tests,
   provers, and provider invocation;
 - leases include attempt identity and fencing tokens;
@@ -356,9 +388,15 @@ legacy mock hardware or mock inference coordinators.
 confidence, risk class, affected dependency cone, unresolved obligations,
 prior repair failures, and available proofs. Routing results use the five
 required classes. Providers are injected by typed capability; none is hardcoded.
-`deterministic_only` means no model invocation. Production mode rejects absent
-providers and any gateway result marked simulated, degraded-to-simulation, or
-replayed without a previously admitted production receipt. Development
+`deterministic_only` means no model invocation, and `human_review_required`
+halts before invocation or root publication. Production uses
+`ProviderExecutionMode.ENFORCE` and requires available coordination, a real
+coordinator/invoker, verified provider attribution, and a non-simulated
+reservation. It rejects `sim:`/`degraded:` reservations, off/simulated/degraded
+phases, fallback reason codes, mismatched effective providers, and replay
+without a previously admitted production receipt. Any `llm_router.generate_text`
+adapter passes `allow_local_fallback=False` and
+`allow_cross_provider_fallback=False`. Development
 simulation is labeled in every result and can never satisfy production
 verification or state-root acceptance.
 
@@ -390,8 +428,10 @@ class DurableSemanticStatePort(Protocol):
     def get(self, cid): ...
     def get_bytes(self, cid): ...
     def has(self, cid): ...
-    def read_root(self, repository_id): ...
-    def compare_and_swap_root(self, repository_id, expected_root, new_root): ...
+    def read_root(self, repository_id) -> RootRef | None: ...
+    def compare_and_swap_root(
+        self, repository_id, expected: RootRef | None, new_root_cid
+    ) -> RootRef: ...
     def recover(self): ...
 ```
 
@@ -401,7 +441,15 @@ lazy and injected. Writes store and verify all immutable blocks first, append a
 prepared WAL transition, perform expected-old CAS, mark committed, and expose
 the new root atomically. Recovery either completes an already-published valid
 root or retains the old root; corruption fails closed. Two distinct concurrent
-writers from one expected root cannot both succeed.
+writers from one expected root cannot both succeed. The monotonic generation is
+part of the expected token, so an A-to-B-to-A sequence cannot admit an ABA-stale
+writer. The CAS target is always a stored and transitively verifiable
+`SemanticStateRootManifest`, never a bare unexplained repository-state CID.
+Observed and rejected candidate manifests may remain as immutable blocks, but
+only an accepted manifest is reachable from the current `RootRef`. The initial
+scan uses an explicit `None -> bootstrap manifest` CAS and labels that manifest
+indexed rather than patch-verified; later verification receipts cannot be
+inferred from bootstrap state.
 
 `receipts.py` binds every receipt to the exact pre/post tree, semantic roots,
 selection, commands, toolchain, dependency/lock/config/policy/interface CIDs,
@@ -412,24 +460,32 @@ but can never satisfy acceptance.
 
 ## 14. Fenced isolated patch workflow
 
-`worktree.py` and `harness.py` implement exactly this acceptance sequence:
+`worktree.py` composes `managed_git_worktree`/`GitWorktreeSession`,
+`WorktreeLifecycleStore`, `LeaseCoordinator`, strict proposal validation, and
+the production-context preimage gate. It asserts that the worktree base is the
+exact scanned commit/tree; if the shared helper cannot select that base, only a
+narrow reviewed base-ref extension is permitted. `worktree.py` and `harness.py`
+implement exactly this acceptance sequence:
 
 1. acquire a fenced attempt and create a disposable Git worktree;
 2. materialize the accepted `ContextPack` by CID;
 3. invoke the configured model adapter through the production gate;
-4. validate that the response is a bounded unified diff;
+4. validate the untrusted proposal through `proposal_validation`, prove every
+   patch preimage was visible in the bound production context, parse a bounded
+   unified diff, and run `git apply --check`;
 5. reject paths outside the declared allowlist, binary patches, symlink escapes,
    submodule changes, and control/runtime/state paths;
-6. apply the patch with Git in the disposable worktree;
+6. apply the already-checked patch with Git in the disposable worktree;
 7. rescan and identify actually changed symbols;
 8. recompute the delta and invalidation obligations;
 9. run declared static checks;
 10. run selected pytest nodes;
 11. run configured available proof obligations;
 12. optionally run the full suite as oracle, mandatorily when policy escalates;
-13. emit immutable artifacts, verification receipts, and the next event node;
-14. compare-and-swap the new semantic-state root only after every acceptance
-    gate passes.
+13. store the graph, capsule index, context pack, delta, obligations, patch,
+    immutable receipts, next event node, and complete root manifest;
+14. compare-and-swap the stored manifest CID using the prior `RootRef` only
+    after every acceptance gate passes.
 
 Rejection leaves the current root unchanged and records a bounded rejection
 receipt. Cleanup is fenced and recoverable. No accepted source commit is made in
@@ -498,6 +554,10 @@ committed snapshots/mutations for:
 18. concurrent watchers/writers;
 19. out-of-scope model patch.
 
+The same controlled repository also supplies explicit end-to-end mutations for
+side-effect/security-policy changes, dependency/lockfile changes, policy
+changes, MCP interface/client-adapter changes, and a post-scan source race.
+
 The release suite proves bounded invalidation, all known dependent
 invalidations, raw-source fallback for opaque behavior, stale-receipt rejection,
 zero controlled-fixture test-selection false negatives, full-suite fallback,
@@ -522,7 +582,11 @@ The checked-in corpus contains exactly 40 reproducible maintenance tasks:
 Every task records baseline raw/retrieval context tokens, semantic `ContextPack`
 tokens, exact raw code excluded, capsule count, invalidation cone, selected and
 full tests, proof obligations, model route, acceptance/rejection, assumptions,
-and uncertainty. Both context modes use the same pinned tokenizer/estimator and
+and uncertainty. Checked-in candidate patches are replay/oracle fixtures only:
+they are always marked `production_eligible=false`, never produce a model
+receipt, and never advance a production root. Candidate verification outcome is
+reported separately from production acceptance. Both context modes use the
+same pinned tokenizer/estimator and
 coverage policy. Required target/test/opaque source cannot be removed to improve
 the result.
 
@@ -530,7 +594,9 @@ The initial gates are at least 30% median input-context reduction overall, zero
 known stale receipts admitted, zero controlled-fixture selection false
 negatives, deterministic state roots, and all uncertainty represented in each
 pack. Results include reduction by task type, precision/recall, fallback rate,
-latency by stage, artifact bytes, and route distribution. Failed and escalated
+latency by stage, artifact bytes, and route distribution. `--check` compares
+only deterministic semantic fields; wall-clock latency is explicitly
+observational. Failed and escalated
 tasks remain in the denominator.
 
 ## 19. Parallel delivery plan
@@ -541,12 +607,12 @@ The exact dependency DAG is encoded in the taskboard. Its waves are:
 A0  SCH-000
 A1  SCH-001 | SCH-002 | SCH-003 | SCH-014
 A2  SCH-004 | SCH-006 | SCH-016
-A3  SCH-005 | SCH-007 | SCH-010
-A4  SCH-008
+A3  SCH-005
+A4  SCH-007 | SCH-008 | SCH-010
 A5  SCH-009
 A6  SCH-011
-A7  SCH-012
-A8  SCH-013 | SCH-015 | SCH-017
+A7  SCH-012 | SCH-017
+A8  SCH-013 | SCH-015
 A9  SCH-018
 ```
 

--- a/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
+++ b/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
@@ -1,0 +1,579 @@
+# Python semantic-compression coding-agent harness plan
+
+Status: reviewed implementation plan; supervisor launch is intentionally gated by
+`SCH-000`.
+
+This plan defines a focused Python 3.12 and pytest harness in
+`ipfs_accelerate_py.agent_supervisor.semantic_state`. It consumes the semantic
+state contracts implemented in `endomorphosis/ipfs_datasets_py`, uses a narrow
+durability port backed by `endomorphosis/ipfs_kit_py`, and reuses the existing
+`ipfs_accelerate_py` supervisor runtime. It does not create another agent
+framework, MCP server, user interface, theorem prover, or general multi-language
+verification platform.
+
+The companion supervisor inputs are:
+
+- `docs/architecture/semantic_compression_harness.objectives.md`
+- `docs/architecture/semantic_compression_harness.todo.md`
+
+## 1. Revision and launch seal
+
+The inspected `ipfs_accelerate_py` baseline is commit
+`ea11293bb996f052d620eae989f5377a956764b1`. The MCP++ wire authority inspected
+is `Mcp-Plus-Plus` commit `dc3164653a48d059ae9812078359daeafb451c07`.
+
+The pre-integration `ipfs_kit_py` checkout inspected while writing this plan was
+`69091bf8f11a3ef1fb0e04e11a6d8a4c87f3fa78`; this is evidence only, not the
+phase-two dependency pin. The reviewed phase-one `ipfs_datasets_py` baseline was
+`a2f5400b7cb89c8481819379a1b7b9959fe81d45`; its completed semantic-index commit
+is also not assumed here.
+
+`SCH-000` must be completed manually before any implementation supervisor is
+launched. It must replace the two unresolved values below with exact 40-hex
+commits after the phase-one semantic-index closeout and the `ipfs_kit_py`
+state-root/CAS closeout:
+
+```text
+IPFS_DATASETS_SEMANTIC_INDEX_COMMIT = UNRESOLVED
+IPFS_KIT_DURABLE_ROOT_COMMIT        = UNRESOLVED
+```
+
+The gate fails closed if either value is unresolved, is not a commit reachable
+from the intended repository, or does not pass its producer's contract tests.
+Workers may not infer a pin from a mutable branch, current checkout, editable
+install, submodule pointer, or ambient `PYTHONPATH` ordering.
+
+## 2. Scope and completion outcome
+
+The release is a complete local loop over a controlled Python fixture repository
+or a deliberately selected stable kernel in `ipfs_datasets_py`. It must:
+
+1. obtain a deterministic repository state from the phase-one scanner;
+2. consume its symbol-level Merkle graph and confidence classifications;
+3. compile and reuse semantic capsules for unchanged dependencies;
+4. consume state deltas and propagate explicit invalidation obligations;
+5. select affected pytest tests and configured proof obligations;
+6. build a minimum-sufficient, assurance-aware `ContextPack`;
+7. create a disposable fenced Git worktree and request a patch from a configured
+   provider;
+8. validate patch syntax and file scope before applying it;
+9. rescan, run static checks, selected tests, and available provers;
+10. publish MCP++-conformant, content-addressed receipts and compare-and-swap the
+    accepted semantic-state root.
+
+The harness never imports or executes a target repository for analysis. Test and
+proof execution occurs only in the isolated validation worktree after the exact
+commands, environment bindings, and selected inputs have been recorded.
+
+### Non-goals
+
+- arbitrary language frontends or verification beyond Python 3.12 and pytest;
+- automatic rewriting of dependent source;
+- model-generated summaries promoted to exact facts;
+- ZK proofs or a new prover;
+- a network service, MCP server, dashboard, or interactive UI;
+- semantic context packing unrelated to this local coding loop;
+- replacing the existing agent supervisor, resource scheduler, leases, event
+  log, provider gateway, or worktree lifecycle implementation;
+- scanning or verifying the whole repository portfolio in the MVP;
+- production fallback to mock hardware, mock inference, replayed model text, or
+  simulation.
+
+## 3. Authorities inspected and reuse decisions
+
+| Concern | Existing authority | Decision |
+|---|---|---|
+| Python repository state, symbols, typed graph, deltas, invalidation, explanations | Final pinned `ipfs_datasets_py.logic.software_contracts.semantic_index` public API | Consume through `SemanticStateProvider`; never reconstruct AST identity or graph semantics in accelerate. |
+| Semantic content identity | Final pinned semantic-index records and their `software_contracts.content` CIDs | Preserve supplied CIDs and verify round trips; never translate them into a second identity. |
+| MCP++ wire shapes | MCP-IDL Profile A, CID-native artifacts Profile B, and Event DAG Profile F at `dc316465…` | Encode a local interface descriptor and conformance vectors against those profiles. No semantic-specific upstream schema was found, so local payload schemas remain namespaced extensions carried by the MCP++ envelope. |
+| MCP++ artifact bytes and real CIDv1 | `ipfs_accelerate_py.mcp_server.mcplusplus.artifacts.canonicalize_artifact` plus `ipfs_accelerate_py.mcp_server.mcplusplus.kubo_cid.cid_for_bytes` | Use this pair for harness wire artifacts. Do not use the SHA-256 string returned by `artifacts.compute_artifact_cid`. Add vectors proving Kubo-compatible CIDv1. |
+| Immutable coordination storage | Lazy `ipfs_kit_py.mcp_server.mcplusplus.coordination_storage.DurableCoordinationStore`, `BlockBackend`, and `IPFSHeliaBlockBackend` | Inject through a small protocol. Local store is hermetic; remote block transport is optional. Do not use Iroh/bucket CAS or the accelerate `VerifiedIPLDBackend` as the semantic root authority. |
+| Mutable current-root CAS and WAL | Generic root-CAS surface delivered at the final `ipfs_kit_py` pin | `SCH-003` binds only to `put`, `get`, `get_bytes`, `read_root`, `compare_and_swap_root`, and `recover`; its concrete import path is sealed in `SCH-000`. |
+| Resource admission and cancellation | `agent_supervisor.runtime.resource_scheduler.ResourceScheduler` and cancellation-aware work contracts | Wrap these types rather than introducing a scheduler. |
+| Provider execution | `agent_supervisor.runtime.provider_execution.ProviderExecutionGateway` | Use its reservation/idempotency path, with a stricter harness promotion gate that rejects simulated/degraded/replayed-as-new results in production. |
+| Worktree ownership and fencing | `merge.worktree_lifecycle.WorktreeLifecycleStore` and `merge.lease_coordination.LeaseCoordinator` | Acquire before `git worktree add`, fence every mutation/publication, and recover by durable attempt identity. |
+| Validation command parsing | `validation.validation_commands` | Reuse command classification and scope rules; execute only explicit argv in the worktree with bounded output/time. |
+| Restart/replay journal | `runtime.event_log` | Append bounded semantic-session events and checkpoint replay cursors. It is a journal, not a task-queue or semantic-state authority. |
+
+`PersistentTaskQueue` is deliberately not an authority or dependency of this
+feature. The harness is one bounded session coordinator over existing resource,
+lease, worktree, event, and provider mechanisms.
+
+## 4. Smallest owning package
+
+All focused implementation belongs under:
+
+```text
+ipfs_accelerate_py/agent_supervisor/semantic_state/
+    __init__.py
+    contracts.py
+    wire.py
+    datasets_adapter.py
+    durable_state.py
+    scheduling.py
+    capsules.py
+    context_pack.py
+    routing.py
+    test_selection.py
+    verification.py
+    receipts.py
+    worktree.py
+    harness.py
+    session.py
+    cli.py
+    benchmark.py
+    schemas/
+        semantic-state-harness.interface.json
+```
+
+Names may be combined only where doing so reduces surface without mixing
+authorities. Tests live in `tests/agent_supervisor/semantic_state/`, the
+controlled repository in `tests/fixtures/semantic_state_harness/controlled_repo/`,
+and the exactly-40-task corpus in `benchmarks/semantic_state/tasks/`.
+
+The root `pyproject.toml` and `setup.py` receive only the matching
+`semantic-state` console entry. No legacy CLI or MCP server is expanded.
+
+## 5. Architecture and data flow
+
+```text
+Git/tree snapshot
+      |
+      v
+SemanticStateProvider ------------------------------+
+  state + graph + delta + invalidation              |
+      |                                              |
+      +--> CapsuleCompiler --> TestSelector          |
+      |           |                 |                |
+      +-----------+--> ContextPacker                 |
+                          |                           |
+                    RoutingPolicy                    |
+                          |                           |
+                 SchedulingAdapter                   |
+                          |                           |
+             Fenced disposable worktree              |
+                          |                           |
+              patch -> rescan -> verification         |
+                          |                           |
+                   MCP++ receipts/event               |
+                          |                           |
+                DurableSemanticStatePort <------------+
+                          |
+              expected-old CAS state root
+```
+
+Every arrow crosses a typed, bounded contract. The scanner remains canonical;
+filesystem watcher events only request another scan.
+
+## 6. Closed harness contracts
+
+`contracts.py` defines deterministic immutable records with `to_dict` and
+strict `from_dict` behavior. Durable collections are sorted and duplicate IDs
+are rejected. At minimum:
+
+- `HarnessMode`: `development` or `production`;
+- `WorkKind`: task parsing, scan, capsule compilation, test selection, context
+  packing, model invocation, static check, pytest, prover, persistence;
+- `Availability`: `available`, `unavailable`;
+- `UnavailableResult`: operation, provider/adapter ID, stable reason code,
+  retryable flag, and bounded diagnostic text;
+- `SemanticCapsule`: stable symbol ID, version CID, source CID, confidence,
+  authoritative facts, hint-only facts, dependencies, tests, proofs,
+  validity/binding CIDs, and raw-source requirement;
+- `ContextPack`: objective, exact raw target/surrounding/test code, dependency
+  capsules, obligations/counterexamples/delta/interfaces/assumptions,
+  exclusions, token accounting, risk, route, and escalation recommendation;
+- `ModelRoute`: exactly `deterministic_only`, `small_local_model`,
+  `medium_model`, `frontier_model`, or `human_review_required`;
+- `PatchProposal`: provider identity, mode, base tree/root, unified diff bytes
+  CID, declared paths, and generation result;
+- `TestSelection`: selected node IDs, reasons, fallbacks, known coverage,
+  unresolved edges, and selection CID;
+- `VerificationReceipt`: exact tree/config/dependency/policy/interface/root
+  bindings, command identity, selected nodes, exit result, output artifact CIDs,
+  simulation flag, freshness, and acceptance eligibility;
+- `HarnessResult`: accepted/rejected/unavailable, old/new roots, patch, receipts,
+  obligations, event head, and stable reasons.
+
+Timestamps, local paths, process IDs, wall-clock durations, and provider billing
+observations may appear in operational receipts but never alter a deterministic
+semantic-state root. Secret values, prompts, raw model output, and repository
+source bodies are never copied into small scheduler observations.
+
+## 7. Semantic-state provider boundary
+
+`datasets_adapter.py` is the only import boundary to `ipfs_datasets_py`. It
+loads the pinned dependency lazily on first operation, checks the expected
+contract/schema/extractor versions, and exposes:
+
+```python
+class SemanticStateProvider(Protocol):
+    def scan_repository(self, repo_path, previous_state=None): ...
+    def diff_repository_states(self, previous_state, current_state): ...
+    def calculate_invalidation(self, previous_state, current_state, delta): ...
+    def explain_symbol(self, repository_state, symbol_id): ...
+    def explain_impact(self, repository_state, changed_symbol_ids): ...
+    def watch_repository(self, repo_path, callback, *, debounce_ms): ...
+```
+
+The adapter validates returned state/root/version CIDs and closed confidence
+values (`exact`, `conservative`, `heuristic`, `opaque`). It does not reach into
+the semantic-index implementation to recover facts absent from its public
+records. Missing capabilities produce `UnavailableResult`, never empty/exact
+state. Git/tree or deterministic filesystem snapshots remain authoritative;
+watch notifications never become mutations or state.
+
+The harness consumes the scanner's modules, imports, symbols, signatures,
+annotations, decorators, exceptions, state reads/writes, calls, inheritance,
+schemas/serialization edges, tests/markers/fixtures/config, generated relations,
+proof edges, and source spans. It does not claim complete dynamic dispatch.
+
+Policy and MCP-interface inputs are explicit content-addressed artifacts. A
+policy CID change invalidates cached policy decisions. An interface descriptor
+CID change invalidates descriptor receipts and client-adapter obligations. These
+are harness bindings layered on the phase-one delta; they do not mutate the
+phase-one graph authority.
+
+## 8. Semantic capsule compiler
+
+`capsules.py` compiles one capsule per requested symbol version from exact
+semantic-index records:
+
+- normalized AST facts and stable/version identities;
+- public signature, annotations, defaults, decorators, and explicit contracts;
+- declared and observed exception/effect sets;
+- bounded static relations and schema/serialization relations;
+- relevant tests, fixtures, configurations, and proof obligations;
+- raw-source CID and spans needed to retrieve exact code;
+- the symbol's analysis confidence and every reason it was reduced.
+
+Docstrings are stored separately as non-authoritative hints. Optional model
+summaries are stored only in `heuristic_annotations`, bind the exact input
+capsule CID and model/provider version, and can never raise confidence or
+satisfy a verification obligation.
+
+Capsule reuse requires equality of symbol-version CID, extractor/schema
+versions, dependency/policy/interface/configuration bindings, and non-stale
+status. `exact` and `conservative` capsules may substitute for unchanged
+dependency code with visible caveats. `heuristic`, `opaque`, missing,
+invalidated, or unknown capsules force raw source retrieval.
+
+## 9. Incremental invalidation and obligations
+
+The harness delegates source-semantic invalidation to
+`calculate_invalidation` and preserves its explanation paths. It additionally
+binds execution artifacts to configuration, dependency lock, policy,
+interface-descriptor, provider, toolchain, and proof identities. Admission
+implements these explicit rules:
+
+- body changes stale that capsule, direct proof obligations, and relevant
+  tests; callers remain reusable if signature/effects/exceptions are stable;
+- signature changes stale callers, adapters, interface descriptions, schemas,
+  and tests;
+- effect changes stale purity/security assumptions and callers bound to the
+  prior effect set;
+- exception changes stale recovery assumptions and exception-contract tests;
+- schema changes stale serializers, deserializers, storage/API adapters, and
+  tests;
+- dependency/lock changes stale dependent summaries and verification receipts;
+- fixture/test configuration changes stale bound test receipts;
+- policy changes stale policy decisions and security admission receipts;
+- MCP interface changes stale interface descriptions and client adapters;
+- opaque behavior emits a raw-source-required obligation.
+
+The output is always a sorted obligation set. No task automatically rewrites an
+arbitrary caller, adapter, or schema consumer.
+
+## 10. Test and proof selection
+
+`test_selection.py` seeds selection with changed/deleted/renamed symbols and
+explicit user rules, then follows bounded typed edges for:
+
+- direct `tested_by` relations;
+- imports and statically resolved caller/callee dependencies;
+- fixture and `usefixtures` dependencies;
+- schema/serialization and configuration dependencies;
+- generated-file and proof-obligation bindings.
+
+Each selected pytest node carries an auditable shortest reason path. Ambiguous
+or unresolved edges are visible. The selector supports an unconditional
+full-suite fallback and an assurance policy that requires it for opaque changes,
+unknown config/plugin effects, global dependency changes, or insufficient
+coverage.
+
+`compare-full-suite` runs selected tests and then the same fixture's full suite
+as an oracle. A false negative is any full-suite failure attributable to the
+mutation that was absent from the selected run. The controlled fixture release
+gate requires zero false negatives and reports precision, recall, fallback rate,
+and selected/full test counts without redefining an unaffected passing test as a
+true positive.
+
+Proof execution is optional and capability-probed. An unavailable prover yields
+a typed unavailable obligation/receipt; it is never reported as a passed proof.
+
+## 11. Assurance-aware context packing
+
+`context_pack.py` optimizes minimum context subject to coverage and assurance
+constraints. It always contains:
+
+- task/objective;
+- exact raw target code and exact surrounding edit context;
+- exact directly edited tests;
+- reusable semantic capsules for unchanged dependencies;
+- unresolved obligations and minimized counterexamples;
+- current repository-state delta;
+- relevant MCP/public interface schemas;
+- explicit assumptions and confidence caveats;
+- an explanation for every excluded source region;
+- token totals by category and estimator version;
+- route and escalation recommendation.
+
+Coverage is a hard constraint, not a ranking score. Exact target/edit spans are
+never compressed. Conservative capsules remain visibly conservative. Heuristic
+capsules can guide retrieval but cannot replace source. Opaque, invalid, stale,
+or unknown facts include raw source. If the budget cannot satisfy coverage, the
+packer recommends escalation or human review instead of silently truncating.
+
+## 12. Scheduling and model routing
+
+`scheduling.py` adapts harness jobs to `ResourceScheduler`,
+`ProviderExecutionGateway`, `LeaseCoordinator`, `WorktreeLifecycleStore`, and
+`runtime.event_log`:
+
+- resource admission occurs before parsing batches, capsule compilation, tests,
+  provers, and provider invocation;
+- leases include attempt identity and fencing tokens;
+- cancellation is propagated to queued/local subprocess/provider work;
+- terminal outcomes are idempotent and replayable without repeating provider
+  charges or publishing stale results;
+- restart reads fenced lifecycle records and a verified event cursor;
+- unavailable capacity/provider/tooling returns `UnavailableResult`.
+
+The adapter does not use `PersistentTaskQueue` as an authority and does not use
+legacy mock hardware or mock inference coordinators.
+
+`routing.py` scores only the declared inputs: context size, lowest relevant
+confidence, risk class, affected dependency cone, unresolved obligations,
+prior repair failures, and available proofs. Routing results use the five
+required classes. Providers are injected by typed capability; none is hardcoded.
+`deterministic_only` means no model invocation. Production mode rejects absent
+providers and any gateway result marked simulated, degraded-to-simulation, or
+replayed without a previously admitted production receipt. Development
+simulation is labeled in every result and can never satisfy production
+verification or state-root acceptance.
+
+## 13. Durable artifacts, MCP++ wire, and freshness
+
+`wire.py` publishes a Profile A interface descriptor for scan/status/graph/
+explain/invalidate/select/pack/verify/apply/compare/benchmark operations. Payload
+schemas are closed, versioned harness extensions. Calls and results are carried
+by Profile B execution envelopes, and session transitions form a Profile F
+parent-linked event DAG.
+
+Harness wire CIDs are calculated as:
+
+```text
+canonical bytes = mcp_server.mcplusplus.artifacts.canonicalize_artifact(payload)
+CIDv1           = mcp_server.mcplusplus.kubo_cid.cid_for_bytes(canonical bytes)
+```
+
+The older `compute_artifact_cid` SHA-256 label is explicitly forbidden for new
+harness artifacts. Conformance tests compare exact bytes/CIDs with MCP++ and
+Kubo-compatible vectors. A phase-one semantic-state CID remains its original
+CID and is referenced, not recomputed.
+
+`durable_state.py` defines this narrow protocol:
+
+```python
+class DurableSemanticStatePort(Protocol):
+    def put(self, artifact, *, expected_cid, codec="dag-json"): ...
+    def get(self, cid): ...
+    def get_bytes(self, cid): ...
+    def has(self, cid): ...
+    def read_root(self, repository_id): ...
+    def compare_and_swap_root(self, repository_id, expected_root, new_root): ...
+    def recover(self): ...
+```
+
+The local implementation uses the pinned `DurableCoordinationStore` plus the
+pinned generic root-CAS/WAL surface and needs no daemon. The optional backend is
+lazy and injected. Writes store and verify all immutable blocks first, append a
+prepared WAL transition, perform expected-old CAS, mark committed, and expose
+the new root atomically. Recovery either completes an already-published valid
+root or retains the old root; corruption fails closed. Two distinct concurrent
+writers from one expected root cannot both succeed.
+
+`receipts.py` binds every receipt to the exact pre/post tree, semantic roots,
+selection, commands, toolchain, dependency/lock/config/policy/interface CIDs,
+provider mode, and output blocks. A receipt is admissible only when all bindings
+match, all required stages passed, all required artifacts rehash, the event
+parent is current, and `simulation == false`. Stale receipts remain inspectable
+but can never satisfy acceptance.
+
+## 14. Fenced isolated patch workflow
+
+`worktree.py` and `harness.py` implement exactly this acceptance sequence:
+
+1. acquire a fenced attempt and create a disposable Git worktree;
+2. materialize the accepted `ContextPack` by CID;
+3. invoke the configured model adapter through the production gate;
+4. validate that the response is a bounded unified diff;
+5. reject paths outside the declared allowlist, binary patches, symlink escapes,
+   submodule changes, and control/runtime/state paths;
+6. apply the patch with Git in the disposable worktree;
+7. rescan and identify actually changed symbols;
+8. recompute the delta and invalidation obligations;
+9. run declared static checks;
+10. run selected pytest nodes;
+11. run configured available proof obligations;
+12. optionally run the full suite as oracle, mandatorily when policy escalates;
+13. emit immutable artifacts, verification receipts, and the next event node;
+14. compare-and-swap the new semantic-state root only after every acceptance
+    gate passes.
+
+Rejection leaves the current root unchanged and records a bounded rejection
+receipt. Cleanup is fenced and recoverable. No accepted source commit is made in
+the user's working checkout; the result identifies the retained/cleaned
+worktree and patch artifact according to configured policy.
+
+## 15. Incremental sessions and watcher behavior
+
+`session.py` coordinates repeated local runs. Watch callbacks debounce only to
+schedule a fresh canonical scan. Concurrent watchers coalesce equal snapshot
+CIDs, and fenced attempts prevent stale callbacks from publishing a root.
+Restart replays event-log pages, verifies immutable artifacts, reconciles WAL
+state, and resumes only nonterminal attempts whose lease/fence still matches.
+
+No watcher event, task queue row, DuckDB projection, model assertion, or receipt
+alone is semantic truth. The pinned scanner state and current-root CAS are the
+truth boundaries.
+
+## 16. CLI
+
+The dedicated `semantic-state` command exposes deterministic JSON by default:
+
+```text
+semantic-state scan <repo>
+semantic-state watch <repo>
+semantic-state status <repo>
+semantic-state graph <repo> [--symbol ID]
+semantic-state explain-symbol <repo> <symbol>
+semantic-state explain-impact <repo> <symbol-or-file>...
+semantic-state invalidate <old-state> <new-state>
+semantic-state select-tests <repo> <symbol-or-file>...
+semantic-state pack-context <repo> <task> <target>
+semantic-state verify <repo> [--full-suite]
+semantic-state apply-patch <repo> <patch-or-task>
+semantic-state compare-full-suite <fixture-or-repo>
+semantic-state benchmark [--corpus PATH]
+```
+
+Commands that need an unavailable optional dependency/provider return a stable
+typed error on stdout/stderr and nonzero exit. Production `apply-patch` never
+falls back to simulation. CLI imports do not start watchers, processes,
+databases, daemons, networks, or package installation.
+
+## 17. Controlled fixtures and acceptance matrix
+
+The fixture repository is small enough for a full-suite oracle and contains
+committed snapshots/mutations for:
+
+1. local function body change;
+2. public signature change;
+3. cross-module call change;
+4. dataclass/schema change;
+5. exception behavior change;
+6. fixture dependency change;
+7. pytest configuration change;
+8. dynamic import;
+9. monkey patch;
+10. opaque native dependency;
+11. unrelated formatting change;
+12. deleted symbol;
+13. renamed symbol;
+14. generated file;
+15. stale receipt;
+16. failed root CAS;
+17. interrupted state transition;
+18. concurrent watchers/writers;
+19. out-of-scope model patch.
+
+The release suite proves bounded invalidation, all known dependent
+invalidations, raw-source fallback for opaque behavior, stale-receipt rejection,
+zero controlled-fixture test-selection false negatives, full-suite fallback,
+deterministic state roots, safe recovery, single-winner CAS, and the production
+simulation gate. It also runs cold-import tests with all automatic install
+features disabled and checks that imports do not change environment, create
+files/processes, or access the network.
+
+## 18. Exactly-40-task benchmark
+
+The checked-in corpus contains exactly 40 reproducible maintenance tasks:
+
+| Task type | Count |
+|---|---:|
+| Small bug fixes | 10 |
+| Test repairs | 6 |
+| API adapters | 6 |
+| Schema migrations | 6 |
+| Multi-file changes and refactors | 6 |
+| Expected rejection or frontier/human escalation | 6 |
+
+Every task records baseline raw/retrieval context tokens, semantic `ContextPack`
+tokens, exact raw code excluded, capsule count, invalidation cone, selected and
+full tests, proof obligations, model route, acceptance/rejection, assumptions,
+and uncertainty. Both context modes use the same pinned tokenizer/estimator and
+coverage policy. Required target/test/opaque source cannot be removed to improve
+the result.
+
+The initial gates are at least 30% median input-context reduction overall, zero
+known stale receipts admitted, zero controlled-fixture selection false
+negatives, deterministic state roots, and all uncertainty represented in each
+pack. Results include reduction by task type, precision/recall, fallback rate,
+latency by stage, artifact bytes, and route distribution. Failed and escalated
+tasks remain in the denominator.
+
+## 19. Parallel delivery plan
+
+The exact dependency DAG is encoded in the taskboard. Its waves are:
+
+```text
+A0  SCH-000
+A1  SCH-001 | SCH-002 | SCH-003 | SCH-014
+A2  SCH-004 | SCH-006 | SCH-016
+A3  SCH-005 | SCH-007 | SCH-010
+A4  SCH-008
+A5  SCH-009
+A6  SCH-011
+A7  SCH-012
+A8  SCH-013 | SCH-015 | SCH-017
+A9  SCH-018
+```
+
+Task output ownership is deliberately narrow. The three reviewed control files
+are protected from implementation workers. Parallel work may proceed only after
+`SCH-000` is manually sealed with the final dependency commits.
+
+## 20. Release evidence and honest limitations
+
+The final report is generated from committed receipts and benchmark results and
+must include architecture, exact packages/modules, commands/examples, tests and
+results, benchmark and task-type token reductions, test-selection precision and
+recall, known unsoundness/opaque cases, performance bottlenecks, and exact work
+remaining before ZK aggregation and production integration.
+
+Expected limitations remain explicit: Python reflection and dynamic dispatch
+can be opaque; static call/test selection is bounded rather than complete;
+pytest plugin behavior can require full-suite fallback; proof tools may be
+unavailable; token estimates depend on a declared estimator; external network,
+filesystem, and native effects cannot be proven absent by this analyzer. These
+limitations lower confidence or force source/full verification. They never
+become exact claims.
+
+No ZK aggregation is implemented. Future ZK work requires a frozen receipt
+circuit/input schema, deterministic verifier semantics, proof-system and setup
+selection, aggregation rules, key lifecycle, and independent security review.
+Production integration additionally requires supported live provider adapters,
+credential isolation, sandbox hardening, resource quotas, platform-specific
+worktree/process tests, release signing, migration/version policy, and an
+operational rollback/recovery runbook.

--- a/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
+++ b/docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md
@@ -22,27 +22,31 @@ The inspected `ipfs_accelerate_py` baseline is commit
 `ea11293bb996f052d620eae989f5377a956764b1`. The MCP++ wire authority inspected
 is `Mcp-Plus-Plus` commit `dc3164653a48d059ae9812078359daeafb451c07`.
 
-The pre-integration `ipfs_kit_py` checkout inspected while writing this plan was
-`69091bf8f11a3ef1fb0e04e11a6d8a4c87f3fa78`; this is evidence only, not the
-phase-two dependency pin. The reviewed phase-one `ipfs_datasets_py` baseline was
-`a2f5400b7cb89c8481819379a1b7b9959fe81d45`; its completed semantic-index commit
-is also not assumed here.
+The repaired `ipfs_kit_py` generation-bearing durable-root authority is pinned
+at commit `05ba9375923cd5fb52e2c9c18b98b530d57d077f`. The reviewed phase-one
+`ipfs_datasets_py` baseline was
+`a2f5400b7cb89c8481819379a1b7b9959fe81d45`; neither the final repaired
+incremental-index closeout nor the final semantic-state/Merkle/capsule closeout
+is assumed here.
 
 `SCH-000` must be completed manually before any implementation supervisor is
-launched. It must replace the two unresolved values below with exact 40-hex
-commits after the repaired `ipfs_datasets_py` semantic-state/Merkle/capsule
-closeout and the repaired `ipfs_kit_py` versioned state-root/CAS closeout:
+launched. The kit authority is already pinned, but both datasets values must
+remain unresolved until their respective repaired closeouts supply exact
+40-hex commits:
 
 ```text
-IPFS_DATASETS_SEMANTIC_STATE_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT
-IPFS_KIT_DURABLE_ROOT_COMMIT        = UNRESOLVED_FINAL_REPAIRED_COMMIT
+IPFS_DATASETS_INCREMENTAL_SEMANTIC_INDEX_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT
+IPFS_DATASETS_SEMANTIC_STATE_COMMIT              = UNRESOLVED_FINAL_REPAIRED_COMMIT
+IPFS_KIT_DURABLE_ROOT_COMMIT                     = 05ba9375923cd5fb52e2c9c18b98b530d57d077f
 ```
 
-The gate fails closed if either value is unresolved, is not a commit reachable
-from the intended repository, or does not pass its producer's contract tests.
-The dependency seal also records the exact accelerate baseline and MCP++ wire
-commit, repository origins, interface/schema fingerprints, and Python 3.12
-toolchain. A deterministic seal validator must check those values; `git
+The gate fails closed if either datasets value is unresolved, or if any pin is
+not a commit reachable from the intended repository or does not pass its
+producer's contract tests.
+The dependency seal records all four repository origins and all five commit
+authorities (accelerate, MCP++, datasets ISI, datasets semantic state, and kit),
+plus interface/schema fingerprints and the Python 3.12 toolchain. A
+deterministic seal validator must check those values; `git
 rev-parse` alone is not validation. Workers may not infer a pin from a mutable
 branch, current checkout, editable install, submodule pointer, or ambient
 `PYTHONPATH` ordering.
@@ -123,7 +127,7 @@ ipfs_accelerate_py/agent_supervisor/semantic_state/
     capsules.py
     context_pack.py
     routing.py
-    test_selection.py
+    selection_execution.py
     verification.py
     receipts.py
     worktree.py
@@ -155,7 +159,7 @@ SemanticStateProvider ------------------------------+
   state + Merkle DAG + capsules + delta             |
   + invalidation + exact tree-bound source          |
       |                                              |
-      +--> CapsuleAdmission --> TestSelector         |
+      +--> CapsuleAdmission --> DatasetsSelection   |
       |           |                 |                |
       +-----------+--> ContextPacker                 |
                           |                           |
@@ -189,10 +193,10 @@ are rejected. At minimum:
 - `Availability`: `available`, `unavailable`;
 - `UnavailableResult`: operation, provider/adapter ID, stable reason code,
   retryable flag, and bounded diagnostic text;
-- `SemanticCapsuleRef`: the datasets-owned capsule CID, stable symbol ID,
-  version/source CIDs, confidence, validity bindings, and raw-source
-  requirement; authoritative semantic facts remain in the referenced datasets
-  capsule;
+- `SemanticCapsuleRef`: an admission-only reference containing the
+  datasets-owned capsule CID, producing semantic-state-root CID, stable symbol
+  ID, version/source CIDs, confidence, validity bindings, and raw-source
+  requirement; it never copies authoritative semantic facts from the capsule;
 - `ContextPack`: objective, exact raw target/surrounding/test code, dependency
   capsules, obligations/counterexamples/delta/interfaces/assumptions,
   exclusions, token accounting, risk, route, and escalation recommendation;
@@ -200,8 +204,10 @@ are rejected. At minimum:
   `medium_model`, `frontier_model`, or `human_review_required`;
 - `PatchProposal`: provider identity, mode, base tree/root, unified diff bytes
   CID, declared paths, and generation result;
-- `TestSelection`: selected node IDs, reasons, fallbacks, known coverage,
-  unresolved edges, and selection CID;
+- `TestSelectionRef`: the datasets-owned selection CID plus its previous
+  semantic-state-root CID (or `None`) and current semantic-state-root CID; the
+  selected node IDs, proof IDs, reason paths, fallback, universe, and coverage
+  facts remain solely in the referenced datasets `TestSelection`;
 - `VerificationReceipt`: exact tree/config/dependency/policy/interface/root
   bindings, command identity, selected nodes, exit result, output artifact CIDs,
   simulation flag, freshness, and acceptance eligibility;
@@ -232,20 +238,43 @@ class SemanticStateProvider(Protocol):
     def explain_symbol(self, repository_state, symbol_id): ...
     def explain_impact(self, repository_state, changed_symbol_ids): ...
     def watch_repository(self, repo_path, callback, *, debounce_ms): ...
-    def compile_semantic_capsule(self, repository_state, symbol_id): ...
-    def read_source_blob(self, repository_state, path, *, expected_source_cid): ...
-    def read_source_span(self, repository_state, symbol_id): ...
+    def build_semantic_state(self, semantic_index, *, environment_bindings=(), previous_bundle=None): ...
+    def verify_semantic_state_bundle(self, bundle): ...
+    def open_semantic_state(self, root_cid, get_block) -> SemanticStateView: ...
+    def compile_semantic_capsule(self, semantic_index, symbol_id, *, relevant_bindings): ...
+    def assess_capsule_freshness(self, capsule, *, current_state, invalidation=None): ...
+    def read_required_source(self, semantic_index, symbol_id, *, expected_producer_state_cid): ...
+    def extend_semantic_invalidation(
+        self, previous_index, current_index, delta, plan, previous_state, current_state
+    ): ...
+    def select_tests_and_proofs(
+        self,
+        previous_state: SemanticStateView | None,
+        current_state: SemanticStateView,
+        invalidation,
+        *,
+        policy,
+        explicit_rules=(),
+    ): ...
+    def compare_test_selection_oracle(
+        self, selection, *, baseline_full, selected_run, candidate_full, authored_oracle=None
+    ): ...
 ```
 
-The adapter validates returned state/Merkle/capsule/version CIDs and closed confidence
-values (`exact`, `conservative`, `heuristic`, `opaque`). It does not reach into
-the semantic-index implementation to recover facts absent from its public
-records. Missing capabilities produce `UnavailableResult`, never empty/exact
-state. Git/tree or deterministic filesystem snapshots remain authoritative;
-watch notifications never become mutations or state. Source retrieval reads the
-exact scanned Git tree/blob and verifies the expected source CID. Reading the
-current filesystem after a scan is forbidden; a source race produces typed
-staleness and a rescan request.
+The adapter validates returned state/Merkle/capsule/version/selection CIDs and
+closed confidence values (`exact`, `conservative`, `heuristic`, `opaque`).
+`open_semantic_state` receives only an injected `get_block(cid) -> bytes`
+function and yields a verified, read-only, storage-neutral `SemanticStateView`;
+no put, CAS, WAL, provider, or network behavior enters the datasets package.
+Selection always supplies the previous view (when one exists), current view,
+and producer invalidation so deletion and rename evidence is not discarded.
+The adapter does not reach into the semantic-index implementation to recover
+facts absent from its public records. Missing capabilities produce
+`UnavailableResult`, never empty/exact state. Git/tree or deterministic
+filesystem snapshots remain authoritative; watch notifications never become
+mutations or state. Source retrieval reads the exact scanned Git tree/blob and
+verifies the expected source CID. Reading the current filesystem after a scan
+is forbidden; a source race produces typed staleness and a rescan request.
 
 The harness consumes the scanner's modules, imports, symbols, signatures,
 annotations, decorators, exceptions, state reads/writes, calls, inheritance,
@@ -311,29 +340,33 @@ implements these explicit rules:
 The output is always a sorted obligation set. No task automatically rewrites an
 arbitrary caller, adapter, or schema consumer.
 
-## 10. Test and proof selection
+## 10. Datasets-owned test/proof selection and execution projection
 
-`test_selection.py` seeds selection with changed/deleted/renamed symbols and
-explicit user rules, then follows bounded typed edges for:
+Test/proof selection remains datasets semantic authority. Through SCH-002 the
+harness calls the sealed `select_tests_and_proofs(previous_state,
+current_state, invalidation, *, policy, explicit_rules=())`, stores the returned
+datasets `TestSelection`, and carries only a `TestSelectionRef` in harness wire
+records. The previous/current root bindings are mandatory so deleted and
+renamed-symbol evidence cannot be lost.
 
-- direct `tested_by` relations;
-- imports and statically resolved caller/callee dependencies;
-- fixture and `usefixtures` dependencies;
-- schema/serialization and configuration dependencies;
-- generated-file and proof-obligation bindings.
-
-Each selected pytest node carries an auditable shortest reason path. Ambiguous
-or unresolved edges are visible. The selector supports an unconditional
-full-suite fallback and an assurance policy that requires it for opaque changes,
-unknown config/plugin effects, global dependency changes, or insufficient
-coverage.
+`selection_execution.py` verifies and dereferences that selection, then maps
+its already-selected pytest node IDs and proof IDs to bounded
+`ValidationScheduler.run_staged` and `ProofScheduler` commands. It also enforces
+the producer's `none`/`full_pytest`/`full_proofs`/`both` fallback directive and
+explicit harness assurance policy. It never traverses semantic edges, chooses a
+second affected set, calls `run_impact_selected`, imports/collects target tests,
+guesses node IDs, or weakens a producer fallback. The producer-owned reason
+paths, ambiguity, unresolved obligations, universe, and coverage facts remain
+available through the referenced selection rather than being copied into a
+competing harness contract.
 
 `compare-full-suite` runs selected tests and then the same fixture's full suite
-as an oracle. A false negative is any full-suite failure attributable to the
-mutation that was absent from the selected run. The controlled fixture release
-gate requires zero false negatives and reports precision, recall, fallback rate,
-and selected/full test counts without redefining an unaffected passing test as a
-true positive.
+as an oracle, then supplies normalized run facts and the referenced producer
+selection to datasets `compare_test_selection_oracle`. A false negative is any
+full-suite failure attributable to the mutation that was absent from the
+selected run. The controlled fixture release gate requires zero false negatives
+and reports precision, recall, fallback rate, and selected/full test counts
+without redefining an unaffected passing test as a true positive.
 
 Proof execution is optional and capability-probed. An unavailable prover yields
 a typed unavailable obligation/receipt; it is never reported as a passed proof.

--- a/docs/architecture/semantic_compression_harness.objectives.md
+++ b/docs/architecture/semantic_compression_harness.objectives.md
@@ -6,9 +6,10 @@ The executable projection is
 `## SCH-`. The reviewed design is
 `docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md`.
 
-Implementation is launch-gated: `SCH-000` must pin and validate the final
-`ipfs_datasets_py` semantic-index and `ipfs_kit_py` durable-root commits before
-any other task is eligible.
+Implementation is launch-gated: `SCH-000` must pin and validate the unresolved
+final repaired `ipfs_datasets_py` semantic-state/Merkle/capsule and
+`ipfs_kit_py` generation-bearing durable-root commits before any other task is
+eligible.
 
 ## Goal tree
 
@@ -33,11 +34,11 @@ SCH-G000  Complete local Python semantic-compression loop
 - Goal: Deliver a Python 3.12 and pytest local coding-agent loop that consumes deterministic symbol state, compresses unchanged dependencies without hiding uncertainty, verifies an isolated patch, emits content-addressed receipts, and atomically advances the semantic-state root.
 - Evidence: sch/contract-pins@1, sch/context-pack@1, sch/patch-loop@1, sch/acceptance@1, sch/benchmark@1
 - Acceptance criteria: sch/contract-pins@1; sch/context-pack@1; sch/patch-loop@1; sch/acceptance@1; sch/benchmark@1
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state, tests/agent_supervisor/semantic_state, benchmarks/semantic_state, docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state
-- Acceptance: The controlled Python repository runs end to end with deterministic roots, bounded invalidation, assurance-aware context, selected/full test evidence, strict production provider gates, durable receipts, and expected-old root CAS; no UI, server, agent framework, or broad portfolio refactor is introduced.
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state, test/api/semantic_state, benchmarks/semantic_state, docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md
+- Validation: python3.12 -m pytest -q test/api/semantic_state
+- Acceptance: The controlled Python repository runs end to end with a datasets-owned symbol Merkle DAG, deterministic root manifests, bounded invalidation, existing-compiler assurance-aware context, selected/full test evidence, strict production provider gates, durable receipts, and generation-bearing expected-old root CAS; no UI, server, agent framework, or broad portfolio refactor is introduced.
 - Gap task: SCH-000 through SCH-018
-- Refinement: Compose the final semantic-index contracts and existing accelerate/kit authorities through narrow ports.
+- Refinement: Compose the final datasets semantic-state contracts and existing accelerate/kit authorities through narrow ports.
 
 ## SCH-G010 Pin MCP++ and repository adapters
 
@@ -52,8 +53,8 @@ SCH-G000  Complete local Python semantic-compression loop
 - Evidence: sch/dependency-seal@1, sch/mcplusplus-wire@1, sch/datasets-adapter@1, sch/kit-adapter@1
 - Acceptance criteria: sch/dependency-seal@1; sch/mcplusplus-wire@1; sch/datasets-adapter@1; sch/kit-adapter@1
 - Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_wire.py tests/agent_supervisor/semantic_state/test_datasets_adapter.py tests/agent_supervisor/semantic_state/test_durable_state.py
-- Acceptance: Accelerate and MCP++ commits plus final datasets/kit commits are exact and tested; real CIDv1 wire artifacts conform; missing or mismatched optional capabilities fail closed with typed unavailability; local durability is hermetic and single-writer CAS safe.
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_wire.py test/api/semantic_state/test_datasets_adapter.py test/api/semantic_state/test_durable_state.py
+- Acceptance: Accelerate and MCP++ commits plus final repaired datasets/kit commits are exact and validated by fingerprints and producer tests; real CIDv1 wire artifacts conform; the datasets Merkle/capsule/source APIs remain authoritative; missing or mismatched capabilities fail closed; local durability is hermetic, ABA-safe, and single-writer CAS safe.
 - Gap task: SCH-000, SCH-001, SCH-002, SCH-003
 - Refinement: Preserve semantic-index CIDs, use MCP++ canonical bytes plus real Kubo-compatible CIDv1 for harness artifacts, and lazily import the pinned kit seam.
 
@@ -66,14 +67,14 @@ SCH-G000  Complete local Python semantic-compression loop
 - Priority: P0
 - Track: execution
 - Bundle: sch/execution
-- Goal: Compile confidence-preserving capsules, select sufficient tests/proofs, pack minimum-sufficient context, route work by assurance, and execute through existing resource/provider/lease mechanisms.
+- Goal: Admit datasets-owned confidence-preserving capsules, select sufficient tests/proofs, pack minimum-sufficient context through the existing ContextCompiler/ProductionContextSlice, route work by assurance, and execute through existing resource/provider/lease mechanisms.
 - Evidence: sch/scheduling-contracts@1, sch/scheduling-adapter@1, sch/context-pack@1, sch/model-routing@1, sch/verification-runner@1
 - Acceptance criteria: sch/scheduling-contracts@1; sch/scheduling-adapter@1; sch/context-pack@1; sch/model-routing@1; sch/verification-runner@1
 - Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling.py tests/agent_supervisor/semantic_state/test_context_pack.py tests/agent_supervisor/semantic_state/test_routing.py tests/agent_supervisor/semantic_state/test_verification.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_scheduling.py test/api/semantic_state/test_context_pack.py test/api/semantic_state/test_routing.py test/api/semantic_state/test_verification.py
 - Acceptance: Exact/conservative capsules substitute only when valid, heuristic/opaque/stale facts retrieve raw source, selected tests have auditable paths and full-suite fallback, unavailable providers/provers are typed, and simulation never becomes production evidence.
 - Gap task: SCH-004, SCH-005, SCH-006, SCH-007, SCH-008
-- Refinement: Reuse ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, validation commands, and event log; do not make PersistentTaskQueue authoritative.
+- Refinement: Reuse ContextCompiler, ProductionContextSlice, ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, ValidationScheduler.run_staged, ProofScheduler, and event log; do not make PersistentTaskQueue authoritative.
 
 ## SCH-G030 Isolated patch acceptance, receipts, and root commit
 
@@ -88,8 +89,8 @@ SCH-G000  Complete local Python semantic-compression loop
 - Evidence: sch/worktree@1, sch/receipt@1, sch/freshness@1, sch/harness-loop@1
 - Acceptance criteria: sch/worktree@1; sch/receipt@1; sch/freshness@1; sch/harness-loop@1
 - Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_worktree.py tests/agent_supervisor/semantic_state/test_receipts.py tests/agent_supervisor/semantic_state/test_harness.py
-- Acceptance: The 14-step workflow rejects malformed/out-of-scope patches and stale/simulated evidence; static, selected-test, prover, and optional oracle outcomes are bound to exact inputs; rejected attempts never move the root; accepted attempts win expected-old CAS exactly once.
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_worktree.py test/api/semantic_state/test_receipts.py test/api/semantic_state/test_harness.py
+- Acceptance: The 14-step workflow reuses strict proposal/preimage validation, rejects malformed/out-of-scope patches and stale/simulated evidence, stores a complete SemanticStateRootManifest, binds static/test/prover/oracle results to exact inputs, leaves rejected candidates unreachable from the current root, and wins generation-bearing CAS exactly once.
 - Gap task: SCH-009, SCH-010, SCH-011
 - Refinement: Emit obligations and receipts, not arbitrary dependent-code rewrites or proof claims from unavailable tools.
 
@@ -105,8 +106,8 @@ SCH-G000  Complete local Python semantic-compression loop
 - Goal: Make the local loop operable through a narrow CLI and restartable watcher/session coordinator, then prove all required controlled mutations and safety failures end to end.
 - Evidence: sch/session@1, sch/cli@1, sch/fixture@1, sch/e2e@1
 - Acceptance criteria: sch/session@1; sch/cli@1; sch/fixture@1; sch/e2e@1
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_acceptance.py, pyproject.toml, setup.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_session.py tests/agent_supervisor/semantic_state/test_cli.py tests/agent_supervisor/semantic_state/test_acceptance.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, test/fixtures/semantic_state_harness/controlled_repo, test/api/semantic_state/test_acceptance.py, pyproject.toml, setup.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_session.py test/api/semantic_state/test_cli.py test/api/semantic_state/test_acceptance.py
 - Acceptance: All requested CLI capabilities return deterministic JSON; notifications trigger canonical rescans; restart/replay and concurrent watchers are fenced; the full fixture matrix proves bounded invalidation, raw fallback, receipt freshness, CAS safety, no selection false negatives, and strict simulation rejection.
 - Gap task: SCH-012, SCH-013, SCH-014, SCH-015
 - Refinement: A dedicated local console command is sufficient; no network service, dashboard, MCP server, or target-code import.
@@ -124,7 +125,7 @@ SCH-G000  Complete local Python semantic-compression loop
 - Evidence: sch/benchmark-corpus@1, sch/benchmark-results@1, sch/release-docs@1, sch/import-safety@1
 - Acceptance criteria: sch/benchmark-corpus@1; sch/benchmark-results@1; sch/release-docs@1; sch/import-safety@1
 - Outputs: benchmarks/semantic_state/tasks, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state && python benchmarks/semantic_state/run_benchmark.py --check
-- Acceptance: Exactly 40 tasks report all required context/invalidation/test/proof/route/outcome fields; median reduction is at least 30 percent without omitting required raw code; controlled recall is 100 percent; stale/simulated evidence admission is zero; import and provider regressions pass; the final report is traceable to committed receipts.
+- Validation: python3.12 -m pytest -q test/api/semantic_state && python3.12 benchmarks/semantic_state/run_benchmark.py --check
+- Acceptance: Exactly 40 tasks report all required context/invalidation/test/proof/route/outcome fields; replay/oracle candidates are production-ineligible and separated from production acceptance; deterministic fields reproduce while timing remains observational; median reduction is at least 30 percent without omitting required raw code; controlled recall is 100 percent; stale/simulated evidence admission is zero; import and provider regressions pass; the final report is traceable to committed receipts.
 - Gap task: SCH-016, SCH-017, SCH-018
 - Refinement: Keep failed and escalated tasks in metrics and state Python unsoundness honestly; do not optimize the benchmark by weakening coverage.

--- a/docs/architecture/semantic_compression_harness.objectives.md
+++ b/docs/architecture/semantic_compression_harness.objectives.md
@@ -6,10 +6,11 @@ The executable projection is
 `## SCH-`. The reviewed design is
 `docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md`.
 
-Implementation is launch-gated: `SCH-000` must pin and validate the unresolved
-final repaired `ipfs_datasets_py` semantic-state/Merkle/capsule and
-`ipfs_kit_py` generation-bearing durable-root commits before any other task is
-eligible.
+Implementation is launch-gated: `SCH-000` must pin and validate the two
+unresolved final repaired `ipfs_datasets_py` incremental-index and
+semantic-state/Merkle/capsule commits, and validate the already-pinned
+`ipfs_kit_py` generation-bearing durable-root commit
+`05ba9375923cd5fb52e2c9c18b98b530d57d077f`, before any other task is eligible.
 
 ## Goal tree
 
@@ -67,14 +68,14 @@ SCH-G000  Complete local Python semantic-compression loop
 - Priority: P0
 - Track: execution
 - Bundle: sch/execution
-- Goal: Admit datasets-owned confidence-preserving capsules, select sufficient tests/proofs, pack minimum-sufficient context through the existing ContextCompiler/ProductionContextSlice, route work by assurance, and execute through existing resource/provider/lease mechanisms.
+- Goal: Admit datasets-owned confidence-preserving capsules and datasets-owned test/proof selections, pack minimum-sufficient context through the existing ContextCompiler/ProductionContextSlice, route work by assurance, and project the sealed selection into existing validation/proof execution mechanisms.
 - Evidence: sch/scheduling-contracts@1, sch/scheduling-adapter@1, sch/context-pack@1, sch/model-routing@1, sch/verification-runner@1
 - Acceptance criteria: sch/scheduling-contracts@1; sch/scheduling-adapter@1; sch/context-pack@1; sch/model-routing@1; sch/verification-runner@1
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/selection_execution.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py
 - Validation: python3.12 -m pytest -q test/api/semantic_state/test_scheduling.py test/api/semantic_state/test_context_pack.py test/api/semantic_state/test_routing.py test/api/semantic_state/test_verification.py
-- Acceptance: Exact/conservative capsules substitute only when valid, heuristic/opaque/stale facts retrieve raw source, selected tests have auditable paths and full-suite fallback, unavailable providers/provers are typed, and simulation never becomes production evidence.
+- Acceptance: Exact/conservative capsules substitute only when valid, heuristic/opaque/stale facts retrieve raw source, the datasets selection retains auditable paths and full-suite fallback while accelerate performs no graph reselection, unavailable providers/provers are typed, and simulation never becomes production evidence.
 - Gap task: SCH-004, SCH-005, SCH-006, SCH-007, SCH-008
-- Refinement: Reuse ContextCompiler, ProductionContextSlice, ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, ValidationScheduler.run_staged, ProofScheduler, and event log; do not make PersistentTaskQueue authoritative.
+- Refinement: Reuse storage-neutral datasets `SemanticStateView`/`open_semantic_state`, previous/current datasets selection, ContextCompiler, ProductionContextSlice, ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, ValidationScheduler.run_staged, ProofScheduler, and event log; do not make PersistentTaskQueue authoritative or add a second selector.
 
 ## SCH-G030 Isolated patch acceptance, receipts, and root commit
 

--- a/docs/architecture/semantic_compression_harness.objectives.md
+++ b/docs/architecture/semantic_compression_harness.objectives.md
@@ -1,0 +1,130 @@
+# Semantic compression harness objective heap
+
+Machine-ingestible goal hierarchy for `ipfs_accelerate_py.agent_supervisor`.
+The executable projection is
+`docs/architecture/semantic_compression_harness.todo.md` with task prefix
+`## SCH-`. The reviewed design is
+`docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md`.
+
+Implementation is launch-gated: `SCH-000` must pin and validate the final
+`ipfs_datasets_py` semantic-index and `ipfs_kit_py` durable-root commits before
+any other task is eligible.
+
+## Goal tree
+
+```text
+SCH-G000  Complete local Python semantic-compression loop
+|-- SCH-G010  Pin MCP++ and repository adapters
+|-- SCH-G020  Scheduling, routing, context, and execution
+|-- SCH-G030  Isolated patch acceptance, receipts, and root commit
+|-- SCH-G040  CLI, incremental sessions, and end-to-end acceptance
+`-- SCH-G050  Exactly-40-task benchmark and release evidence
+```
+
+## SCH-G000 Complete local Python semantic-compression loop
+
+- Status: active
+- Parent:
+- Depends on:
+- Fib priority: 1
+- Priority: P0
+- Track: semantic-state-harness
+- Bundle: sch/root
+- Goal: Deliver a Python 3.12 and pytest local coding-agent loop that consumes deterministic symbol state, compresses unchanged dependencies without hiding uncertainty, verifies an isolated patch, emits content-addressed receipts, and atomically advances the semantic-state root.
+- Evidence: sch/contract-pins@1, sch/context-pack@1, sch/patch-loop@1, sch/acceptance@1, sch/benchmark@1
+- Acceptance criteria: sch/contract-pins@1; sch/context-pack@1; sch/patch-loop@1; sch/acceptance@1; sch/benchmark@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state, tests/agent_supervisor/semantic_state, benchmarks/semantic_state, docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state
+- Acceptance: The controlled Python repository runs end to end with deterministic roots, bounded invalidation, assurance-aware context, selected/full test evidence, strict production provider gates, durable receipts, and expected-old root CAS; no UI, server, agent framework, or broad portfolio refactor is introduced.
+- Gap task: SCH-000 through SCH-018
+- Refinement: Compose the final semantic-index contracts and existing accelerate/kit authorities through narrow ports.
+
+## SCH-G010 Pin MCP++ and repository adapters
+
+- Status: active
+- Parent: SCH-G000
+- Depends on:
+- Fib priority: 2
+- Priority: P0
+- Track: contracts
+- Bundle: sch/contracts
+- Goal: Seal exact dependency commits and expose closed MCP++, semantic-state, and durable-state boundaries without creating competing identity, graph, or storage authorities.
+- Evidence: sch/dependency-seal@1, sch/mcplusplus-wire@1, sch/datasets-adapter@1, sch/kit-adapter@1
+- Acceptance criteria: sch/dependency-seal@1; sch/mcplusplus-wire@1; sch/datasets-adapter@1; sch/kit-adapter@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_wire.py tests/agent_supervisor/semantic_state/test_datasets_adapter.py tests/agent_supervisor/semantic_state/test_durable_state.py
+- Acceptance: Accelerate and MCP++ commits plus final datasets/kit commits are exact and tested; real CIDv1 wire artifacts conform; missing or mismatched optional capabilities fail closed with typed unavailability; local durability is hermetic and single-writer CAS safe.
+- Gap task: SCH-000, SCH-001, SCH-002, SCH-003
+- Refinement: Preserve semantic-index CIDs, use MCP++ canonical bytes plus real Kubo-compatible CIDv1 for harness artifacts, and lazily import the pinned kit seam.
+
+## SCH-G020 Scheduling, routing, context, and execution
+
+- Status: active
+- Parent: SCH-G000
+- Depends on: SCH-G010
+- Fib priority: 3
+- Priority: P0
+- Track: execution
+- Bundle: sch/execution
+- Goal: Compile confidence-preserving capsules, select sufficient tests/proofs, pack minimum-sufficient context, route work by assurance, and execute through existing resource/provider/lease mechanisms.
+- Evidence: sch/scheduling-contracts@1, sch/scheduling-adapter@1, sch/context-pack@1, sch/model-routing@1, sch/verification-runner@1
+- Acceptance criteria: sch/scheduling-contracts@1; sch/scheduling-adapter@1; sch/context-pack@1; sch/model-routing@1; sch/verification-runner@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling.py tests/agent_supervisor/semantic_state/test_context_pack.py tests/agent_supervisor/semantic_state/test_routing.py tests/agent_supervisor/semantic_state/test_verification.py
+- Acceptance: Exact/conservative capsules substitute only when valid, heuristic/opaque/stale facts retrieve raw source, selected tests have auditable paths and full-suite fallback, unavailable providers/provers are typed, and simulation never becomes production evidence.
+- Gap task: SCH-004, SCH-005, SCH-006, SCH-007, SCH-008
+- Refinement: Reuse ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, validation commands, and event log; do not make PersistentTaskQueue authoritative.
+
+## SCH-G030 Isolated patch acceptance, receipts, and root commit
+
+- Status: active
+- Parent: SCH-G000
+- Depends on: SCH-G010, SCH-G020
+- Fib priority: 5
+- Priority: P0
+- Track: patch-acceptance
+- Bundle: sch/patch-acceptance
+- Goal: Apply only an admitted patch in a fenced disposable worktree, rescan and verify it, issue freshness-bound MCP++ receipts, and publish the next state root only after every gate succeeds.
+- Evidence: sch/worktree@1, sch/receipt@1, sch/freshness@1, sch/harness-loop@1
+- Acceptance criteria: sch/worktree@1; sch/receipt@1; sch/freshness@1; sch/harness-loop@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_worktree.py tests/agent_supervisor/semantic_state/test_receipts.py tests/agent_supervisor/semantic_state/test_harness.py
+- Acceptance: The 14-step workflow rejects malformed/out-of-scope patches and stale/simulated evidence; static, selected-test, prover, and optional oracle outcomes are bound to exact inputs; rejected attempts never move the root; accepted attempts win expected-old CAS exactly once.
+- Gap task: SCH-009, SCH-010, SCH-011
+- Refinement: Emit obligations and receipts, not arbitrary dependent-code rewrites or proof claims from unavailable tools.
+
+## SCH-G040 CLI, incremental sessions, and end-to-end acceptance
+
+- Status: active
+- Parent: SCH-G000
+- Depends on: SCH-G030
+- Fib priority: 8
+- Priority: P0
+- Track: acceptance
+- Bundle: sch/acceptance
+- Goal: Make the local loop operable through a narrow CLI and restartable watcher/session coordinator, then prove all required controlled mutations and safety failures end to end.
+- Evidence: sch/session@1, sch/cli@1, sch/fixture@1, sch/e2e@1
+- Acceptance criteria: sch/session@1; sch/cli@1; sch/fixture@1; sch/e2e@1
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_acceptance.py, pyproject.toml, setup.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_session.py tests/agent_supervisor/semantic_state/test_cli.py tests/agent_supervisor/semantic_state/test_acceptance.py
+- Acceptance: All requested CLI capabilities return deterministic JSON; notifications trigger canonical rescans; restart/replay and concurrent watchers are fenced; the full fixture matrix proves bounded invalidation, raw fallback, receipt freshness, CAS safety, no selection false negatives, and strict simulation rejection.
+- Gap task: SCH-012, SCH-013, SCH-014, SCH-015
+- Refinement: A dedicated local console command is sufficient; no network service, dashboard, MCP server, or target-code import.
+
+## SCH-G050 Exactly-40-task benchmark and release evidence
+
+- Status: active
+- Parent: SCH-G000
+- Depends on: SCH-G040
+- Fib priority: 13
+- Priority: P0
+- Track: release
+- Bundle: sch/release
+- Goal: Measure an honest exactly-40-task Python maintenance corpus and publish reproducible release evidence, limitations, bottlenecks, and the remaining production/ZK work.
+- Evidence: sch/benchmark-corpus@1, sch/benchmark-results@1, sch/release-docs@1, sch/import-safety@1
+- Acceptance criteria: sch/benchmark-corpus@1; sch/benchmark-results@1; sch/release-docs@1; sch/import-safety@1
+- Outputs: benchmarks/semantic_state/tasks, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state && python benchmarks/semantic_state/run_benchmark.py --check
+- Acceptance: Exactly 40 tasks report all required context/invalidation/test/proof/route/outcome fields; median reduction is at least 30 percent without omitting required raw code; controlled recall is 100 percent; stale/simulated evidence admission is zero; import and provider regressions pass; the final report is traceable to committed receipts.
+- Gap task: SCH-016, SCH-017, SCH-018
+- Refinement: Keep failed and escalated tasks in metrics and state Python unsoundness honestly; do not optimize the benchmark by weakening coverage.

--- a/docs/architecture/semantic_compression_harness.todo.md
+++ b/docs/architecture/semantic_compression_harness.todo.md
@@ -10,20 +10,25 @@ Protected companion artifacts:
 
 These control documents are reviewed inputs and may be changed only by the
 operator while sealing `SCH-000`; implementation workers must not edit them.
-`SCH-000` is deliberately open. Do not launch implementation lanes until it
-contains exact final `ipfs_datasets_py` and `ipfs_kit_py` commit pins and is
-manually marked complete.
+`SCH-000` is deliberately open. Do not launch implementation lanes until the
+explicit unresolved placeholders have been replaced by exact final repaired
+`ipfs_datasets_py` semantic-state/Merkle/capsule and `ipfs_kit_py` durable-root
+commit pins, the deterministic seal validator passes, and the task is manually
+marked complete.
 
 Implementation is focused in
 `ipfs_accelerate_py.agent_supervisor.semantic_state`. Workers consume the pinned
-semantic-index contracts rather than recreating scanner/graph/invalidation
-authority. They must reuse MCP++ Profile A/B/F wire rules, lazy
+datasets semantic-state contracts rather than recreating scanner/graph/Merkle/
+capsule/invalidation authority. They must reuse MCP++ Profile A/B/F wire rules, lazy
 `DurableCoordinationStore` plus the pinned generic root-CAS port,
 `ResourceScheduler`, `ProviderExecutionGateway`, `WorktreeLifecycleStore`,
 `LeaseCoordinator`, validation command contracts, and `runtime.event_log`.
-They must not use `PersistentTaskQueue` as authority, the legacy mock hardware
-or inference coordinator, `compute_artifact_cid` for new artifacts, or a silent
-simulation fallback in production.
+They must also reuse `ContextCompiler`, `ProductionContextSlice`, strict
+proposal validation, `ValidationScheduler.run_staged`, `ProofScheduler`, and
+the shared managed-worktree lifecycle. They must not use `PersistentTaskQueue`
+as authority, the legacy mock hardware or inference coordinator,
+`compute_artifact_cid` for new artifacts, `run_impact_selected` as a second
+test selector, or a silent simulation/fallback path in production.
 
 ## Parallel waves
 
@@ -31,12 +36,12 @@ simulation fallback in production.
 A0  SCH-000
 A1  SCH-001 | SCH-002 | SCH-003 | SCH-014
 A2  SCH-004 | SCH-006 | SCH-016
-A3  SCH-005 | SCH-007 | SCH-010
-A4  SCH-008
+A3  SCH-005
+A4  SCH-007 | SCH-008 | SCH-010
 A5  SCH-009
 A6  SCH-011
-A7  SCH-012
-A8  SCH-013 | SCH-015 | SCH-017
+A7  SCH-012 | SCH-017
+A8  SCH-013 | SCH-015
 A9  SCH-018
 ```
 
@@ -48,8 +53,8 @@ A9  SCH-018
 - Track: control
 - Depends on:
 - Goal id: SCH-G010
-- Outputs: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json
-- Validation: git rev-parse HEAD
+- Outputs: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json, scripts/validate_semantic_state_dependencies.py, test/api/semantic_state/test_dependency_seal.py
+- Validation: python3.12 scripts/validate_semantic_state_dependencies.py --check config/semantic_state_dependencies.seal.json && python3.12 -m pytest -q test/api/semantic_state/test_dependency_seal.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/control
 - Parallel lane: sch-control
@@ -59,13 +64,13 @@ A9  SCH-018
 - Context budget tokens: 0
 - LLM context budget bytes: 0
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1 through 3
-- Predicted files: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json
+- Predicted files: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json, scripts/validate_semantic_state_dependencies.py, test/api/semantic_state/test_dependency_seal.py
 - Predicted symbols: SemanticStateDependencySeal
 - Interfaces: SemanticStateDependencySeal@1
 - Conflict policy: Operator-only launch gate. No implementation worker may infer, update, merge, or bypass dependency pins or edit the protected control files.
-- Preconditions: Accelerate baseline is `ea11293bb996f052d620eae989f5377a956764b1`; MCP++ authority is `dc3164653a48d059ae9812078359daeafb451c07`; final datasets semantic-index and kit durable-root commits have been supplied by their closeouts.
-- Effects: Replaces both `UNRESOLVED` values with exact reachable 40-hex commits, records repository origins/schema versions/test commands, runs producer contract tests, and seals their outputs for every downstream worker.
-- Acceptance: Seal rejects unresolved, mutable, unreachable, dirty, schema-incompatible, or failing dependencies; datasets exposes the required scan/diff/invalidate/explain/watch state contracts; kit exposes direct lazy `DurableCoordinationStore` plus generic read-root/expected-old-CAS/recover; the board remains acyclic and only then is SCH-000 marked complete.
+- Preconditions: Accelerate baseline is `ea11293bb996f052d620eae989f5377a956764b1`; MCP++ authority is `dc3164653a48d059ae9812078359daeafb451c07`; the exact final repaired datasets semantic-state/Merkle/capsule commit and final repaired kit generation-bearing durable-root commit have been supplied by their closeouts. Until then `IPFS_DATASETS_SEMANTIC_STATE_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` and `IPFS_KIT_DURABLE_ROOT_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` remain fail-closed.
+- Effects: Replaces both unresolved placeholders with exact reachable 40-hex commits; records all four repository origins/commits, interface and schema fingerprints, Python 3.12/toolchain, and producer test commands; rejects ambient editable/PYTHONPATH substitution; runs real producer contract tests and seals their outputs for every downstream worker.
+- Acceptance: The validator rejects unresolved, mutable, unreachable, dirty, origin-mismatched, fingerprint-incompatible, non-Python-3.12, or failing dependencies. Datasets proves real Git-tree scan -> resolved graph -> symbol-node Merkle DAG -> delta -> invalidation and exposes capsule plus tree-bound source-blob/span retrieval without injected edges. Kit exposes direct lazy `DurableCoordinationStore` plus generation-bearing read-root/expected-token-CAS/recover. The board is acyclic and only then is SCH-000 marked complete.
 
 ## SCH-001 Implement MCP++ wire codec and interface descriptor
 
@@ -75,8 +80,8 @@ A9  SCH-018
 - Track: wire-contracts
 - Depends on: SCH-000
 - Goal id: SCH-G010
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, tests/agent_supervisor/semantic_state/test_wire.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_wire.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, test/api/semantic_state/test_wire.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_wire.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/wire-contracts
 - Parallel lane: sch-wire
@@ -86,13 +91,13 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3, 6, and 13
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, tests/agent_supervisor/semantic_state/test_wire.py
-- Predicted symbols: Availability, UnavailableResult, HarnessMode, WorkKind, SemanticCapsule, ContextPack, ModelRoute, PatchProposal, TestSelection, VerificationReceipt, HarnessResult, SemanticStateWireCodec, semantic_state_interface_descriptor
-- Interfaces: SemanticStateHarnessContracts@1, SemanticStateMcpWire@1
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, test/api/semantic_state/test_wire.py
+- Predicted symbols: Availability, UnavailableResult, HarnessMode, WorkKind, SemanticCapsuleRef, ContextPack, ModelRoute, PatchProposal, TestSelection, VerificationReceipt, HarnessResult, RootRef, SemanticStateRootManifest, SemanticStateWireCodec, semantic_state_interface_descriptor
+- Interfaces: SemanticStateHarnessContracts@1, SemanticStateRootManifest@1, SemanticStateMcpWire@1
 - Conflict policy: MCP++ Profile A/B/F at the sealed commit is wire authority. Use `canonicalize_artifact` plus `kubo_cid.cid_for_bytes`; never use `compute_artifact_cid` pseudo-CIDs, copy CID code, mutate MCP server transport, or recompute datasets identities.
 - Preconditions: SCH-000 sealed exact commits and MCP++ conformance inputs.
-- Effects: Defines closed deterministic harness records, a Profile A descriptor, Profile B request/result envelopes, Profile F event nodes, strict decoding, bounded errors, and Kubo-compatible CIDv1 vectors.
-- Acceptance: Equivalent payloads have identical canonical bytes and real CIDv1; unknown fields/enums or forged CIDs fail closed; semantic-state CIDs remain opaque verified references; descriptor/interface changes have detectable CIDs; ordinary imports perform no I/O.
+- Effects: Defines closed deterministic harness records, the accepted root-manifest and generation-bearing root-reference contracts, a Profile A descriptor, Profile B request/result envelopes, Profile F event nodes, strict decoding, bounded errors, and Kubo-compatible CIDv1 vectors. `SemanticCapsuleRef` references the sealed datasets capsule instead of duplicating semantic facts.
+- Acceptance: Equivalent payloads have identical canonical bytes and real CIDv1; unknown fields/enums or forged CIDs fail closed; semantic-state CIDs remain opaque verified references; every accepted manifest transitively names graph/capsule/delta/obligation/selection/receipt and environment bindings; operational fields cannot alter its CID; descriptor/interface changes have detectable CIDs; ordinary imports perform no I/O.
 
 ## SCH-002 Implement the pinned datasets semantic-state adapter
 
@@ -102,8 +107,8 @@ A9  SCH-018
 - Track: datasets-adapter
 - Depends on: SCH-000
 - Goal id: SCH-G010
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, tests/agent_supervisor/semantic_state/test_datasets_adapter.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_datasets_adapter.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, test/api/semantic_state/test_datasets_adapter.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_datasets_adapter.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/datasets-adapter
 - Parallel lane: sch-datasets
@@ -113,13 +118,13 @@ A9  SCH-018
 - Context budget tokens: 34000
 - LLM context budget bytes: 278528
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1, 3, 7, and 9
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, tests/agent_supervisor/semantic_state/test_datasets_adapter.py
-- Predicted symbols: SemanticStateProvider, IpfsDatasetsSemanticStateProvider, SemanticStateCapability, SemanticStateUnavailable, load_semantic_state_provider
-- Interfaces: SemanticStateProvider@1, IncrementalSemanticIndexModels@1
-- Conflict policy: Lazy-load only the sealed public semantic-index surface. Do not parse target AST, reconstruct symbol IDs/edges/deltas, import target repositories, claim complete Python semantics, or accept an ambient incompatible package.
-- Preconditions: Sealed datasets commit passes its semantic-index tests and exposes scan_repository, diff_repository_states, calculate_invalidation, explain_symbol, explain_impact, and watch_repository.
-- Effects: Capability-checks schema/extractor versions, invokes canonical Git/tree scans, validates state/delta/invalidation CIDs and four confidence values, and converts missing capability into typed unavailability.
-- Acceptance: Clean and incremental scans round-trip without identity translation; watcher events trigger scans but never become state; mismatched commit/schema/CID fails closed; every opaque/invalid state remains visible and requires raw source.
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, test/api/semantic_state/test_datasets_adapter.py
+- Predicted symbols: SemanticStateProvider, IpfsDatasetsSemanticStateProvider, SemanticStateCapability, SemanticStateUnavailable, SourceBlobStale, load_semantic_state_provider
+- Interfaces: SemanticStateProvider@1, IncrementalSemanticIndexModels@sealed, SymbolMerkleDAG@sealed, SemanticCapsule@sealed, TreeBoundSource@sealed
+- Conflict policy: Lazy-load only the sealed public semantic-state surface. Do not parse target AST, reconstruct symbol IDs/edges/deltas/Merkle nodes/capsule facts, read post-scan filesystem bytes as authoritative, import target repositories, claim complete Python semantics, or accept an ambient incompatible package.
+- Preconditions: Sealed datasets commit passes its repaired semantic-state tests and exposes scan_repository, diff_repository_states, calculate_invalidation, explain_symbol, explain_impact, watch_repository, symbol-Merkle materialization, compile_semantic_capsule, read_source_blob, and read_source_span.
+- Effects: Capability-checks contract fingerprints and schema/extractor/capsule versions, invokes canonical Git/tree scans, validates state/Merkle/capsule/delta/invalidation CIDs and four confidence values, retrieves exact source only from the scanned tree with expected-CID verification, and converts missing/stale capability into typed unavailability.
+- Acceptance: Clean and incremental scans, Merkle nodes, and capsules round-trip without identity translation; all required scanner facts and typed relations survive the adapter; watcher events trigger scans but never become state; mismatched commit/schema/CID fails closed; a filesystem mutation after scan yields `SourceBlobStale` or a rescan rather than mixed source; every opaque/invalid state remains visible and requires raw source.
 
 ## SCH-003 Implement the narrow kit durable-root adapter
 
@@ -129,8 +134,8 @@ A9  SCH-018
 - Track: durable-state
 - Depends on: SCH-000
 - Goal id: SCH-G010
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, tests/agent_supervisor/semantic_state/test_durable_state.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_durable_state.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, test/api/semantic_state/test_durable_state.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_durable_state.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/durable-state
 - Parallel lane: sch-durable
@@ -140,13 +145,13 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3 and 13
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, tests/agent_supervisor/semantic_state/test_durable_state.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, test/api/semantic_state/test_durable_state.py
 - Predicted symbols: DurableSemanticStatePort, IpfsKitDurableStateAdapter, DurableStateUnavailable, RootConflict, open_local_durable_state
-- Interfaces: DurableSemanticStatePort@1, SemanticStateRootCAS@1
+- Interfaces: DurableSemanticStatePort@1, SemanticStateRootCAS@2
 - Conflict policy: Directly and lazily adapt the sealed `ipfs_kit_py.mcp_server.mcplusplus.coordination_storage.DurableCoordinationStore` and sealed generic root-CAS protocol. Do not duplicate local blocks/WAL, use a facade/provisional path, VerifiedIPLDBackend, Iroh/bucket CAS, or require a daemon/network.
-- Preconditions: SCH-000 pins a kit commit with `DurableCoordinationStore(storage_dir, backend=None)`, put/get/get_bytes/has/recover, and generic read_root/compare_and_swap_root behavior.
-- Effects: Exposes verified put/get/has, expected-old root CAS, replay, corruption checks, and interrupted-transition recovery behind one injected protocol; remote block transport remains optional.
-- Acceptance: Hermetic local tests use an explicit temporary storage directory and no daemon; supplied authoritative CID must match bytes; interrupted publication retains or completes one valid root; corrupted blocks fail closed; two distinct writers from one expected root yield at most one success.
+- Preconditions: SCH-000 pins a kit commit with `DurableCoordinationStore(storage_dir, backend=None)`, put/get/get_bytes/has/recover, and generic generation-bearing read_root/compare_and_swap_root behavior.
+- Effects: Exposes verified put/get/has, `RootRef(root_cid, generation)` expected-token CAS, replay, corruption checks, transitive root-manifest verification, and interrupted-transition recovery behind one injected protocol; remote block transport remains optional.
+- Acceptance: Hermetic local tests use an explicit temporary storage directory and no daemon; supplied authoritative CID must match bytes; only a stored and transitively valid SemanticStateRootManifest may be published; initial `None -> bootstrap` is explicit; interrupted publication retains or completes one valid root; corrupted blocks fail closed; two distinct writers from one expected token yield at most one success; an A-to-B-to-A sequence rejects an ABA-stale writer.
 
 ## SCH-004 Define scheduling and execution contracts
 
@@ -156,8 +161,8 @@ A9  SCH-018
 - Track: scheduling-contracts
 - Depends on: SCH-001
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, test/api/semantic_state/test_scheduling_contracts.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_scheduling_contracts.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/scheduling-contracts
 - Parallel lane: sch-scheduling-contracts
@@ -167,12 +172,12 @@ A9  SCH-018
 - Context budget tokens: 32000
 - LLM context budget bytes: 262144
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 and 12
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, test/api/semantic_state/test_scheduling_contracts.py
 - Predicted symbols: SemanticWorkRequest, SemanticWorkResult, SemanticWorkStatus, CancellationToken, LeaseBinding, ResourceBinding, ProviderBinding
 - Interfaces: SemanticWorkScheduling@1
 - Conflict policy: Define a narrow projection over existing runtime contracts; do not introduce a scheduler, queue authority, provider registry, mock coordinator, or unbounded observation payload.
 - Preconditions: Closed wire/harness records exist.
-- Effects: Specifies idempotent work identities for scan, capsule, selection, context, model, static, pytest, prover, and persistence stages plus typed cancellation/unavailability/fencing results.
+- Effects: Specifies idempotent work identities for deterministic task parsing, scan, datasets capsule/summary projection, selection, context, model, static, pytest, prover, and persistence stages plus typed cancellation/unavailability/fencing results. Optional model summaries are always heuristic work products.
 - Acceptance: Records are deterministic, bounded, secret/source-body free in scheduler observations, distinguish unavailable/cancelled/failed/simulated, and cannot interpret scheduling success as verification success.
 
 ## SCH-005 Implement the existing-supervisor scheduling adapter
@@ -183,8 +188,8 @@ A9  SCH-018
 - Track: scheduling
 - Depends on: SCH-004
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, tests/agent_supervisor/semantic_state/test_scheduling.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, test/api/semantic_state/test_scheduling.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_scheduling.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/scheduling
 - Parallel lane: sch-scheduling
@@ -194,24 +199,24 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3 and 12
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, tests/agent_supervisor/semantic_state/test_scheduling.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, test/api/semantic_state/test_scheduling.py
 - Predicted symbols: SemanticSchedulingAdapter, ScheduledAttempt, schedule_semantic_work, replay_semantic_work
 - Interfaces: SemanticSchedulingAdapter@1, ResourceScheduler@existing, ProviderExecutionGateway@existing
 - Conflict policy: Compose ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, and runtime.event_log only. `PersistentTaskQueue` is not authority. Never use legacy mock hardware/inference, bypass leases/fences, or treat a simulated provider result as available production work.
 - Preconditions: SCH-004 work contracts are closed and existing runtime modules pass focused regressions.
-- Effects: Performs resource admission, lease/fence acquisition, cancellation propagation, exact-attempt idempotency, bounded event journaling, and restart/replay for every harness work kind.
+- Effects: Performs resource admission, lease/fence acquisition, cancellation propagation, exact-attempt idempotency, bounded event journaling, and restart/replay for every harness work kind. It is the sole harness owner of `ProviderExecutionGateway` invocation and returns a fenced attempt consumed by routing/provider and worktree adapters.
 - Acceptance: Capacity/provider absence returns typed unavailable; cancellation reaches subprocess/provider boundary; replay does not reinvoke a terminal provider call; expired fences cannot publish; cold import starts no resources, threads, processes, databases, or network calls.
 
-## SCH-006 Compile capsules and assurance-aware ContextPacks
+## SCH-006 Admit capsules and compile assurance-aware ContextPacks
 
 - Status: todo
 - Completion: auto
 - Priority: P0
 - Track: context
-- Depends on: SCH-001, SCH-002
+- Depends on: SCH-001, SCH-002, SCH-003
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, tests/agent_supervisor/semantic_state/test_capsules.py, tests/agent_supervisor/semantic_state/test_context_pack.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_capsules.py tests/agent_supervisor/semantic_state/test_context_pack.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, test/api/semantic_state/test_capsules.py, test/api/semantic_state/test_context_pack.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_capsules.py test/api/semantic_state/test_context_pack.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/context
 - Parallel lane: sch-context
@@ -221,13 +226,13 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 through 11
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, tests/agent_supervisor/semantic_state/test_capsules.py, tests/agent_supervisor/semantic_state/test_context_pack.py
-- Predicted symbols: SemanticCapsuleCompiler, CapsuleCache, CapsuleAdmission, ContextPacker, ContextCoveragePolicy, ContextTokenEstimate, compile_capsule, pack_context
-- Interfaces: SemanticCapsule@1, ContextPack@1
-- Conflict policy: Compile only from authoritative semantic records and exact source retrieval. Docstrings/model summaries are hints only. Exact targets/edit context/tests are never compressed; heuristic, opaque, stale, invalid, unknown, or insufficient facts force raw source rather than truncation.
-- Preconditions: MCP++ records and the sealed datasets provider are available.
-- Effects: Builds version/config/policy/interface-bound capsules, safely reuses unchanged dependencies, chooses source versus capsule by confidence/freshness, minimizes counterexamples, accounts tokens, and explains included/excluded context and escalation.
-- Acceptance: Exact/conservative substitution rules and visible caveats pass; no LLM summary can raise confidence or satisfy proof; all required ContextPack fields are present; budget failure recommends escalation; identical inputs yield identical pack/capsule CIDs and token accounting.
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, test/api/semantic_state/test_capsules.py, test/api/semantic_state/test_context_pack.py
+- Predicted symbols: CapsuleCache, CapsuleAdmission, ContextPacker, ContextCoveragePolicy, ContextTokenEstimate, admit_capsule, pack_context
+- Interfaces: SemanticCapsule@sealed, SemanticCapsuleAdmission@1, ContextPack@1, ProductionContextSlice@1
+- Conflict policy: Admit only datasets-owned capsules and exact tree-bound source. Compose `context.context_compiler.ContextCompiler`, `context_contracts` references/tiers, and `todo_daemon.production_context_slice`; do not create a second generic context optimizer or semantic compiler. `CapsuleCache` uses `DurableSemanticStatePort`, not a new disk/DB authority. Docstrings/model summaries are hints only. Exact targets/edit context/tests are never compressed; heuristic, opaque, stale, invalid, unknown, or insufficient facts force raw source rather than truncation.
+- Preconditions: MCP++ records, the sealed datasets capsule/source provider, and durable artifact port are available.
+- Effects: Verifies and stores datasets capsules, projects raw/capsule inputs into existing `ContextReference` tiers, compiles a `ContextPack` and verified `ProductionContextSliceManifest`, chooses source versus capsule by confidence/freshness, minimizes counterexamples, accounts tokens with `ContextCompiler`, and explains included/excluded context and escalation.
+- Acceptance: Exact/conservative substitution rules and visible caveats pass; capsule facts/CIDs remain datasets authority; no LLM summary can raise confidence or satisfy proof; opaque source is retrieved from the exact scanned tree; all required ContextPack fields and production source-coverage proofs are present; budget failure recommends escalation; identical inputs yield identical pack/CID/token accounting.
 
 ## SCH-007 Implement model routing and real-provider adapters
 
@@ -235,10 +240,10 @@ A9  SCH-018
 - Completion: auto
 - Priority: P0
 - Track: model-routing
-- Depends on: SCH-001, SCH-004
+- Depends on: SCH-001, SCH-004, SCH-005
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, tests/agent_supervisor/semantic_state/test_routing.py, tests/agent_supervisor/semantic_state/test_providers.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_routing.py tests/agent_supervisor/semantic_state/test_providers.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, test/api/semantic_state/test_routing.py, test/api/semantic_state/test_providers.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_routing.py test/api/semantic_state/test_providers.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/model-routing
 - Parallel lane: sch-routing
@@ -248,13 +253,13 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 and 12
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, tests/agent_supervisor/semantic_state/test_routing.py, tests/agent_supervisor/semantic_state/test_providers.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, test/api/semantic_state/test_routing.py, test/api/semantic_state/test_providers.py
 - Predicted symbols: ModelRoutingPolicy, ModelProvider, ModelCapability, ProductionProviderGate, route_model, invoke_model
 - Interfaces: ModelRouting@1, ModelProvider@1
-- Conflict policy: Do not hardcode a provider or add mock inference. Route only on context size, confidence, risk, dependency cone, obligations, prior failures, and proof availability. Production cannot silently replay or simulate a patch.
+- Conflict policy: Do not hardcode a provider, add mock inference, or invoke a second ProviderExecutionGateway outside SCH-005. Route only on context size, confidence, risk, dependency cone, obligations, prior failures, and proof availability. Production cannot silently replay, simulate, degrade, use off mode, or use local/cross-provider fallback.
 - Preconditions: Closed wire and scheduling records exist.
-- Effects: Selects deterministic_only/small_local_model/medium_model/frontier_model/human_review_required, capability-checks injected providers, and maps absence/errors to typed unavailable results through ProviderExecutionGateway.
-- Acceptance: Route decision is deterministic and explained; high-risk/opaque/oversized/failed cases escalate; missing provider is unavailable and nonzero; simulated output is labeled development-only and is never eligible for production verification or root commit.
+- Effects: Selects deterministic_only/small_local_model/medium_model/frontier_model/human_review_required, capability-checks injected providers, supplies the invoker to SCH-005, and applies a fail-closed promotion gate to its gateway result. Any `llm_router.generate_text` call explicitly sets `allow_local_fallback=False` and `allow_cross_provider_fallback=False` and verifies the effective provider.
+- Acceptance: Route decision is deterministic and explained; `human_review_required` halts before provider dispatch/root publication; high-risk/opaque/oversized/failed cases escalate; missing provider is typed unavailable and nonzero. Production requires ENFORCE mode, AVAILABLE coordination, real coordinator and invoker, verified attribution, matching provider, and a non-simulated reservation; rejects `sim:`/`degraded:`, OFF/SIMULATED/DEGRADED, fallback reasons, and unadmitted replay; development simulation can never verify or commit.
 
 ## SCH-008 Select and execute static checks, pytest tests, and provers
 
@@ -262,10 +267,10 @@ A9  SCH-018
 - Completion: auto
 - Priority: P0
 - Track: verification
-- Depends on: SCH-004, SCH-005
+- Depends on: SCH-002, SCH-004, SCH-005
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, tests/agent_supervisor/semantic_state/test_test_selection.py, tests/agent_supervisor/semantic_state/test_verification.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_test_selection.py tests/agent_supervisor/semantic_state/test_verification.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_test_selection.py, test/api/semantic_state/test_verification.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_test_selection.py test/api/semantic_state/test_verification.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/verification
 - Parallel lane: sch-verification
@@ -275,12 +280,12 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9, 10, and 12
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, tests/agent_supervisor/semantic_state/test_test_selection.py, tests/agent_supervisor/semantic_state/test_verification.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_test_selection.py, test/api/semantic_state/test_verification.py
 - Predicted symbols: TestSelector, SelectionPolicy, VerificationRunner, StaticCheckResult, PytestResult, ProverResult, FullSuiteComparison, select_tests, compare_full_suite
 - Interfaces: TestSelection@1, SemanticVerification@1
-- Conflict policy: Reuse validation command parsing/classification and execute bounded explicit commands only inside the fenced worktree. Do not import targets for collection, guess dynamic pytest/plugin behavior as exact, report unavailable provers as passing, or disable full-suite fallback.
+- Conflict policy: Reuse `validation_commands`, `validation_runtime`, `ValidationScheduler.run_staged`/`schedule_staged_validations`, `ProofScheduler`, formal capability records, and existing test-execution receipts. The semantic selector is authority: do not call `run_impact_selected`, add a subprocess/test/proof scheduler, import targets for collection, guess dynamic pytest/plugin behavior as exact, report unavailable provers as passing, or disable full-suite fallback.
 - Preconditions: Scheduling adapter is cancellation/fence safe and semantic graph/test facts are supplied through SCH-002 at runtime.
-- Effects: Selects tests from direct/import/caller/fixture/schema/config/generated/proof edges plus user rules, records reason paths, runs static/pytest/prover stages, and optionally/mandatorily runs the full-suite oracle by assurance policy.
+- Effects: Selects tests from direct/import/caller/fixture/schema/config/generated/proof edges plus user rules, records reason paths, converts the selected nodes into explicit bounded commands, runs static/pytest stages through `ValidationScheduler.run_staged`, runs proofs through `ProofScheduler`, references existing execution receipts, and optionally/mandatorily runs the full-suite oracle by assurance policy.
 - Acceptance: Direct known dependents are all selected; ambiguity and opaque/config/dependency changes trigger visible fallback; commands bind exact tree/config/toolchain; timeouts/cancellation are typed; controlled comparison metrics define false negatives correctly and support 100 percent recall.
 
 ## SCH-009 Emit MCP++ receipts and enforce freshness admission
@@ -291,8 +296,8 @@ A9  SCH-018
 - Track: receipts
 - Depends on: SCH-001, SCH-003, SCH-008
 - Goal id: SCH-G030
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, tests/agent_supervisor/semantic_state/test_receipts.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_receipts.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, test/api/semantic_state/test_receipts.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_receipts.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/receipts
 - Parallel lane: sch-receipts
@@ -302,12 +307,12 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9 and 13
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, tests/agent_supervisor/semantic_state/test_receipts.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, test/api/semantic_state/test_receipts.py
 - Predicted symbols: ReceiptCompiler, ReceiptFreshnessPolicy, ReceiptAdmission, StaleReceiptError, compile_verification_receipt, admit_receipt
 - Interfaces: SemanticVerificationReceipt@1, ReceiptFreshnessAdmission@1
 - Conflict policy: Receipts are MCP++ Profile B artifacts linked by Profile F events and real CIDv1. Operational/scheduler/provider receipts do not prove correctness. Never admit stale, corrupted, incomplete, unavailable, simulated, or mismatched evidence.
 - Preconditions: Wire codec, durable port, and verification results exist.
-- Effects: Binds receipts to exact trees/roots/delta/selection/commands/toolchain/dependency-lock/config/policy/interface/provider/proof/output identities, stores them before reference, and emits sorted stale obligations on any binding change.
+- Effects: Binds receipts to exact trees/root manifests/datasets Merkle root/capsule index/delta/selection/commands/toolchain/dependency-lock/config/policy/interface/provider/proof/output identities, stores them before reference, and emits sorted stale obligations on any binding change.
 - Acceptance: Rehash and closed-schema validation pass; any bound input change stales the receipt; policy/interface changes invalidate decisions/adapters; unavailable proof is explicit; a stale or simulation receipt cannot satisfy verification or state-root promotion.
 
 ## SCH-010 Implement safe fenced worktree and patch validation
@@ -316,10 +321,10 @@ A9  SCH-018
 - Completion: auto
 - Priority: P0
 - Track: worktree
-- Depends on: SCH-004
+- Depends on: SCH-004, SCH-005
 - Goal id: SCH-G030
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, tests/agent_supervisor/semantic_state/test_worktree.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_worktree.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, test/api/semantic_state/test_worktree.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_worktree.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/worktree
 - Parallel lane: sch-worktree
@@ -329,13 +334,13 @@ A9  SCH-018
 - Context budget tokens: 34000
 - LLM context budget bytes: 278528
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 12 and 14
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, tests/agent_supervisor/semantic_state/test_worktree.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, test/api/semantic_state/test_worktree.py
 - Predicted symbols: IsolatedWorktree, PatchValidator, PatchScope, PatchValidationError, create_isolated_worktree, validate_patch, apply_patch
 - Interfaces: IsolatedPatchWorktree@1
-- Conflict policy: Acquire WorktreeLifecycleStore/LeaseCoordinator ownership before `git worktree add`; use explicit validated paths and argv; reject control/runtime/state paths, symlink escapes, submodules, binary patches, path traversal, undeclared files, and stale fences. Never mutate the user's checkout.
+- Conflict policy: Consume the fenced attempt from SCH-005 and compose `WorktreeLifecycleStore`, `LeaseCoordinator`, `todo_daemon.worktrees.managed_git_worktree`/`GitWorktreeSession`, `validation.proposal_validation.validate_untrusted_implementation_proposal`, and `production_context_slice.assert_proposal_covered_by_context`. Do not create parallel worktree/proposal authorities. Use explicit paths/argv; reject control/runtime/state paths, symlink/hardlink escapes, submodules, binary patches, traversal, undeclared files, stale fences, and invisible patch preimages. Never mutate the user's checkout.
 - Preconditions: Scheduling lease/fence contracts exist and the target is a valid Git repository.
-- Effects: Creates a disposable attempt worktree, materializes ContextPack artifacts, validates bounded unified diffs and declared file scope, applies with Git, records exact pre/post trees, and performs recoverable fenced cleanup.
-- Acceptance: Malformed/out-of-scope patches cause no target/root mutation; allowed text patches apply deterministically; concurrent/stale owners cannot publish or clean a live peer worktree; interrupted prepare/apply/cleanup states recover safely.
+- Effects: Creates a disposable attempt worktree at the exact scanned base commit/tree, materializes and verifies the ContextPack/ProductionContextSlice, validates the proposal and immutable task scope, parses a bounded unified diff, runs explicit `git apply --check` before `git apply`, records exact pre/post trees, and performs recoverable fenced cleanup. If the shared managed helper cannot select the bound base, only a narrow reviewed base-ref extension is allowed.
+- Acceptance: A stale base, invisible preimage, malformed/out-of-scope patch, or failed apply check causes no target/root mutation; allowed text patches apply deterministically; concurrent/stale owners cannot publish or clean a live peer worktree; interrupted prepare/apply/cleanup states recover safely.
 
 ## SCH-011 Implement the complete 14-step harness loop
 
@@ -345,8 +350,8 @@ A9  SCH-018
 - Track: harness-loop
 - Depends on: SCH-002, SCH-003, SCH-005, SCH-006, SCH-007, SCH-008, SCH-009, SCH-010
 - Goal id: SCH-G030
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, tests/agent_supervisor/semantic_state/test_harness.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_harness.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, test/api/semantic_state/test_harness.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_harness.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/harness-loop
 - Parallel lane: sch-harness
@@ -356,13 +361,13 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 5 through 15
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, tests/agent_supervisor/semantic_state/test_harness.py
-- Predicted symbols: SemanticCompressionHarness, HarnessPolicy, HarnessRequest, HarnessResult, run_semantic_patch_loop
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, test/api/semantic_state/test_harness.py
+- Predicted symbols: SemanticCompressionHarness, HarnessPolicy, HarnessRequest, run_semantic_patch_loop
 - Interfaces: SemanticCompressionHarness@1
 - Conflict policy: Orchestrate existing ports only. Do not add an agent framework/server/UI, auto-rewrite dependents, bypass an obligation, scan the portfolio, run providers before admission, or move a root before all acceptance receipts are fresh.
 - Preconditions: All scanner, durability, scheduling, context, routing, verification, receipt, and worktree ports pass their focused tests.
-- Effects: Executes worktree creation, ContextPack materialization, model invocation, patch/scope validation, application, rescan/delta/invalidation, static checks, selected tests, provers, optional oracle, receipts, and accepted expected-old root CAS in the documented 14-step order.
-- Acceptance: Rejection/unavailability/cancellation leaves the current root unchanged; acceptance requires a real production provider when a model is needed and fresh passing required receipts; actual changed symbols and obligations are returned; exact replay is idempotent; root conflict is reported rather than overwritten.
+- Effects: Executes worktree creation, ContextPack/ProductionContextSlice materialization, model invocation, strict proposal/preimage/scope validation, checked application, rescan/delta/invalidation, static checks, selected tests, provers, optional oracle, immutable graph/capsule/pack/delta/obligation/patch/receipt/event storage, complete SemanticStateRootManifest construction, and generation-bearing accepted-root CAS in the documented 14-step order. Bootstrap scan is an explicit `None -> indexed manifest` transition and does not invent verification.
+- Acceptance: Rejection/unavailability/cancellation may leave immutable candidate blocks but leaves the current RootRef unchanged; acceptance requires a real production provider when a model is needed and fresh passing required receipts; every manifest reference rehashes; actual changed symbols and obligations are returned; exact replay is idempotent; `human_review_required` never invokes or publishes; root conflict is reported rather than overwritten.
 
 ## SCH-012 Implement incremental session, watch, restart, and replay
 
@@ -372,8 +377,8 @@ A9  SCH-018
 - Track: session
 - Depends on: SCH-011
 - Goal id: SCH-G040
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, tests/agent_supervisor/semantic_state/test_session.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_session.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, test/api/semantic_state/test_session.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_session.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/session
 - Parallel lane: sch-session
@@ -383,7 +388,7 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 12, 13, and 15
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, tests/agent_supervisor/semantic_state/test_session.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, test/api/semantic_state/test_session.py
 - Predicted symbols: SemanticStateSession, SessionPolicy, SessionStatus, watch_session, replay_session
 - Interfaces: SemanticStateSession@1
 - Conflict policy: Watch notifications only schedule a canonical scan. Reuse runtime.event_log cursors and existing fences; do not make events/mtime/queue rows authoritative, start background work on import, or allow a stale callback to commit.
@@ -397,10 +402,10 @@ A9  SCH-018
 - Completion: auto
 - Priority: P0
 - Track: cli
-- Depends on: SCH-011, SCH-012
+- Depends on: SCH-011, SCH-012, SCH-017
 - Goal id: SCH-G040
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/agent_supervisor/semantic_state/test_cli.py, pyproject.toml, setup.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_cli.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, test/api/semantic_state/test_cli.py, test/api/semantic_state/test_wheel_install.py, pyproject.toml, setup.py, MANIFEST.in
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_cli.py test/api/semantic_state/test_wheel_install.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/cli
 - Parallel lane: sch-cli
@@ -410,13 +415,13 @@ A9  SCH-018
 - Context budget tokens: 36000
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md section 16
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/agent_supervisor/semantic_state/test_cli.py, pyproject.toml, setup.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, test/api/semantic_state/test_cli.py, test/api/semantic_state/test_wheel_install.py, pyproject.toml, setup.py, MANIFEST.in
 - Predicted symbols: build_parser, main
 - Interfaces: SemanticStateCLI@1
-- Conflict policy: Add one dedicated `semantic-state` entrypoint mirrored in pyproject/setup. Do not expand legacy monolithic CLI, expose a network/MCP service, auto-install dependencies, or hide typed unavailable/production-simulation errors behind exit zero.
+- Conflict policy: Add one dedicated `semantic-state` entrypoint mirrored in pyproject/setup and package the closed JSON interface schema for `importlib.resources`. Do not expand legacy monolithic CLI, expose a network/MCP service, auto-install dependencies, or hide typed unavailable/production-simulation errors behind exit zero.
 - Preconditions: Harness and restartable session APIs are stable.
 - Effects: Implements scan, watch, status, graph, explain-symbol, explain-impact, invalidate, select-tests, pack-context, verify, apply-patch, compare-full-suite, and benchmark capabilities with deterministic JSON.
-- Acceptance: All commands have bounded help/errors and stable exit codes; production apply-patch cannot simulate; local commands need no IPFS daemon; cold `--help` and imports cause no install/network/environment/process/database mutation.
+- Acceptance: All commands, including the implemented SCH-017 benchmark, have bounded help/errors and stable exit codes; production apply-patch cannot simulate; local commands need no IPFS daemon; a built-wheel smoke test finds the console entry and schema; cold `--help` and imports cause no install/network/environment/process/database mutation.
 
 ## SCH-014 Create the controlled Python fixture repository
 
@@ -426,8 +431,8 @@ A9  SCH-018
 - Track: fixtures
 - Depends on: SCH-000
 - Goal id: SCH-G040
-- Outputs: tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_fixture_repository.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_fixture_repository.py
+- Outputs: test/fixtures/semantic_state_harness/controlled_repo, test/api/semantic_state/test_fixture_repository.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_fixture_repository.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/fixtures
 - Parallel lane: sch-fixtures
@@ -437,13 +442,13 @@ A9  SCH-018
 - Context budget tokens: 34000
 - LLM context budget bytes: 278528
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 2, 10, and 17
-- Predicted files: tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_fixture_repository.py
+- Predicted files: test/fixtures/semantic_state_harness/controlled_repo, test/api/semantic_state/test_fixture_repository.py
 - Predicted symbols: controlled_repository, mutation_case, fixture_oracle
 - Interfaces: ControlledSemanticRepository@1
 - Conflict policy: Keep the fixture small, self-contained, Python 3.12/pytest-only, deterministic, and free of network/native execution. Native/dynamic behavior is represented syntactically and not imported during scans. Do not depend on the user's portfolio checkout.
-- Preconditions: Exact datasets semantic-index fixture/API contract is sealed.
-- Effects: Supplies base/mutated Git trees for local body, signature, cross-module, dataclass/schema, exception, fixture/config, dynamic import, monkey patch, opaque native, formatting, delete/rename, generated file, stale receipt, failed CAS, interruption, concurrent watcher, and out-of-scope patch cases.
-- Acceptance: Full fixture suite is fast and deterministic; every mutation has expected changed symbols, invalidation/test/proof oracle, and confidence/raw-source behavior; unrelated formatting and changes remain bounded; no fixture scan imports or executes fixture code.
+- Preconditions: Exact repaired datasets semantic-state/Merkle/capsule/source fixture/API contract is sealed.
+- Effects: Supplies base/mutated Git trees for local body, signature, cross-module, dataclass/schema, exception, side-effect/security, fixture/config, dependency/lockfile, policy, MCP interface/client adapter, dynamic import, monkey patch, opaque native, formatting, delete/rename, generated file, stale receipt, failed/ABA CAS, interruption, concurrent watcher, post-scan source race, and out-of-scope patch cases.
+- Acceptance: Full fixture suite is fast and deterministic; every mutation has independently declared changed-symbol, Merkle, invalidation/test/proof, receipt-freshness, and confidence/raw-source oracles; source-race bytes never enter a pack; unrelated formatting and changes remain bounded; no fixture scan imports or executes fixture code.
 
 ## SCH-015 Prove the end-to-end acceptance matrix
 
@@ -453,8 +458,8 @@ A9  SCH-018
 - Track: acceptance
 - Depends on: SCH-011, SCH-012, SCH-014
 - Goal id: SCH-G040
-- Outputs: tests/agent_supervisor/semantic_state/test_acceptance.py, tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py, tests/agent_supervisor/semantic_state/test_production_gates.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_acceptance.py tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py tests/agent_supervisor/semantic_state/test_production_gates.py
+- Outputs: test/api/semantic_state/test_acceptance.py, test/api/semantic_state/test_concurrency_and_recovery.py, test/api/semantic_state/test_production_gates.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_acceptance.py test/api/semantic_state/test_concurrency_and_recovery.py test/api/semantic_state/test_production_gates.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/acceptance
 - Parallel lane: sch-acceptance
@@ -464,13 +469,13 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9 through 17
-- Predicted files: tests/agent_supervisor/semantic_state/test_acceptance.py, tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py, tests/agent_supervisor/semantic_state/test_production_gates.py
+- Predicted files: test/api/semantic_state/test_acceptance.py, test/api/semantic_state/test_concurrency_and_recovery.py, test/api/semantic_state/test_production_gates.py
 - Predicted symbols: test_controlled_invalidation_matrix, test_selected_suite_recall, test_root_cas_and_recovery, test_production_rejects_simulation
 - Interfaces: SemanticStateAcceptance@1
 - Conflict policy: Test real local behavior and injected typed unavailable paths, not mock success claims. Do not weaken selection/oracle/freshness/scope/CAS gates or omit failing/escalated cases.
 - Preconditions: Complete harness/session and controlled fixture exist.
-- Effects: Runs all required mutation cases, compares selected/full suites, injects interrupted writes/concurrent writers/watchers, forges stale/corrupt receipts, and submits a simulated/out-of-scope provider patch.
-- Acceptance: Unrelated changes do not invalidate the repository; known dependents are invalidated; opaque source is retrieved; stale receipts never verify; controlled selection recall is 100 percent; full fallback works; roots are deterministic; recovery is safe; CAS has one winner; simulation never reports production verification.
+- Effects: Runs all required plus side-effect/lockfile/policy/interface/source-race mutation cases through the real pinned local datasets and kit adapters, compares selected/full suites, injects interrupted writes/concurrent/ABA writers/watchers, forges stale/corrupt receipts, and exercises the actual default ProviderExecutionGateway simulated reservation plus degraded/off/replay/fallback and out-of-scope patch paths.
+- Acceptance: At least one complete no-fake cross-repository adapter path passes; unrelated changes do not invalidate the repository; all known semantic/environment/policy/interface dependents are invalidated; opaque source is retrieved from the bound tree; stale receipts never verify; controlled selection recall is 100 percent; full fallback works; root manifests are deterministic and transitively valid; recovery is safe; generation CAS has one winner and rejects ABA; `sim:`/`degraded:`/OFF/SIMULATED/DEGRADED/fallback/unadmitted replay never report production verification.
 
 ## SCH-016 Create the exactly-40-task benchmark corpus
 
@@ -480,8 +485,8 @@ A9  SCH-018
 - Track: benchmark-corpus
 - Depends on: SCH-014
 - Goal id: SCH-G050
-- Outputs: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
+- Outputs: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, test/api/semantic_state/test_benchmark_corpus.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_benchmark_corpus.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/benchmark-corpus
 - Parallel lane: sch-benchmark-corpus
@@ -491,13 +496,13 @@ A9  SCH-018
 - Context budget tokens: 34000
 - LLM context budget bytes: 278528
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md section 18
-- Predicted files: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
+- Predicted files: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, test/api/semantic_state/test_benchmark_corpus.py
 - Predicted symbols: BenchmarkTask, BenchmarkCorpus
 - Interfaces: SemanticStateBenchmarkCorpus@1
 - Conflict policy: Exactly 40 checked-in deterministic tasks: 10 small bug fixes and 6 each test repair, API adapter, schema migration, multi-file/refactor, and rejection/escalation. Do not omit hard/failed tasks or required raw source to bias metrics.
 - Preconditions: Controlled fixture mutation format and oracle are stable.
-- Effects: Defines task objective/target/base mutation/oracle/risk/expected route and reproducible baseline-retrieval policy for every representative task.
-- Acceptance: Corpus has exactly 40 unique stable task IDs and the required category counts; includes multi-file and frontier/human cases; every task is runnable offline against a pinned fixture tree and declares no expected outcome derived from benchmark implementation output.
+- Effects: Defines task objective/target/base mutation/oracle/risk/expected route and reproducible baseline-retrieval policy for every representative task. Any checked-in candidate diff is explicitly an oracle/replay fixture with `production_eligible=false`, never model output.
+- Acceptance: Corpus has exactly 40 unique stable task IDs and the required category counts; includes multi-file and frontier/human cases; every task is runnable offline against a pinned fixture tree, separates candidate verification outcome from production acceptance, and declares no expected outcome derived from benchmark implementation output.
 
 ## SCH-017 Implement benchmark runner and publish measured results
 
@@ -507,8 +512,8 @@ A9  SCH-018
 - Track: benchmark
 - Depends on: SCH-006, SCH-007, SCH-011, SCH-016
 - Goal id: SCH-G050
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, tests/agent_supervisor/semantic_state/test_benchmark.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_benchmark.py && python benchmarks/semantic_state/run_benchmark.py --check
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, test/api/semantic_state/test_benchmark.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_benchmark.py && python3.12 benchmarks/semantic_state/run_benchmark.py --check
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/benchmark
 - Parallel lane: sch-benchmark
@@ -518,13 +523,13 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 11 and 18
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, tests/agent_supervisor/semantic_state/test_benchmark.py
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, test/api/semantic_state/test_benchmark.py
 - Predicted symbols: BenchmarkRunner, BenchmarkResult, BenchmarkSummary, run_benchmark, compare_context_modes
 - Interfaces: SemanticStateBenchmark@1
-- Conflict policy: Use the same declared tokenizer/estimator and coverage assurance for raw and semantic modes. Count all 40 tasks including rejection/escalation; never manufacture model success, drop opaque code, or report unavailable/simulation as accepted.
+- Conflict policy: Use the same declared tokenizer/estimator and coverage assurance for raw and semantic modes. Count all 40 tasks including rejection/escalation; never manufacture model success, drop opaque code, report replay/unavailable/simulation as production accepted, emit a model receipt for an oracle diff, or advance a production root from benchmark replay.
 - Preconditions: Context packer, routing, complete harness, and corpus are stable.
-- Effects: Captures baseline/pack tokens, excluded raw code, capsules, invalidation cone, selected/full tests, proofs, route, outcome, timing, receipt freshness, precision/recall, fallback, and category/overall reductions into reproducible JSON/Markdown.
-- Acceptance: `--check` recomputes identical deterministic fields; overall median context reduction is at least 30 percent without coverage omissions; stale/simulated admissions and controlled false negatives are zero; results report task-type reductions, precision, recall, failures, and uncertainty rather than hiding them.
+- Effects: Captures baseline/pack tokens, excluded raw code, capsules, invalidation cone, selected/full tests, proofs, route, candidate-verification outcome, production eligibility/acceptance, observational timing, receipt freshness, precision/recall, fallback, and category/overall reductions into JSON/Markdown.
+- Acceptance: `--check` recomputes identical deterministic semantic fields while excluding wall-clock observations from byte equality; every oracle/replay row is `production_eligible=false`; overall median context reduction is at least 30 percent without coverage omissions; stale/simulated admissions and controlled false negatives are zero; results report task-type reductions, precision, recall, failures, and uncertainty rather than hiding them.
 
 ## SCH-018 Complete documentation, import safety, and provider regressions
 
@@ -534,8 +539,8 @@ A9  SCH-018
 - Track: release
 - Depends on: SCH-013, SCH-015, SCH-017
 - Goal id: SCH-G050
-- Outputs: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, tests/agent_supervisor/semantic_state/test_import_safety.py, tests/agent_supervisor/semantic_state/test_provider_regressions.py
-- Validation: python -m pytest -q tests/agent_supervisor/semantic_state && python benchmarks/semantic_state/run_benchmark.py --check
+- Outputs: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, test/api/semantic_state/test_import_safety.py, test/api/semantic_state/test_provider_regressions.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state test/api/test_agent_supervisor_context_compiler.py test/api/test_agent_supervisor_production_context_slice.py test/api/test_agent_supervisor_provider_execution.py test/api/test_agent_supervisor_resource_scheduler.py test/api/test_agent_supervisor_lease_coordination.py test/api/test_agent_supervisor_worktree_lifecycle.py test/api/test_agent_supervisor_proposal_validation.py test/api/test_agent_supervisor_validation_scheduler.py test/api/test_agent_supervisor_proof_scheduler.py test/api/test_agent_supervisor_hermetic_validation.py && python3.12 benchmarks/semantic_state/run_benchmark.py --check
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/release
 - Parallel lane: sch-release
@@ -545,10 +550,10 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 16 through 20
-- Predicted files: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, tests/agent_supervisor/semantic_state/test_import_safety.py, tests/agent_supervisor/semantic_state/test_provider_regressions.py
+- Predicted files: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, test/api/semantic_state/test_import_safety.py, test/api/semantic_state/test_provider_regressions.py
 - Predicted symbols: release_report, import_safety_probe, provider_production_gate_regression
 - Interfaces: SemanticStateHarnessRelease@1
 - Conflict policy: Document code and measured receipts exactly. Do not claim complete Python analysis, universal verification, ZK support, provider availability, or production readiness; do not auto-install on import or weaken a failing gate to close the board.
 - Preconditions: CLI, acceptance matrix, and benchmark results are committed and reproducible.
-- Effects: Documents architecture/modules/commands/examples/tests/benchmark/token reductions/precision-recall/limitations/bottlenecks and exact pre-ZK/production work; tests imports with installer/network/process/environment mutation disabled and real/absent/simulated provider dispositions.
-- Acceptance: Focused and relevant existing supervisor tests pass; ordinary imports are side-effect free; production unavailable/simulation is nonzero and never verified; final report is traceable to exact commits and receipts and contains every requested completion-report section.
+- Effects: Documents architecture/modules/commands/examples/tests/benchmark/token reductions/precision-recall/limitations/bottlenecks and exact pre-ZK/production work; tests imports with installer/network/process/environment mutation disabled; statically rejects legacy mock hardware/inference imports; and tests real/absent/default-simulated/degraded/off/replayed/fallback provider dispositions.
+- Acceptance: Focused semantic and named existing ContextCompiler/provider/resource/lease/worktree/hermetic-validation regressions pass under Python 3.12; ordinary imports are side-effect free; production unavailable/simulation/fallback is nonzero and never verified; final report is traceable to exact commits/root manifests/receipts and contains every requested completion-report section.

--- a/docs/architecture/semantic_compression_harness.todo.md
+++ b/docs/architecture/semantic_compression_harness.todo.md
@@ -10,11 +10,11 @@ Protected companion artifacts:
 
 These control documents are reviewed inputs and may be changed only by the
 operator while sealing `SCH-000`; implementation workers must not edit them.
-`SCH-000` is deliberately open. Do not launch implementation lanes until the
-explicit unresolved placeholders have been replaced by exact final repaired
-`ipfs_datasets_py` semantic-state/Merkle/capsule and `ipfs_kit_py` durable-root
-commit pins, the deterministic seal validator passes, and the task is manually
-marked complete.
+`SCH-000` is deliberately open. Do not launch implementation lanes until both
+explicit datasets placeholders have been replaced by the exact final repaired
+incremental-index and semantic-state/Merkle/capsule commits, the already-pinned
+`ipfs_kit_py` durable-root commit is validated, the deterministic seal validator
+passes, and the task is manually marked complete.
 
 Implementation is focused in
 `ipfs_accelerate_py.agent_supervisor.semantic_state`. Workers consume the pinned
@@ -27,8 +27,9 @@ They must also reuse `ContextCompiler`, `ProductionContextSlice`, strict
 proposal validation, `ValidationScheduler.run_staged`, `ProofScheduler`, and
 the shared managed-worktree lifecycle. They must not use `PersistentTaskQueue`
 as authority, the legacy mock hardware or inference coordinator,
-`compute_artifact_cid` for new artifacts, `run_impact_selected` as a second
-test selector, or a silent simulation/fallback path in production.
+`compute_artifact_cid` for new artifacts, graph traversal/reselection or
+`run_impact_selected` as a second test selector, or a silent
+simulation/fallback path in production.
 
 ## Parallel waves
 
@@ -68,9 +69,9 @@ A9  SCH-018
 - Predicted symbols: SemanticStateDependencySeal
 - Interfaces: SemanticStateDependencySeal@1
 - Conflict policy: Operator-only launch gate. No implementation worker may infer, update, merge, or bypass dependency pins or edit the protected control files.
-- Preconditions: Accelerate baseline is `ea11293bb996f052d620eae989f5377a956764b1`; MCP++ authority is `dc3164653a48d059ae9812078359daeafb451c07`; the exact final repaired datasets semantic-state/Merkle/capsule commit and final repaired kit generation-bearing durable-root commit have been supplied by their closeouts. Until then `IPFS_DATASETS_SEMANTIC_STATE_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` and `IPFS_KIT_DURABLE_ROOT_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` remain fail-closed.
-- Effects: Replaces both unresolved placeholders with exact reachable 40-hex commits; records all four repository origins/commits, interface and schema fingerprints, Python 3.12/toolchain, and producer test commands; rejects ambient editable/PYTHONPATH substitution; runs real producer contract tests and seals their outputs for every downstream worker.
-- Acceptance: The validator rejects unresolved, mutable, unreachable, dirty, origin-mismatched, fingerprint-incompatible, non-Python-3.12, or failing dependencies. Datasets proves real Git-tree scan -> resolved graph -> symbol-node Merkle DAG -> delta -> invalidation and exposes capsule plus tree-bound source-blob/span retrieval without injected edges. Kit exposes direct lazy `DurableCoordinationStore` plus generation-bearing read-root/expected-token-CAS/recover. The board is acyclic and only then is SCH-000 marked complete.
+- Preconditions: Accelerate baseline is `ea11293bb996f052d620eae989f5377a956764b1`; MCP++ authority is `dc3164653a48d059ae9812078359daeafb451c07`; final kit generation-bearing durable-root authority is `05ba9375923cd5fb52e2c9c18b98b530d57d077f`; the exact final repaired datasets incremental-semantic-index and semantic-state/Merkle/capsule commits have not yet both been supplied. Until those separate closeouts arrive, `IPFS_DATASETS_INCREMENTAL_SEMANTIC_INDEX_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` and `IPFS_DATASETS_SEMANTIC_STATE_COMMIT = UNRESOLVED_FINAL_REPAIRED_COMMIT` remain fail-closed; workers must not infer either value from ancestry or a mutable branch.
+- Effects: Replaces only the two unresolved datasets placeholders with their exact reachable 40-hex commits, retains and validates the exact kit commit, and records all four repository origins and all five commit authorities, interface and schema fingerprints, Python 3.12/toolchain, and producer test commands; rejects ambient editable/PYTHONPATH substitution; runs real producer contract tests and seals their outputs for every downstream worker.
+- Acceptance: The validator rejects unresolved, mutable, unreachable, dirty, origin-mismatched, fingerprint-incompatible, non-Python-3.12, or failing dependencies. Datasets separately proves the real Git-tree scan -> resolved graph -> delta -> invalidation path and the storage-neutral semantic-state bundle/view -> symbol-node Merkle DAG -> capsule/source -> previous/current selection path without injected edges. Kit exposes direct lazy `DurableCoordinationStore` plus generation-bearing read-root/expected-token-CAS/recover. The board is acyclic and only then is SCH-000 marked complete.
 
 ## SCH-001 Implement MCP++ wire codec and interface descriptor
 
@@ -92,11 +93,11 @@ A9  SCH-018
 - LLM context budget bytes: 294912
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3, 6, and 13
 - Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, test/api/semantic_state/test_wire.py
-- Predicted symbols: Availability, UnavailableResult, HarnessMode, WorkKind, SemanticCapsuleRef, ContextPack, ModelRoute, PatchProposal, TestSelection, VerificationReceipt, HarnessResult, RootRef, SemanticStateRootManifest, SemanticStateWireCodec, semantic_state_interface_descriptor
+- Predicted symbols: Availability, UnavailableResult, HarnessMode, WorkKind, SemanticCapsuleRef, ContextPack, ModelRoute, PatchProposal, TestSelectionRef, VerificationReceipt, HarnessResult, RootRef, SemanticStateRootManifest, SemanticStateWireCodec, semantic_state_interface_descriptor
 - Interfaces: SemanticStateHarnessContracts@1, SemanticStateRootManifest@1, SemanticStateMcpWire@1
 - Conflict policy: MCP++ Profile A/B/F at the sealed commit is wire authority. Use `canonicalize_artifact` plus `kubo_cid.cid_for_bytes`; never use `compute_artifact_cid` pseudo-CIDs, copy CID code, mutate MCP server transport, or recompute datasets identities.
 - Preconditions: SCH-000 sealed exact commits and MCP++ conformance inputs.
-- Effects: Defines closed deterministic harness records, the accepted root-manifest and generation-bearing root-reference contracts, a Profile A descriptor, Profile B request/result envelopes, Profile F event nodes, strict decoding, bounded errors, and Kubo-compatible CIDv1 vectors. `SemanticCapsuleRef` references the sealed datasets capsule instead of duplicating semantic facts.
+- Effects: Defines closed deterministic harness records, the accepted root-manifest and generation-bearing root-reference contracts, a Profile A descriptor, Profile B request/result envelopes, Profile F event nodes, strict decoding, bounded errors, and Kubo-compatible CIDv1 vectors. `SemanticCapsuleRef` is admission/reference metadata only. `TestSelectionRef` contains only the sealed datasets selection CID plus previous/current semantic-state-root CIDs; neither record duplicates producer semantic facts, selected nodes, reason paths, universe, or fallback authority.
 - Acceptance: Equivalent payloads have identical canonical bytes and real CIDv1; unknown fields/enums or forged CIDs fail closed; semantic-state CIDs remain opaque verified references; every accepted manifest transitively names graph/capsule/delta/obligation/selection/receipt and environment bindings; operational fields cannot alter its CID; descriptor/interface changes have detectable CIDs; ordinary imports perform no I/O.
 
 ## SCH-002 Implement the pinned datasets semantic-state adapter
@@ -117,14 +118,14 @@ A9  SCH-018
 - Provider role: codex-implement
 - Context budget tokens: 34000
 - LLM context budget bytes: 278528
-- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1, 3, 7, and 9
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1, 3, 7, 9, and 10
 - Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, test/api/semantic_state/test_datasets_adapter.py
-- Predicted symbols: SemanticStateProvider, IpfsDatasetsSemanticStateProvider, SemanticStateCapability, SemanticStateUnavailable, SourceBlobStale, load_semantic_state_provider
-- Interfaces: SemanticStateProvider@1, IncrementalSemanticIndexModels@sealed, SymbolMerkleDAG@sealed, SemanticCapsule@sealed, TreeBoundSource@sealed
+- Predicted symbols: SemanticStateProvider, IpfsDatasetsSemanticStateProvider, SemanticStateCapability, SemanticStateUnavailable, SourceBlobStale, SemanticStateView, load_semantic_state_provider
+- Interfaces: SemanticStateProvider@1, IncrementalSemanticIndexModels@sealed, SemanticStateView@sealed, SymbolMerkleDAG@sealed, SemanticCapsule@sealed, TestSelection@sealed, TreeBoundSource@sealed
 - Conflict policy: Lazy-load only the sealed public semantic-state surface. Do not parse target AST, reconstruct symbol IDs/edges/deltas/Merkle nodes/capsule facts, read post-scan filesystem bytes as authoritative, import target repositories, claim complete Python semantics, or accept an ambient incompatible package.
-- Preconditions: Sealed datasets commit passes its repaired semantic-state tests and exposes scan_repository, diff_repository_states, calculate_invalidation, explain_symbol, explain_impact, watch_repository, symbol-Merkle materialization, compile_semantic_capsule, read_source_blob, and read_source_span.
-- Effects: Capability-checks contract fingerprints and schema/extractor/capsule versions, invokes canonical Git/tree scans, validates state/Merkle/capsule/delta/invalidation CIDs and four confidence values, retrieves exact source only from the scanned tree with expected-CID verification, and converts missing/stale capability into typed unavailability.
-- Acceptance: Clean and incremental scans, Merkle nodes, and capsules round-trip without identity translation; all required scanner facts and typed relations survive the adapter; watcher events trigger scans but never become state; mismatched commit/schema/CID fails closed; a filesystem mutation after scan yields `SourceBlobStale` or a rescan rather than mixed source; every opaque/invalid state remains visible and requires raw source.
+- Preconditions: The separately sealed datasets ISI and semantic-state commits pass their repaired producer tests and expose the exact phase-one operations plus `build_semantic_state`, `verify_semantic_state_bundle`, storage-neutral `open_semantic_state(root_cid, get_block) -> SemanticStateView`, capsule/freshness/tree-bound source operations, environment invalidation, `select_tests_and_proofs(previous_state, current_state, invalidation, *, policy, explicit_rules=())`, and pure oracle comparison.
+- Effects: Capability-checks contract fingerprints and schema/extractor/capsule/selection versions, invokes canonical Git/tree scans, opens verified read-only semantic views using an injected `get_block(cid) -> bytes` reader, validates state/Merkle/capsule/delta/invalidation/selection CIDs and four confidence values, always passes previous/current views into selection so delete/rename evidence survives, retrieves exact source only from the scanned tree with expected-CID verification, and converts missing/stale capability into typed unavailability.
+- Acceptance: Clean and incremental scans, Merkle nodes, capsules, and datasets selections round-trip without identity translation; an in-memory bundle reader and sealed durable reader expose equivalent `SemanticStateView` results without granting datasets put/CAS/WAL/network authority; all required scanner facts and typed relations survive the adapter; watcher events trigger scans but never become state; mismatched commit/schema/CID/root bindings fail closed; a filesystem mutation after scan yields `SourceBlobStale` or a rescan rather than mixed source; every opaque/invalid state remains visible and requires raw source.
 
 ## SCH-003 Implement the narrow kit durable-root adapter
 
@@ -261,7 +262,7 @@ A9  SCH-018
 - Effects: Selects deterministic_only/small_local_model/medium_model/frontier_model/human_review_required, capability-checks injected providers, supplies the invoker to SCH-005, and applies a fail-closed promotion gate to its gateway result. Any `llm_router.generate_text` call explicitly sets `allow_local_fallback=False` and `allow_cross_provider_fallback=False` and verifies the effective provider.
 - Acceptance: Route decision is deterministic and explained; `human_review_required` halts before provider dispatch/root publication; high-risk/opaque/oversized/failed cases escalate; missing provider is typed unavailable and nonzero. Production requires ENFORCE mode, AVAILABLE coordination, real coordinator and invoker, verified attribution, matching provider, and a non-simulated reservation; rejects `sim:`/`degraded:`, OFF/SIMULATED/DEGRADED, fallback reasons, and unadmitted replay; development simulation can never verify or commit.
 
-## SCH-008 Select and execute static checks, pytest tests, and provers
+## SCH-008 Adapt the sealed selection and execute checks, tests, and provers
 
 - Status: todo
 - Completion: auto
@@ -269,8 +270,8 @@ A9  SCH-018
 - Track: verification
 - Depends on: SCH-002, SCH-004, SCH-005
 - Goal id: SCH-G020
-- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_test_selection.py, test/api/semantic_state/test_verification.py
-- Validation: python3.12 -m pytest -q test/api/semantic_state/test_test_selection.py test/api/semantic_state/test_verification.py
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/selection_execution.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_selection_execution.py, test/api/semantic_state/test_verification.py
+- Validation: python3.12 -m pytest -q test/api/semantic_state/test_selection_execution.py test/api/semantic_state/test_verification.py
 - Board namespace: semantic-compression-harness-v1
 - Bundle: sch/verification
 - Parallel lane: sch-verification
@@ -280,13 +281,13 @@ A9  SCH-018
 - Context budget tokens: 40000
 - LLM context budget bytes: 327680
 - Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9, 10, and 12
-- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_test_selection.py, test/api/semantic_state/test_verification.py
-- Predicted symbols: TestSelector, SelectionPolicy, VerificationRunner, StaticCheckResult, PytestResult, ProverResult, FullSuiteComparison, select_tests, compare_full_suite
-- Interfaces: TestSelection@1, SemanticVerification@1
-- Conflict policy: Reuse `validation_commands`, `validation_runtime`, `ValidationScheduler.run_staged`/`schedule_staged_validations`, `ProofScheduler`, formal capability records, and existing test-execution receipts. The semantic selector is authority: do not call `run_impact_selected`, add a subprocess/test/proof scheduler, import targets for collection, guess dynamic pytest/plugin behavior as exact, report unavailable provers as passing, or disable full-suite fallback.
-- Preconditions: Scheduling adapter is cancellation/fence safe and semantic graph/test facts are supplied through SCH-002 at runtime.
-- Effects: Selects tests from direct/import/caller/fixture/schema/config/generated/proof edges plus user rules, records reason paths, converts the selected nodes into explicit bounded commands, runs static/pytest stages through `ValidationScheduler.run_staged`, runs proofs through `ProofScheduler`, references existing execution receipts, and optionally/mandatorily runs the full-suite oracle by assurance policy.
-- Acceptance: Direct known dependents are all selected; ambiguity and opaque/config/dependency changes trigger visible fallback; commands bind exact tree/config/toolchain; timeouts/cancellation are typed; controlled comparison metrics define false negatives correctly and support 100 percent recall.
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/selection_execution.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, test/api/semantic_state/test_selection_execution.py, test/api/semantic_state/test_verification.py
+- Predicted symbols: SelectionExecutionAdapter, VerificationRunner, StaticCheckResult, PytestResult, ProverResult, FullSuiteComparison, materialize_selection_commands, compare_full_suite
+- Interfaces: TestSelectionRef@1, TestSelection@sealed, SemanticVerification@1
+- Conflict policy: Reuse `validation_commands`, `validation_runtime`, `ValidationScheduler.run_staged`/`schedule_staged_validations`, `ProofScheduler`, formal capability records, and existing test-execution receipts. The sealed datasets `TestSelection` is the only semantic selection authority: do not traverse or re-resolve its graph, choose a second affected set, call `run_impact_selected`, add a subprocess/test/proof scheduler, import targets for collection, guess node IDs or dynamic pytest/plugin behavior, report unavailable provers as passing, or weaken its full-suite fallback.
+- Preconditions: Scheduling adapter is cancellation/fence safe and SCH-002 supplies a verified datasets selection bound to the previous/current `SemanticStateView` roots and producer invalidation.
+- Effects: Verifies the `TestSelectionRef` against its datasets selection block and both semantic root bindings; converts only its already-selected pytest/proof IDs into explicit bounded commands; applies its `none`/`full_pytest`/`full_proofs`/`both` fallback plus explicit harness assurance policy; runs static/pytest stages through `ValidationScheduler.run_staged`, proofs through `ProofScheduler`, references existing execution receipts, and supplies normalized selected/full results to the datasets oracle comparison.
+- Acceptance: No accelerate graph traversal or reselection occurs; command provenance retains producer reason paths and selection/root CIDs; producer ambiguity/opaque/config/dependency fallback cannot be weakened; commands bind exact tree/config/toolchain; timeouts/cancellation are typed; controlled producer-oracle metrics define false negatives correctly and support 100 percent recall.
 
 ## SCH-009 Emit MCP++ receipts and enforce freshness admission
 

--- a/docs/architecture/semantic_compression_harness.todo.md
+++ b/docs/architecture/semantic_compression_harness.todo.md
@@ -1,0 +1,554 @@
+# Semantic compression harness supervisor taskboard
+
+Consumable by `ipfs_accelerate_py.agent_supervisor` with task prefix `SCH-`.
+
+Protected companion artifacts:
+
+- `docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md`
+- `docs/architecture/semantic_compression_harness.objectives.md`
+- `docs/architecture/semantic_compression_harness.todo.md`
+
+These control documents are reviewed inputs and may be changed only by the
+operator while sealing `SCH-000`; implementation workers must not edit them.
+`SCH-000` is deliberately open. Do not launch implementation lanes until it
+contains exact final `ipfs_datasets_py` and `ipfs_kit_py` commit pins and is
+manually marked complete.
+
+Implementation is focused in
+`ipfs_accelerate_py.agent_supervisor.semantic_state`. Workers consume the pinned
+semantic-index contracts rather than recreating scanner/graph/invalidation
+authority. They must reuse MCP++ Profile A/B/F wire rules, lazy
+`DurableCoordinationStore` plus the pinned generic root-CAS port,
+`ResourceScheduler`, `ProviderExecutionGateway`, `WorktreeLifecycleStore`,
+`LeaseCoordinator`, validation command contracts, and `runtime.event_log`.
+They must not use `PersistentTaskQueue` as authority, the legacy mock hardware
+or inference coordinator, `compute_artifact_cid` for new artifacts, or a silent
+simulation fallback in production.
+
+## Parallel waves
+
+```text
+A0  SCH-000
+A1  SCH-001 | SCH-002 | SCH-003 | SCH-014
+A2  SCH-004 | SCH-006 | SCH-016
+A3  SCH-005 | SCH-007 | SCH-010
+A4  SCH-008
+A5  SCH-009
+A6  SCH-011
+A7  SCH-012
+A8  SCH-013 | SCH-015 | SCH-017
+A9  SCH-018
+```
+
+## SCH-000 Pin and validate phase-two contract authorities
+
+- Status: todo
+- Completion: manual
+- Priority: P0
+- Track: control
+- Depends on:
+- Goal id: SCH-G010
+- Outputs: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json
+- Validation: git rev-parse HEAD
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/control
+- Parallel lane: sch-control
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: operator-only
+- Context budget tokens: 0
+- LLM context budget bytes: 0
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1 through 3
+- Predicted files: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md, docs/architecture/semantic_compression_harness.objectives.md, docs/architecture/semantic_compression_harness.todo.md, config/semantic_state_dependencies.seal.json
+- Predicted symbols: SemanticStateDependencySeal
+- Interfaces: SemanticStateDependencySeal@1
+- Conflict policy: Operator-only launch gate. No implementation worker may infer, update, merge, or bypass dependency pins or edit the protected control files.
+- Preconditions: Accelerate baseline is `ea11293bb996f052d620eae989f5377a956764b1`; MCP++ authority is `dc3164653a48d059ae9812078359daeafb451c07`; final datasets semantic-index and kit durable-root commits have been supplied by their closeouts.
+- Effects: Replaces both `UNRESOLVED` values with exact reachable 40-hex commits, records repository origins/schema versions/test commands, runs producer contract tests, and seals their outputs for every downstream worker.
+- Acceptance: Seal rejects unresolved, mutable, unreachable, dirty, schema-incompatible, or failing dependencies; datasets exposes the required scan/diff/invalidate/explain/watch state contracts; kit exposes direct lazy `DurableCoordinationStore` plus generic read-root/expected-old-CAS/recover; the board remains acyclic and only then is SCH-000 marked complete.
+
+## SCH-001 Implement MCP++ wire codec and interface descriptor
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: wire-contracts
+- Depends on: SCH-000
+- Goal id: SCH-G010
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, tests/agent_supervisor/semantic_state/test_wire.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_wire.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/wire-contracts
+- Parallel lane: sch-wire
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3, 6, and 13
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/contracts.py, ipfs_accelerate_py/agent_supervisor/semantic_state/wire.py, ipfs_accelerate_py/agent_supervisor/semantic_state/schemas/semantic-state-harness.interface.json, tests/agent_supervisor/semantic_state/test_wire.py
+- Predicted symbols: Availability, UnavailableResult, HarnessMode, WorkKind, SemanticCapsule, ContextPack, ModelRoute, PatchProposal, TestSelection, VerificationReceipt, HarnessResult, SemanticStateWireCodec, semantic_state_interface_descriptor
+- Interfaces: SemanticStateHarnessContracts@1, SemanticStateMcpWire@1
+- Conflict policy: MCP++ Profile A/B/F at the sealed commit is wire authority. Use `canonicalize_artifact` plus `kubo_cid.cid_for_bytes`; never use `compute_artifact_cid` pseudo-CIDs, copy CID code, mutate MCP server transport, or recompute datasets identities.
+- Preconditions: SCH-000 sealed exact commits and MCP++ conformance inputs.
+- Effects: Defines closed deterministic harness records, a Profile A descriptor, Profile B request/result envelopes, Profile F event nodes, strict decoding, bounded errors, and Kubo-compatible CIDv1 vectors.
+- Acceptance: Equivalent payloads have identical canonical bytes and real CIDv1; unknown fields/enums or forged CIDs fail closed; semantic-state CIDs remain opaque verified references; descriptor/interface changes have detectable CIDs; ordinary imports perform no I/O.
+
+## SCH-002 Implement the pinned datasets semantic-state adapter
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: datasets-adapter
+- Depends on: SCH-000
+- Goal id: SCH-G010
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, tests/agent_supervisor/semantic_state/test_datasets_adapter.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_datasets_adapter.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/datasets-adapter
+- Parallel lane: sch-datasets
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 34000
+- LLM context budget bytes: 278528
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 1, 3, 7, and 9
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/datasets_adapter.py, tests/agent_supervisor/semantic_state/test_datasets_adapter.py
+- Predicted symbols: SemanticStateProvider, IpfsDatasetsSemanticStateProvider, SemanticStateCapability, SemanticStateUnavailable, load_semantic_state_provider
+- Interfaces: SemanticStateProvider@1, IncrementalSemanticIndexModels@1
+- Conflict policy: Lazy-load only the sealed public semantic-index surface. Do not parse target AST, reconstruct symbol IDs/edges/deltas, import target repositories, claim complete Python semantics, or accept an ambient incompatible package.
+- Preconditions: Sealed datasets commit passes its semantic-index tests and exposes scan_repository, diff_repository_states, calculate_invalidation, explain_symbol, explain_impact, and watch_repository.
+- Effects: Capability-checks schema/extractor versions, invokes canonical Git/tree scans, validates state/delta/invalidation CIDs and four confidence values, and converts missing capability into typed unavailability.
+- Acceptance: Clean and incremental scans round-trip without identity translation; watcher events trigger scans but never become state; mismatched commit/schema/CID fails closed; every opaque/invalid state remains visible and requires raw source.
+
+## SCH-003 Implement the narrow kit durable-root adapter
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: durable-state
+- Depends on: SCH-000
+- Goal id: SCH-G010
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, tests/agent_supervisor/semantic_state/test_durable_state.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_durable_state.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/durable-state
+- Parallel lane: sch-durable
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3 and 13
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/durable_state.py, tests/agent_supervisor/semantic_state/test_durable_state.py
+- Predicted symbols: DurableSemanticStatePort, IpfsKitDurableStateAdapter, DurableStateUnavailable, RootConflict, open_local_durable_state
+- Interfaces: DurableSemanticStatePort@1, SemanticStateRootCAS@1
+- Conflict policy: Directly and lazily adapt the sealed `ipfs_kit_py.mcp_server.mcplusplus.coordination_storage.DurableCoordinationStore` and sealed generic root-CAS protocol. Do not duplicate local blocks/WAL, use a facade/provisional path, VerifiedIPLDBackend, Iroh/bucket CAS, or require a daemon/network.
+- Preconditions: SCH-000 pins a kit commit with `DurableCoordinationStore(storage_dir, backend=None)`, put/get/get_bytes/has/recover, and generic read_root/compare_and_swap_root behavior.
+- Effects: Exposes verified put/get/has, expected-old root CAS, replay, corruption checks, and interrupted-transition recovery behind one injected protocol; remote block transport remains optional.
+- Acceptance: Hermetic local tests use an explicit temporary storage directory and no daemon; supplied authoritative CID must match bytes; interrupted publication retains or completes one valid root; corrupted blocks fail closed; two distinct writers from one expected root yield at most one success.
+
+## SCH-004 Define scheduling and execution contracts
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: scheduling-contracts
+- Depends on: SCH-001
+- Goal id: SCH-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/scheduling-contracts
+- Parallel lane: sch-scheduling-contracts
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 32000
+- LLM context budget bytes: 262144
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 and 12
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling_contracts.py, tests/agent_supervisor/semantic_state/test_scheduling_contracts.py
+- Predicted symbols: SemanticWorkRequest, SemanticWorkResult, SemanticWorkStatus, CancellationToken, LeaseBinding, ResourceBinding, ProviderBinding
+- Interfaces: SemanticWorkScheduling@1
+- Conflict policy: Define a narrow projection over existing runtime contracts; do not introduce a scheduler, queue authority, provider registry, mock coordinator, or unbounded observation payload.
+- Preconditions: Closed wire/harness records exist.
+- Effects: Specifies idempotent work identities for scan, capsule, selection, context, model, static, pytest, prover, and persistence stages plus typed cancellation/unavailability/fencing results.
+- Acceptance: Records are deterministic, bounded, secret/source-body free in scheduler observations, distinguish unavailable/cancelled/failed/simulated, and cannot interpret scheduling success as verification success.
+
+## SCH-005 Implement the existing-supervisor scheduling adapter
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: scheduling
+- Depends on: SCH-004
+- Goal id: SCH-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, tests/agent_supervisor/semantic_state/test_scheduling.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_scheduling.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/scheduling
+- Parallel lane: sch-scheduling
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 3 and 12
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/scheduling.py, tests/agent_supervisor/semantic_state/test_scheduling.py
+- Predicted symbols: SemanticSchedulingAdapter, ScheduledAttempt, schedule_semantic_work, replay_semantic_work
+- Interfaces: SemanticSchedulingAdapter@1, ResourceScheduler@existing, ProviderExecutionGateway@existing
+- Conflict policy: Compose ResourceScheduler, ProviderExecutionGateway, WorktreeLifecycleStore, LeaseCoordinator, and runtime.event_log only. `PersistentTaskQueue` is not authority. Never use legacy mock hardware/inference, bypass leases/fences, or treat a simulated provider result as available production work.
+- Preconditions: SCH-004 work contracts are closed and existing runtime modules pass focused regressions.
+- Effects: Performs resource admission, lease/fence acquisition, cancellation propagation, exact-attempt idempotency, bounded event journaling, and restart/replay for every harness work kind.
+- Acceptance: Capacity/provider absence returns typed unavailable; cancellation reaches subprocess/provider boundary; replay does not reinvoke a terminal provider call; expired fences cannot publish; cold import starts no resources, threads, processes, databases, or network calls.
+
+## SCH-006 Compile capsules and assurance-aware ContextPacks
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: context
+- Depends on: SCH-001, SCH-002
+- Goal id: SCH-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, tests/agent_supervisor/semantic_state/test_capsules.py, tests/agent_supervisor/semantic_state/test_context_pack.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_capsules.py tests/agent_supervisor/semantic_state/test_context_pack.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/context
+- Parallel lane: sch-context
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 through 11
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/capsules.py, ipfs_accelerate_py/agent_supervisor/semantic_state/context_pack.py, tests/agent_supervisor/semantic_state/test_capsules.py, tests/agent_supervisor/semantic_state/test_context_pack.py
+- Predicted symbols: SemanticCapsuleCompiler, CapsuleCache, CapsuleAdmission, ContextPacker, ContextCoveragePolicy, ContextTokenEstimate, compile_capsule, pack_context
+- Interfaces: SemanticCapsule@1, ContextPack@1
+- Conflict policy: Compile only from authoritative semantic records and exact source retrieval. Docstrings/model summaries are hints only. Exact targets/edit context/tests are never compressed; heuristic, opaque, stale, invalid, unknown, or insufficient facts force raw source rather than truncation.
+- Preconditions: MCP++ records and the sealed datasets provider are available.
+- Effects: Builds version/config/policy/interface-bound capsules, safely reuses unchanged dependencies, chooses source versus capsule by confidence/freshness, minimizes counterexamples, accounts tokens, and explains included/excluded context and escalation.
+- Acceptance: Exact/conservative substitution rules and visible caveats pass; no LLM summary can raise confidence or satisfy proof; all required ContextPack fields are present; budget failure recommends escalation; identical inputs yield identical pack/capsule CIDs and token accounting.
+
+## SCH-007 Implement model routing and real-provider adapters
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: model-routing
+- Depends on: SCH-001, SCH-004
+- Goal id: SCH-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, tests/agent_supervisor/semantic_state/test_routing.py, tests/agent_supervisor/semantic_state/test_providers.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_routing.py tests/agent_supervisor/semantic_state/test_providers.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/model-routing
+- Parallel lane: sch-routing
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 6 and 12
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/routing.py, ipfs_accelerate_py/agent_supervisor/semantic_state/providers.py, tests/agent_supervisor/semantic_state/test_routing.py, tests/agent_supervisor/semantic_state/test_providers.py
+- Predicted symbols: ModelRoutingPolicy, ModelProvider, ModelCapability, ProductionProviderGate, route_model, invoke_model
+- Interfaces: ModelRouting@1, ModelProvider@1
+- Conflict policy: Do not hardcode a provider or add mock inference. Route only on context size, confidence, risk, dependency cone, obligations, prior failures, and proof availability. Production cannot silently replay or simulate a patch.
+- Preconditions: Closed wire and scheduling records exist.
+- Effects: Selects deterministic_only/small_local_model/medium_model/frontier_model/human_review_required, capability-checks injected providers, and maps absence/errors to typed unavailable results through ProviderExecutionGateway.
+- Acceptance: Route decision is deterministic and explained; high-risk/opaque/oversized/failed cases escalate; missing provider is unavailable and nonzero; simulated output is labeled development-only and is never eligible for production verification or root commit.
+
+## SCH-008 Select and execute static checks, pytest tests, and provers
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: verification
+- Depends on: SCH-004, SCH-005
+- Goal id: SCH-G020
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, tests/agent_supervisor/semantic_state/test_test_selection.py, tests/agent_supervisor/semantic_state/test_verification.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_test_selection.py tests/agent_supervisor/semantic_state/test_verification.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/verification
+- Parallel lane: sch-verification
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9, 10, and 12
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/test_selection.py, ipfs_accelerate_py/agent_supervisor/semantic_state/verification.py, tests/agent_supervisor/semantic_state/test_test_selection.py, tests/agent_supervisor/semantic_state/test_verification.py
+- Predicted symbols: TestSelector, SelectionPolicy, VerificationRunner, StaticCheckResult, PytestResult, ProverResult, FullSuiteComparison, select_tests, compare_full_suite
+- Interfaces: TestSelection@1, SemanticVerification@1
+- Conflict policy: Reuse validation command parsing/classification and execute bounded explicit commands only inside the fenced worktree. Do not import targets for collection, guess dynamic pytest/plugin behavior as exact, report unavailable provers as passing, or disable full-suite fallback.
+- Preconditions: Scheduling adapter is cancellation/fence safe and semantic graph/test facts are supplied through SCH-002 at runtime.
+- Effects: Selects tests from direct/import/caller/fixture/schema/config/generated/proof edges plus user rules, records reason paths, runs static/pytest/prover stages, and optionally/mandatorily runs the full-suite oracle by assurance policy.
+- Acceptance: Direct known dependents are all selected; ambiguity and opaque/config/dependency changes trigger visible fallback; commands bind exact tree/config/toolchain; timeouts/cancellation are typed; controlled comparison metrics define false negatives correctly and support 100 percent recall.
+
+## SCH-009 Emit MCP++ receipts and enforce freshness admission
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: receipts
+- Depends on: SCH-001, SCH-003, SCH-008
+- Goal id: SCH-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, tests/agent_supervisor/semantic_state/test_receipts.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_receipts.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/receipts
+- Parallel lane: sch-receipts
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9 and 13
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/receipts.py, tests/agent_supervisor/semantic_state/test_receipts.py
+- Predicted symbols: ReceiptCompiler, ReceiptFreshnessPolicy, ReceiptAdmission, StaleReceiptError, compile_verification_receipt, admit_receipt
+- Interfaces: SemanticVerificationReceipt@1, ReceiptFreshnessAdmission@1
+- Conflict policy: Receipts are MCP++ Profile B artifacts linked by Profile F events and real CIDv1. Operational/scheduler/provider receipts do not prove correctness. Never admit stale, corrupted, incomplete, unavailable, simulated, or mismatched evidence.
+- Preconditions: Wire codec, durable port, and verification results exist.
+- Effects: Binds receipts to exact trees/roots/delta/selection/commands/toolchain/dependency-lock/config/policy/interface/provider/proof/output identities, stores them before reference, and emits sorted stale obligations on any binding change.
+- Acceptance: Rehash and closed-schema validation pass; any bound input change stales the receipt; policy/interface changes invalidate decisions/adapters; unavailable proof is explicit; a stale or simulation receipt cannot satisfy verification or state-root promotion.
+
+## SCH-010 Implement safe fenced worktree and patch validation
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: worktree
+- Depends on: SCH-004
+- Goal id: SCH-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, tests/agent_supervisor/semantic_state/test_worktree.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_worktree.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/worktree
+- Parallel lane: sch-worktree
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 34000
+- LLM context budget bytes: 278528
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 12 and 14
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/worktree.py, tests/agent_supervisor/semantic_state/test_worktree.py
+- Predicted symbols: IsolatedWorktree, PatchValidator, PatchScope, PatchValidationError, create_isolated_worktree, validate_patch, apply_patch
+- Interfaces: IsolatedPatchWorktree@1
+- Conflict policy: Acquire WorktreeLifecycleStore/LeaseCoordinator ownership before `git worktree add`; use explicit validated paths and argv; reject control/runtime/state paths, symlink escapes, submodules, binary patches, path traversal, undeclared files, and stale fences. Never mutate the user's checkout.
+- Preconditions: Scheduling lease/fence contracts exist and the target is a valid Git repository.
+- Effects: Creates a disposable attempt worktree, materializes ContextPack artifacts, validates bounded unified diffs and declared file scope, applies with Git, records exact pre/post trees, and performs recoverable fenced cleanup.
+- Acceptance: Malformed/out-of-scope patches cause no target/root mutation; allowed text patches apply deterministically; concurrent/stale owners cannot publish or clean a live peer worktree; interrupted prepare/apply/cleanup states recover safely.
+
+## SCH-011 Implement the complete 14-step harness loop
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: harness-loop
+- Depends on: SCH-002, SCH-003, SCH-005, SCH-006, SCH-007, SCH-008, SCH-009, SCH-010
+- Goal id: SCH-G030
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, tests/agent_supervisor/semantic_state/test_harness.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_harness.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/harness-loop
+- Parallel lane: sch-harness
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 5 through 15
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/harness.py, ipfs_accelerate_py/agent_supervisor/semantic_state/__init__.py, tests/agent_supervisor/semantic_state/test_harness.py
+- Predicted symbols: SemanticCompressionHarness, HarnessPolicy, HarnessRequest, HarnessResult, run_semantic_patch_loop
+- Interfaces: SemanticCompressionHarness@1
+- Conflict policy: Orchestrate existing ports only. Do not add an agent framework/server/UI, auto-rewrite dependents, bypass an obligation, scan the portfolio, run providers before admission, or move a root before all acceptance receipts are fresh.
+- Preconditions: All scanner, durability, scheduling, context, routing, verification, receipt, and worktree ports pass their focused tests.
+- Effects: Executes worktree creation, ContextPack materialization, model invocation, patch/scope validation, application, rescan/delta/invalidation, static checks, selected tests, provers, optional oracle, receipts, and accepted expected-old root CAS in the documented 14-step order.
+- Acceptance: Rejection/unavailability/cancellation leaves the current root unchanged; acceptance requires a real production provider when a model is needed and fresh passing required receipts; actual changed symbols and obligations are returned; exact replay is idempotent; root conflict is reported rather than overwritten.
+
+## SCH-012 Implement incremental session, watch, restart, and replay
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: session
+- Depends on: SCH-011
+- Goal id: SCH-G040
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, tests/agent_supervisor/semantic_state/test_session.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_session.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/session
+- Parallel lane: sch-session
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 12, 13, and 15
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/session.py, tests/agent_supervisor/semantic_state/test_session.py
+- Predicted symbols: SemanticStateSession, SessionPolicy, SessionStatus, watch_session, replay_session
+- Interfaces: SemanticStateSession@1
+- Conflict policy: Watch notifications only schedule a canonical scan. Reuse runtime.event_log cursors and existing fences; do not make events/mtime/queue rows authoritative, start background work on import, or allow a stale callback to commit.
+- Preconditions: The end-to-end harness and durable event/root ports exist.
+- Effects: Coalesces concurrent notifications by snapshot CID, serializes accepted attempts by repository/fence, checkpoints bounded event cursors, and reconciles nonterminal work plus WAL/root state on restart.
+- Acceptance: Concurrent watchers do not duplicate equal work or overwrite roots; restart neither loses an accepted transition nor publishes an unverified one; corrupt/truncated events recover or fail closed; explicit shutdown cancels and joins owned work.
+
+## SCH-013 Add semantic-state CLI and console entrypoint
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: cli
+- Depends on: SCH-011, SCH-012
+- Goal id: SCH-G040
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/agent_supervisor/semantic_state/test_cli.py, pyproject.toml, setup.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_cli.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/cli
+- Parallel lane: sch-cli
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 36000
+- LLM context budget bytes: 294912
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md section 16
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/cli.py, tests/agent_supervisor/semantic_state/test_cli.py, pyproject.toml, setup.py
+- Predicted symbols: build_parser, main
+- Interfaces: SemanticStateCLI@1
+- Conflict policy: Add one dedicated `semantic-state` entrypoint mirrored in pyproject/setup. Do not expand legacy monolithic CLI, expose a network/MCP service, auto-install dependencies, or hide typed unavailable/production-simulation errors behind exit zero.
+- Preconditions: Harness and restartable session APIs are stable.
+- Effects: Implements scan, watch, status, graph, explain-symbol, explain-impact, invalidate, select-tests, pack-context, verify, apply-patch, compare-full-suite, and benchmark capabilities with deterministic JSON.
+- Acceptance: All commands have bounded help/errors and stable exit codes; production apply-patch cannot simulate; local commands need no IPFS daemon; cold `--help` and imports cause no install/network/environment/process/database mutation.
+
+## SCH-014 Create the controlled Python fixture repository
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: fixtures
+- Depends on: SCH-000
+- Goal id: SCH-G040
+- Outputs: tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_fixture_repository.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_fixture_repository.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/fixtures
+- Parallel lane: sch-fixtures
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 34000
+- LLM context budget bytes: 278528
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 2, 10, and 17
+- Predicted files: tests/fixtures/semantic_state_harness/controlled_repo, tests/agent_supervisor/semantic_state/test_fixture_repository.py
+- Predicted symbols: controlled_repository, mutation_case, fixture_oracle
+- Interfaces: ControlledSemanticRepository@1
+- Conflict policy: Keep the fixture small, self-contained, Python 3.12/pytest-only, deterministic, and free of network/native execution. Native/dynamic behavior is represented syntactically and not imported during scans. Do not depend on the user's portfolio checkout.
+- Preconditions: Exact datasets semantic-index fixture/API contract is sealed.
+- Effects: Supplies base/mutated Git trees for local body, signature, cross-module, dataclass/schema, exception, fixture/config, dynamic import, monkey patch, opaque native, formatting, delete/rename, generated file, stale receipt, failed CAS, interruption, concurrent watcher, and out-of-scope patch cases.
+- Acceptance: Full fixture suite is fast and deterministic; every mutation has expected changed symbols, invalidation/test/proof oracle, and confidence/raw-source behavior; unrelated formatting and changes remain bounded; no fixture scan imports or executes fixture code.
+
+## SCH-015 Prove the end-to-end acceptance matrix
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: acceptance
+- Depends on: SCH-011, SCH-012, SCH-014
+- Goal id: SCH-G040
+- Outputs: tests/agent_supervisor/semantic_state/test_acceptance.py, tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py, tests/agent_supervisor/semantic_state/test_production_gates.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_acceptance.py tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py tests/agent_supervisor/semantic_state/test_production_gates.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/acceptance
+- Parallel lane: sch-acceptance
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 9 through 17
+- Predicted files: tests/agent_supervisor/semantic_state/test_acceptance.py, tests/agent_supervisor/semantic_state/test_concurrency_and_recovery.py, tests/agent_supervisor/semantic_state/test_production_gates.py
+- Predicted symbols: test_controlled_invalidation_matrix, test_selected_suite_recall, test_root_cas_and_recovery, test_production_rejects_simulation
+- Interfaces: SemanticStateAcceptance@1
+- Conflict policy: Test real local behavior and injected typed unavailable paths, not mock success claims. Do not weaken selection/oracle/freshness/scope/CAS gates or omit failing/escalated cases.
+- Preconditions: Complete harness/session and controlled fixture exist.
+- Effects: Runs all required mutation cases, compares selected/full suites, injects interrupted writes/concurrent writers/watchers, forges stale/corrupt receipts, and submits a simulated/out-of-scope provider patch.
+- Acceptance: Unrelated changes do not invalidate the repository; known dependents are invalidated; opaque source is retrieved; stale receipts never verify; controlled selection recall is 100 percent; full fallback works; roots are deterministic; recovery is safe; CAS has one winner; simulation never reports production verification.
+
+## SCH-016 Create the exactly-40-task benchmark corpus
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: benchmark-corpus
+- Depends on: SCH-014
+- Goal id: SCH-G050
+- Outputs: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/benchmark-corpus
+- Parallel lane: sch-benchmark-corpus
+- Resource class: cpu-small
+- Implementation timeout seconds: 5400
+- Provider role: codex-implement
+- Context budget tokens: 34000
+- LLM context budget bytes: 278528
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md section 18
+- Predicted files: benchmarks/semantic_state/tasks, benchmarks/semantic_state/corpus.json, tests/agent_supervisor/semantic_state/test_benchmark_corpus.py
+- Predicted symbols: BenchmarkTask, BenchmarkCorpus
+- Interfaces: SemanticStateBenchmarkCorpus@1
+- Conflict policy: Exactly 40 checked-in deterministic tasks: 10 small bug fixes and 6 each test repair, API adapter, schema migration, multi-file/refactor, and rejection/escalation. Do not omit hard/failed tasks or required raw source to bias metrics.
+- Preconditions: Controlled fixture mutation format and oracle are stable.
+- Effects: Defines task objective/target/base mutation/oracle/risk/expected route and reproducible baseline-retrieval policy for every representative task.
+- Acceptance: Corpus has exactly 40 unique stable task IDs and the required category counts; includes multi-file and frontier/human cases; every task is runnable offline against a pinned fixture tree and declares no expected outcome derived from benchmark implementation output.
+
+## SCH-017 Implement benchmark runner and publish measured results
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: benchmark
+- Depends on: SCH-006, SCH-007, SCH-011, SCH-016
+- Goal id: SCH-G050
+- Outputs: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, tests/agent_supervisor/semantic_state/test_benchmark.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state/test_benchmark.py && python benchmarks/semantic_state/run_benchmark.py --check
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/benchmark
+- Parallel lane: sch-benchmark
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 11 and 18
+- Predicted files: ipfs_accelerate_py/agent_supervisor/semantic_state/benchmark.py, benchmarks/semantic_state/run_benchmark.py, docs/benchmarks/semantic_compression_harness_results.json, docs/benchmarks/semantic_compression_harness_results.md, tests/agent_supervisor/semantic_state/test_benchmark.py
+- Predicted symbols: BenchmarkRunner, BenchmarkResult, BenchmarkSummary, run_benchmark, compare_context_modes
+- Interfaces: SemanticStateBenchmark@1
+- Conflict policy: Use the same declared tokenizer/estimator and coverage assurance for raw and semantic modes. Count all 40 tasks including rejection/escalation; never manufacture model success, drop opaque code, or report unavailable/simulation as accepted.
+- Preconditions: Context packer, routing, complete harness, and corpus are stable.
+- Effects: Captures baseline/pack tokens, excluded raw code, capsules, invalidation cone, selected/full tests, proofs, route, outcome, timing, receipt freshness, precision/recall, fallback, and category/overall reductions into reproducible JSON/Markdown.
+- Acceptance: `--check` recomputes identical deterministic fields; overall median context reduction is at least 30 percent without coverage omissions; stale/simulated admissions and controlled false negatives are zero; results report task-type reductions, precision, recall, failures, and uncertainty rather than hiding them.
+
+## SCH-018 Complete documentation, import safety, and provider regressions
+
+- Status: todo
+- Completion: auto
+- Priority: P0
+- Track: release
+- Depends on: SCH-013, SCH-015, SCH-017
+- Goal id: SCH-G050
+- Outputs: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, tests/agent_supervisor/semantic_state/test_import_safety.py, tests/agent_supervisor/semantic_state/test_provider_regressions.py
+- Validation: python -m pytest -q tests/agent_supervisor/semantic_state && python benchmarks/semantic_state/run_benchmark.py --check
+- Board namespace: semantic-compression-harness-v1
+- Bundle: sch/release
+- Parallel lane: sch-release
+- Resource class: cpu-medium
+- Implementation timeout seconds: 7200
+- Provider role: codex-implement
+- Context budget tokens: 40000
+- LLM context budget bytes: 327680
+- Plan context: docs/architecture/SEMANTIC_COMPRESSION_HARNESS_PLAN.md sections 16 through 20
+- Predicted files: docs/semantic_state/SEMANTIC_COMPRESSION_HARNESS.md, tests/agent_supervisor/semantic_state/test_import_safety.py, tests/agent_supervisor/semantic_state/test_provider_regressions.py
+- Predicted symbols: release_report, import_safety_probe, provider_production_gate_regression
+- Interfaces: SemanticStateHarnessRelease@1
+- Conflict policy: Document code and measured receipts exactly. Do not claim complete Python analysis, universal verification, ZK support, provider availability, or production readiness; do not auto-install on import or weaken a failing gate to close the board.
+- Preconditions: CLI, acceptance matrix, and benchmark results are committed and reproducible.
+- Effects: Documents architecture/modules/commands/examples/tests/benchmark/token reductions/precision-recall/limitations/bottlenecks and exact pre-ZK/production work; tests imports with installer/network/process/environment mutation disabled and real/absent/simulated provider dispositions.
+- Acceptance: Focused and relevant existing supervisor tests pass; ordinary imports are side-effect free; production unavailable/simulation is nonzero and never verified; final report is traceable to exact commits and receipts and contains every requested completion-report section.

--- a/ipfs_accelerate_py/agent_supervisor/validation/proposal_validation.py
+++ b/ipfs_accelerate_py/agent_supervisor/validation/proposal_validation.py
@@ -2911,9 +2911,11 @@ _SYNTHETIC_TEST_SECRET_REFERENCE_RE = re.compile(
     r"""(?x)^(?:env://[A-Z][A-Z0-9_]{1,127}|"""
     r"""vault://[A-Za-z0-9_.][A-Za-z0-9_./-]{0,255})$"""
 )
+# Exact documentation/redaction sentinel only.  Do not exempt
+# ``should-not-appear`` (and similar synthetic canaries) — those remain
+# concrete secret-like values in production sources and are rejected there.
 _NEVER_EXPOSE_SENTINEL_RE = re.compile(
-    r"""(?ix)^(?:should|must)[_-]?(?:never|not)[_-]?"""
-    r"""(?:appear|persist|log|store|commit)$"""
+    r"""(?ix)^(?:should|must)[_-]?never[_-]?(?:appear|persist|log|store|commit)$"""
 )
 _TEST_ONLY_NON_SECRET_SENTINEL_RE = re.compile(
     r"(?i)^sk[_-]live[_-]not[_-]a[_-]real[_-]key$"
@@ -3267,7 +3269,16 @@ def _command_is_allowed(
     # Exact task-board allowlist hit: trust the reviewed command when the
     # executable itself is not a shell interpreter. This admits env-assignment
     # prefixes (PYTHONPATH=...) that are already on the task validation plan.
+    # Bare operator tokens and subshell expansion remain forbidden even when
+    # the exact argv is allowlisted (an allowlist cannot waive shell chaining).
     if command_t in prefixes_t and clause_executable_is_safe(command_t):
+        if any(
+            part in _SHELL_OPERATOR_TOKENS or part in {"&&", "||"}
+            for part in command_t
+        ):
+            return False
+        if any(_SHELL_EXPANSION_RE.search(part) for part in command_t):
+            return False
         return True
 
     if not clause_is_safe(command_t):

--- a/test/api/test_agent_supervisor_proposal_validation.py
+++ b/test/api/test_agent_supervisor_proposal_validation.py
@@ -1286,7 +1286,12 @@ def test_new_secret_like_content_remains_rejected() -> None:
 
 @pytest.mark.parametrize(
     "sentinel",
-    ("should-never-appear", "should-not-appear"),
+    (
+        # Exact redaction/documentation sentinel only.  ``should-not-appear`` is
+        # a synthetic secret canary and must still be rejected in production
+        # sources (see test_production_source_still_rejects_synthetic_secret_canary).
+        "should-never-appear",
+    ),
 )
 def test_exact_never_expose_sentinel_is_not_treated_as_a_secret(
     sentinel: str,


### PR DESCRIPTION
## Summary
- Based on the SCH consumer-contract tip (`bde62375`) plus tight proposal-validation guards.
- Fixes production rejection of synthetic secret canaries and bare shell operators on exact allowlists.
- Used as the sealed accelerate authority for DSS-000 multi-repo validation.

## Test plan
- [x] Sealed accelerate suite green (context slice + proposal validation)
- [ ] CI green