### PR TITLE
fix(agent-supervisor): age-aware post-merge freshness horizon

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/analysis/code_evidence_graph.py
+++ b/ipfs_accelerate_py/agent_supervisor/analysis/code_evidence_graph.py
@@ -789,6 +789,56 @@ def _post_merge_observed_at(record: Mapping[str, Any]) -> datetime | None:
         return None
 
 
+def _post_merge_age_aware_deadline(
+    *,
+    assembled: datetime,
+    nested_records: Iterable[Any],
+    freshness_deadline: datetime | str | None,
+    freshness_seconds: float,
+) -> datetime:
+    """Size the post-merge freshness window from nested observed_at ages.
+
+    Nested evidence keeps its original ``observed_at``. Reason-code checks
+    require ``(now - observed_at) <= (deadline - assembled)``, so a fixed
+    one-hour window rejects valid sealed digests after multi-hour operator
+    recovery even when digests and trees still bind exactly. Expand the
+    horizon to cover the oldest nested timestamp (plus a small slack) while
+    never shrinking an explicit caller deadline below its requested length
+    when nested evidence is already current.
+    """
+
+    if freshness_deadline is None:
+        if isinstance(freshness_seconds, bool) or float(freshness_seconds) <= 0:
+            raise EvidenceGraphValidationError("freshness_seconds must be positive")
+        base_horizon = timedelta(seconds=float(freshness_seconds))
+    else:
+        explicit = _post_merge_datetime(
+            freshness_deadline, name="freshness_deadline"
+        )
+        base_horizon = explicit - assembled
+        if base_horizon <= timedelta(0):
+            # Fail closed for inverted windows only when nested evidence is
+            # current; age-aware expansion below still rescues recovery paths.
+            base_horizon = timedelta(0)
+
+    oldest_observed = assembled
+    for record in nested_records:
+        if not isinstance(record, Mapping):
+            continue
+        observed = _post_merge_observed_at(record)
+        if observed is not None and observed < oldest_observed:
+            oldest_observed = observed
+    evidence_age = (
+        assembled - oldest_observed if oldest_observed < assembled else timedelta(0)
+    )
+    # Floor at one hour for default assembly (DQK / ASI-109 operator recovery).
+    # Explicit short windows still expand when nested evidence is older.
+    needed = max(base_horizon, evidence_age + timedelta(minutes=30))
+    if freshness_deadline is None:
+        needed = max(needed, timedelta(hours=1))
+    return assembled + needed
+
+
 def _post_merge_gate(value: Any) -> str:
     return str(value or "").strip().lower().replace("-", "_").replace("/", "_")
 
@@ -1665,14 +1715,6 @@ def assemble_post_merge_evidence(
         if assembled_at is not None
         else datetime.now(timezone.utc)
     )
-    if freshness_deadline is None:
-        if isinstance(freshness_seconds, bool) or float(freshness_seconds) <= 0:
-            raise EvidenceGraphValidationError("freshness_seconds must be positive")
-        deadline = assembled + timedelta(seconds=float(freshness_seconds))
-    else:
-        deadline = _post_merge_datetime(
-            freshness_deadline, name="freshness_deadline"
-        )
     verified = (
         _post_merge_datetime(verified_at, name="verified_at")
         if verified_at is not None
@@ -1703,6 +1745,24 @@ def assemble_post_merge_evidence(
     tree_records = _post_merge_record(
         merged_tree_records if merged_tree_records is not None else graph_records,
         name="merged_tree_records",
+    )
+    # Nested sealed digests keep original observed_at; size the horizon so
+    # multi-hour operator recovery does not false-stale exact-tree packets.
+    deadline = _post_merge_age_aware_deadline(
+        assembled=assembled,
+        nested_records=(
+            report,
+            receipt,
+            *semantic,
+            *protocol,
+            *legal,
+            *theorem,
+            *proofs,
+            *coverage,
+            merge,
+        ),
+        freshness_deadline=freshness_deadline,
+        freshness_seconds=freshness_seconds,
     )
     graph = _build_post_merge_graph(
         task_id=str(task_id),

--- a/test/api/test_agent_supervisor_post_merge_evidence.py
+++ b/test/api/test_agent_supervisor_post_merge_evidence.py
@@ -345,6 +345,51 @@ def test_verifier_closes_authority_for_changed_tree_or_expired_receipt() -> None
     assert PostMergeEvidenceReceipt.from_dict(changed.to_dict()) == changed
 
 
+def test_age_aware_horizon_admits_multi_hour_nested_observed_at() -> None:
+    """Operator recovery hours later must not false-stale exact-tree packets.
+
+    Nested post-merge evidence keeps original observed_at. A fixed one-hour
+    assembly window makes timestamp_is_current reject valid sealed digests as
+    stale_evidence. The horizon must expand from the oldest nested timestamp.
+    """
+
+    assembled = NOW_DT
+    nested_dt = assembled - timedelta(hours=3)
+    nested_observed = nested_dt.isoformat()
+
+    # Build a full fixture with nested timestamps 3h before assembly, then
+    # assemble with the default 1h freshness_seconds (no explicit deadline).
+    old_now = NOW
+    old_now_dt = NOW_DT
+    try:
+        globals()["NOW"] = nested_observed
+        globals()["NOW_DT"] = nested_dt
+        kwargs = _kwargs()
+    finally:
+        globals()["NOW"] = old_now
+        globals()["NOW_DT"] = old_now_dt
+
+    kwargs["assembled_at"] = assembled.isoformat()
+    kwargs.pop("freshness_deadline", None)
+    kwargs["freshness_seconds"] = 3600.0
+
+    receipt = assemble_post_merge_evidence(**kwargs)
+    deadline = datetime.fromisoformat(receipt.freshness_deadline)
+    assert deadline - assembled >= timedelta(hours=3, minutes=30)
+    assert receipt.accepted is True, receipt.reason_codes
+    assert receipt.freshness_authoritative is True
+    assert "stale_evidence" not in receipt.reason_codes
+    assert "stale_validation" not in receipt.reason_codes
+
+    revalidated = verify_post_merge_evidence(
+        receipt,
+        MERGED_TREE,
+        now=assembled.isoformat(),
+    )
+    assert revalidated.accepted is True, revalidated.reason_codes
+    assert revalidated.freshness_authoritative is True
+
+
 def test_formal_admission_replays_exact_tree_commit_graph_and_criteria() -> None:
     receipt = assemble_post_merge_evidence(**_kwargs())
 


### PR DESCRIPTION
## Summary
- Expand `assemble_post_merge_evidence` freshness horizons from the oldest nested `observed_at` (plus 30m slack; 1h floor on the default path).
- Prevents multi-hour operator recovery from false-staling exact-tree sealed digests as `stale_evidence` / `stale_validation`.
- Ports the DQK pin tip logic (`87c113a28` / `fix/dqk-post-merge-age-aware-horizon`) onto current `main`, where post-merge assembly lives in `code_evidence_graph` (not the DQK-era `implementation_daemon` path).

## Context
`ipfs_datasets_py` main pins accelerate at `87c113a28` after DQK 97/97 ([datasets PR #1248](https://github.com/endomorphosis/ipfs_datasets_py/pull/1248)). That commit was only reachable on a divergent submodule branch. This PR lands the semantic fix cleanly on `main` so future pins need not carry the divergent history.

## Test plan
- [x] `python3 -m pytest test/api/test_agent_supervisor_post_merge_evidence.py -q` (17 passed)
- [x] New regression: `test_age_aware_horizon_admits_multi_hour_nested_observed_at`
- [ ] CI green on this PR