### PR TITLE
fix(apmc): bind relative Quack registry to repository root

### DIFF
--- a/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
+++ b/ipfs_accelerate_py/agent_supervisor/todo_daemon/implementation_supervisor.py
@@ -8357,6 +8357,7 @@ class PortalImplementationSupervisor:
         )
         child_environment = _managed_daemon_child_environment(
             database_program=self.config.database_program,
+            repo_root=self.config.repo_root,
         )
         spec = ManagedDaemonSpec(
             name=f"{prefix}-implementation-daemon",
@@ -8378,10 +8379,7 @@ class PortalImplementationSupervisor:
             latest_log_path=self.config.state_dir / f"{prefix}_managed_daemon.latest.log",
             daemon_process_match_all=command,
             worktree_root=self.config.worktree_root,
-            launch_env=_managed_daemon_child_environment(
-                database_program=self.config.database_program,
-                repo_root=self.config.repo_root,
-            ),
+            launch_env=child_environment,
         )
         return SupervisorLoopConfig(
             spec=spec,


### PR DESCRIPTION
The origin/main merge left one `build_supervisor_loop_config` call without `repository_root`. APMC lanes then crashed with:

```
relative runtime registry requires an explicit repository root
```

Pass `self.config.repo_root` into the managed-daemon child environment so Quack mutation inboxes bind under the live worktree.

Local APMC units were restarted against this commit; four lanes stay live and spawn daemons.