### PR TITLE
chore(apmc): close APMC-022 and APMC-025 leftover worktree extras

### DIFF
--- a/docs/architecture/agent_supervisor_autonomous_meta_controller.todo.md
+++ b/docs/architecture/agent_supervisor_autonomous_meta_controller.todo.md
@@ -878,7 +878,7 @@ control/lease/fence/merge authorities.
 
 ## APMC-022 Resolve 1 dirty backlogged worktrees blocked by content_not_in_target
 
-- Status: blocked
+- Status: completed
 - Completion: manual
 - Is schedulable: false
 - Review only: true
@@ -941,7 +941,7 @@ control/lease/fence/merge authorities.
 
 ## APMC-025 Resolve 1 preflight-conflicting backlogged worktree merges
 
-- Status: blocked
+- Status: completed
 - Completion: manual
 - Is schedulable: false
 - Review only: true


### PR DESCRIPTION
Operator reconciliation of markdown extras APMC-022 and APMC-025.

- APMC-022 leftover APMC-013 worktree untracked files were already on the target; the one differing test was the pre-fix copy. Worktree removed.
- APMC-025 APMC-017 rescue worktree conflicted with landed `188a073dd`. Not merged (would regress accepted adapters). Worktree removed; rescue branch retained for audit.

DuckDB APMC-000..020 remain 21/21 completed. These extras are not DuckDB-authoritative.